### PR TITLE
boards: Add particle-xenon (for full-image and riotboot)

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -118,6 +118,7 @@ contexts:
       flash-riotboot:
         required_vars:
           - FLASH_OFFSET
+          - FLASH_SLOT_OFFSET
         cmd:
           - riotboot-genhdr generate ${out} $$(date +%s) $(${FLASH_OFFSET} + ${FLASH_SLOT_OFFSET}) ${FLASH_SLOT_OFFSET} - > ${out}.hdr.bin
           - ${OBJCOPY} -Obinary ${out} ${out}.bin
@@ -520,6 +521,17 @@ modules:
         FEATURES:
           - riot-rs/wifi-esp
 
+  - name: runner-riotboot-dfu
+    required_vars:
+      - FLASH_OFFSET
+      - FLASH_SLOT_OFFSET
+      - FLASH_SIZE_TOTAL
+      - FLASH_SLOT
+      - FLASH_NUM_SLOTS
+    env:
+      global:
+        CARGO_RUNNER: "${SCRIPTS}/runner-riotboot.sh\\ ${FLASH_OFFSET}\\ ${FLASH_SLOT_OFFSET}\\ ${FLASH_SIZE_TOTAL}\\ ${FLASH_SLOT}\\ ${FLASH_NUM_SLOTS}"
+
 builders:
   # host builder (for housekeeping tasks)
   - name: host
@@ -593,6 +605,38 @@ builders:
 
   - name: particle-xenon
     parent: nrf52840
+
+  - name: _particle-xenon-riotboot-dfu
+    parent: particle-xenon
+    env:
+      # Bootloader size. This is why the board is riotboot-dfu: The version
+      # without DFU needs less flash for the bootloader.
+      FLASH_OFFSET: "0x4000"
+      # Size of image header
+      FLASH_SLOT_OFFSET: "0x400"
+      # This is default for nrf52/build.rs anyway, but runner-riotbuild needs
+      # the information explicitly.
+      FLASH_NUM_SLOTS: "2"
+      # FIXME: This information ("The nrf52840 has 1024KiB of flash") is
+      # duplicated between here and src/riot-rs-boards/nrf52/build.rs.
+      FLASH_SIZE_TOTAL: "1048576"
+      CARGO_ENV:
+        - NRF52_FLASH_OFFSET=${FLASH_OFFSET}
+        - NRF52_FLASH_SLOT_OFFSET=${FLASH_SLOT_OFFSET}
+        - NRF52_FLASH_SLOT=${FLASH_SLOT}
+        - NRF52_FLASH_NUM_SLOTS=${FLASH_NUM_SLOTS}
+    selects:
+      - runner-riotboot-dfu
+
+  - name: particle-xenon-riotboot-dfu-slot0
+    parent: _particle-xenon-riotboot-dfu
+    env:
+      FLASH_SLOT: "0"
+
+  - name: particle-xenon-riotboot-dfu-slot1
+    parent: _particle-xenon-riotboot-dfu
+    env:
+      FLASH_SLOT: "1"
 
   - name: rpi-pico
     parent: rp2040

--- a/scripts/runner-riotboot.sh
+++ b/scripts/runner-riotboot.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# Take an image built merely with the right offsets (and possibly higher leve
+# riotboot functionality such as reboot-into-bootloader), send it through
+# riotboot-genhdr, and flash it using dfu-util.
+#
+# It may be practical to split this into a build-image-from-elf and a
+# flash-image step using laze, but right now this works.
+
+set -e
+
+FLASH_OFFSET="$1"
+FLASH_SLOT_OFFSET="$2"
+FLASH_SIZE_TOTAL="$3"
+FLASH_SLOT="$4"
+FLASH_NUM_SLOTS="$5"
+BUILT_ELF="$6"
+
+IMAGE="${BUILT_ELF}.img"
+VERSION=$(date +%s)
+
+# FIXME: How do we best access this, if not by asking the user to get a RIOT
+# checkout and place its dist/tools/riotboot_gen_hdr/bin/ in the PATH?
+GENHDR=genhdr
+
+objcopy "${BUILT_ELF}" -Obinary "${BUILT_ELF}.bin"
+
+${GENHDR} generate \
+    "${BUILT_ELF}.bin" \
+    ${VERSION} \
+    $((${FLASH_OFFSET} + (${FLASH_SIZE_TOTAL} - ${FLASH_OFFSET}) / ${FLASH_NUM_SLOTS} * ${FLASH_SLOT} + ${FLASH_SLOT_OFFSET})) \
+    ${FLASH_SLOT_OFFSET} \
+    "${BUILT_ELF}.riotboot"
+
+cat "${BUILT_ELF}.riotboot" "${BUILT_ELF}.bin" > "${IMAGE}"
+
+dfu-util --device 1209:7d02 --alt ${FLASH_SLOT} --download "${IMAGE}"

--- a/src/riot-rs-boards/Cargo.toml
+++ b/src/riot-rs-boards/Cargo.toml
@@ -30,3 +30,6 @@ particle-xenon = { optional = true, path = "particle-xenon" }
 # Allows to have no boards selected, useful to run platform-independent tooling
 no-boards = []
 rpi-pico-w = ["rpi-pico/rpi-pico-w"]
+
+particle-xenon-riotboot-dfu-slot0 = [ "particle-xenon" ]
+particle-xenon-riotboot-dfu-slot1 = [ "particle-xenon" ]


### PR DESCRIPTION
This adds yet another board, but this time it's tricky because that board doesn't have an on-board debugger. It is commonly used in either of three modes:

* with the upstream bootloader (which uses dfu-util and an elaborate startup sequence)
* with riotboot-dfu (which uses 16KiB bootloader followed by two slots, which is a weird default for a USB based bootloader, but convenient when you also want to do OTA)
* with an external programmer (using a 2x5 pin ~50mil IDC connector)

On the long run I hope we can support the upstream bootloader, but riotboot is a) easier (no checksumming outside the header, and I can flash it and debug step through the loading process), and b) more widely spread in our ecosystem. This PR includes riotboot support.

Riotboot support is implemented using cargo flags that tell a build.rs which partitioning is used. On the long run, that code will need to be more universal; right now it's sitting in nrf52/build.rs for further experimentation.

I've successfully used this to flash a board through riotboot-dfu, but so far that's a manual process, because it involves:

```
$ laze -C examples/embassy-net-udp build --verbose -b particle-xenon-riotboot-dfu-slot0 -s probe-rs-run
$ objcopy build/bin/particle-xenon-riotboot-dfu-slot0/embassy-net-udp/embassy-net-udp.elf -Obinary out.bin
$ ${RIOT}/dist/tools/riotboot_gen_hdr/bin/genhdr generate out.bin 1 16640 256 header.bin
$ cat header.bin out.bin > total.bin
$ dfu-util -a 0 -D total.bin
```

I'm confident that either laze or probe-rs (or whatever the Rust ecosystem uses for flashing when no probe is attached) will be helpful in automating this, but first steps first and I'd appreciate a rough yes/no on the direction before continuing.