### PR TITLE
refactor: enable `clippy::pedantic` at workspace-level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,4 +101,6 @@ unused_must_use = "deny"
 indexing_slicing = "warn"
 missing_safety_doc = { level = "warn" }
 pedantic = "deny"
-module_name_repetitions = "allow"       # Part of pedantic
+# Part of pedantic but not relevant to us, mostly because we sometimes erase
+# module names when re-exporting types
+module_name_repetitions = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,3 +100,5 @@ unused_must_use = "deny"
 # Clippy lints are documented here: https://rust-lang.github.io/rust-clippy/master/index.html
 indexing_slicing = "warn"
 missing_safety_doc = { level = "warn" }
+pedantic = "deny"
+module_name_repetitions = "allow" # Part of pedantic

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,4 +101,4 @@ unused_must_use = "deny"
 indexing_slicing = "warn"
 missing_safety_doc = { level = "warn" }
 pedantic = "deny"
-module_name_repetitions = "allow" # Part of pedantic
+module_name_repetitions = "allow"       # Part of pedantic

--- a/src/riot-rs-bench/src/lib.rs
+++ b/src/riot-rs-bench/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![cfg_attr(not(test), no_std)]
 #![feature(error_in_core)]
-#![deny(clippy::pedantic)]
 #![deny(missing_docs)]
 
 cfg_if::cfg_if! {

--- a/src/riot-rs-embassy/src/arch/dummy/executor.rs
+++ b/src/riot-rs-embassy/src/arch/dummy/executor.rs
@@ -6,6 +6,7 @@ pub struct Executor;
 
 impl Executor {
     #[allow(clippy::new_without_default)]
+    #[must_use]
     pub const fn new() -> Self {
         // Actually return a value instead of marking it unimplemented like other dummy
         // functions, because this function is const and is thus run during compilation
@@ -16,6 +17,7 @@ impl Executor {
         unimplemented!();
     }
 
+    #[must_use]
     pub fn spawner(&self) -> Spawner {
         unimplemented!();
     }
@@ -24,9 +26,15 @@ impl Executor {
 pub struct Spawner;
 
 impl Spawner {
-    #[allow(clippy::result_unit_err)]
+    #[allow(
+        clippy::result_unit_err,
+        clippy::needless_pass_by_value,
+        clippy::missing_errors_doc,
+        reason = "dummy implementation"
+    )]
     pub fn spawn<S>(&self, _token: SpawnToken<S>) -> Result<(), ()> {
         unimplemented!();
     }
+    #[allow(clippy::needless_pass_by_value, reason = "dummy implementation")]
     pub fn must_spawn<S>(&self, _token: SpawnToken<S>) {}
 }

--- a/src/riot-rs-embassy/src/arch/dummy/mod.rs
+++ b/src/riot-rs-embassy/src/arch/dummy/mod.rs
@@ -28,6 +28,8 @@ impl From<Peripherals> for OptionalPeripherals {
 #[derive(Default)]
 pub struct Config;
 
+#[allow(clippy::needless_pass_by_value, reason = "dummy implementation")]
+#[must_use]
 pub fn init(_config: Config) -> OptionalPeripherals {
     unimplemented!();
 }

--- a/src/riot-rs-embassy/src/arch/esp/mod.rs
+++ b/src/riot-rs-embassy/src/arch/esp/mod.rs
@@ -10,6 +10,7 @@ pub use esp_hal::{
 #[derive(Default)]
 pub struct Config {}
 
+#[must_use]
 pub fn init(_config: Config) -> OptionalPeripherals {
     let mut peripherals = OptionalPeripherals::from(Peripherals::take());
     let system = peripherals.SYSTEM.take().unwrap().split();

--- a/src/riot-rs-embassy/src/arch/nrf/mod.rs
+++ b/src/riot-rs-embassy/src/arch/nrf/mod.rs
@@ -32,6 +32,7 @@ unsafe fn EGU0() {
     unsafe { crate::EXECUTOR.on_interrupt() }
 }
 
+#[must_use]
 pub fn init(config: Config) -> OptionalPeripherals {
     let peripherals = embassy_nrf::init(config);
     OptionalPeripherals::from(peripherals)

--- a/src/riot-rs-embassy/src/arch/nrf/usb.rs
+++ b/src/riot-rs-embassy/src/arch/nrf/usb.rs
@@ -23,6 +23,7 @@ bind_interrupts!(struct Irqs {
 
 pub type UsbDriver = Driver<'static, peripherals::USBD, HardwareVbusDetect>;
 
+#[must_use]
 pub fn driver(peripherals: &mut arch::OptionalPeripherals) -> UsbDriver {
     let usbd = peripherals.USBD.take().unwrap();
     Driver::new(usbd, Irqs, HardwareVbusDetect::new(Irqs))

--- a/src/riot-rs-embassy/src/arch/rp2040/mod.rs
+++ b/src/riot-rs-embassy/src/arch/rp2040/mod.rs
@@ -17,6 +17,7 @@ unsafe fn SWI_IRQ_1() {
     unsafe { crate::EXECUTOR.on_interrupt() }
 }
 
+#[must_use]
 pub fn init(config: Config) -> OptionalPeripherals {
     // SWI & DMA priority need to match. DMA is hard-coded to P3 by upstream.
     use embassy_rp::interrupt::{InterruptExt, Priority};

--- a/src/riot-rs-embassy/src/arch/rp2040/usb.rs
+++ b/src/riot-rs-embassy/src/arch/rp2040/usb.rs
@@ -11,6 +11,7 @@ bind_interrupts!(struct Irqs {
 
 pub type UsbDriver = Driver<'static, peripherals::USB>;
 
+#[must_use]
 pub fn driver(peripherals: &mut arch::OptionalPeripherals) -> UsbDriver {
     let usb = peripherals.USB.take().unwrap();
     Driver::new(usb, Irqs)

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -3,6 +3,7 @@
 #![no_std]
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
+#![feature(lint_reasons)]
 
 pub mod define_peripherals;
 

--- a/src/riot-rs-macros/src/lib.rs
+++ b/src/riot-rs-macros/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(clippy::pedantic)]
-
 mod utils;
 
 use proc_macro::TokenStream;

--- a/src/riot-rs-rt/src/lib.rs
+++ b/src/riot-rs-rt/src/lib.rs
@@ -53,7 +53,9 @@ static ISR_STACK: [u8; ISR_STACKSIZE] = [0u8; ISR_STACKSIZE];
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     #[cfg(not(feature = "silent-panic"))]
     {
-        println!("panic: {}\n", _info);
+        #[allow(clippy::used_underscore_binding)]
+        let info = _info;
+        println!("panic: {}\n", info);
         riot_rs_debug::exit(riot_rs_debug::EXIT_FAILURE);
     }
     #[allow(clippy::empty_loop)]

--- a/src/riot-rs-rt/src/lib.rs
+++ b/src/riot-rs-rt/src/lib.rs
@@ -50,11 +50,12 @@ static ISR_STACK: [u8; ISR_STACKSIZE] = [0u8; ISR_STACKSIZE];
 
 #[cfg(feature = "_panic-handler")]
 #[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    #[cfg(feature = "silent-panic")]
+    let _ = info;
+
     #[cfg(not(feature = "silent-panic"))]
     {
-        #[allow(clippy::used_underscore_binding)]
-        let info = _info;
         println!("panic: {}\n", info);
         riot_rs_debug::exit(riot_rs_debug::EXIT_FAILURE);
     }

--- a/src/riot-rs-runqueue/src/lib.rs
+++ b/src/riot-rs-runqueue/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), no_std)]
+#![feature(lint_reasons)]
 
 mod runqueue;
 pub use runqueue::{RunQueue, RunqueueId, ThreadId};

--- a/src/riot-rs-threads/src/arch/mod.rs
+++ b/src/riot-rs-threads/src/arch/mod.rs
@@ -49,5 +49,5 @@ cfg_if::cfg_if! {
 pub type ThreadData = <Cpu as Arch>::ThreadData;
 
 pub fn schedule() {
-    Cpu::schedule()
+    Cpu::schedule();
 }

--- a/src/riot-rs-threads/src/ensure_once.rs
+++ b/src/riot-rs-threads/src/ensure_once.rs
@@ -1,4 +1,4 @@
-//! This module provides a Mutex-protected RefCell --- basically a way to ensure
+//! This module provides a Mutex-protected [`RefCell`] --- basically a way to ensure
 //! at runtime that some reference is used only once.
 use core::cell::{Ref, RefCell, RefMut};
 use critical_section::{with, CriticalSection, Mutex};

--- a/src/riot-rs-threads/src/lock.rs
+++ b/src/riot-rs-threads/src/lock.rs
@@ -21,6 +21,7 @@ enum LockState {
 
 impl Lock {
     /// Creates new **unlocked** Lock
+    #[must_use]
     pub const fn new() -> Self {
         Self {
             state: UnsafeCell::new(LockState::Unlocked),
@@ -28,6 +29,7 @@ impl Lock {
     }
 
     /// Creates new **locked** Lock
+    #[must_use]
     pub const fn new_locked() -> Self {
         Self {
             state: UnsafeCell::new(LockState::Locked(ThreadList::new())),
@@ -60,7 +62,7 @@ impl Lock {
                     waiters.put_current(cs, ThreadState::LockBlocked);
                 }
             }
-        })
+        });
     }
 
     /// Get the lock (non-blocking)
@@ -93,11 +95,11 @@ impl Lock {
                 LockState::Unlocked => {}
                 LockState::Locked(waiters) => {
                     if waiters.pop(cs).is_none() {
-                        *state = LockState::Unlocked
+                        *state = LockState::Unlocked;
                     }
                 }
             }
-        })
+        });
     }
 }
 

--- a/src/riot-rs-threads/src/thread.rs
+++ b/src/riot-rs-threads/src/thread.rs
@@ -45,6 +45,7 @@ pub enum ThreadState {
 
 impl Thread {
     /// Creates an empty [`Thread`] object with [`ThreadState::Invalid`].
+    #[must_use]
     pub const fn default() -> Thread {
         Thread {
             sp: 0,

--- a/src/riot-rs-threads/src/thread_flags.rs
+++ b/src/riot-rs-threads/src/thread_flags.rs
@@ -20,7 +20,7 @@ pub enum WaitMode {
 ///
 /// Panics if `thread_id` is >= [`THREADS_NUMOF`](crate::THREADS_NUMOF).
 pub fn set(thread_id: ThreadId, mask: ThreadFlags) {
-    THREADS.with_mut(|mut threads| threads.flag_set(thread_id, mask))
+    THREADS.with_mut(|mut threads| threads.flag_set(thread_id, mask));
 }
 
 /// Waits until all flags in `mask` are set for the current thread.

--- a/src/riot-rs-threads/src/threadlist.rs
+++ b/src/riot-rs-threads/src/threadlist.rs
@@ -11,6 +11,7 @@ pub struct ThreadList {
 
 impl ThreadList {
     /// Creates a new empty [`ThreadList`]
+    #[must_use]
     pub const fn new() -> Self {
         Self { head: None }
     }
@@ -47,6 +48,7 @@ impl ThreadList {
     }
 
     /// Determines if this [`ThreadList`] is empty.
+    #[must_use]
     pub fn is_empty(&self, _cs: CriticalSection) -> bool {
         self.head.is_none()
     }


### PR DESCRIPTION
Make the required changes to make clippy happy.

Depends on #886.