### PR TITLE
embassy: enable usage of `esp-wifi` with `ariel-os-threads`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3634,6 +3634,8 @@ dependencies = [
  "paste",
  "riot-rs-debug",
  "riot-rs-embassy-common",
+ "riot-rs-macros",
+ "riot-rs-threads",
  "riot-rs-utils",
 ]
 

--- a/src/riot-rs-arch/Cargo.toml
+++ b/src/riot-rs-arch/Cargo.toml
@@ -76,6 +76,13 @@ storage = [
   #"riot-rs-stm32/storage",
 ]
 
+threading = [
+  "riot-rs-esp/threading",
+  #"riot-rs-nrf/threading",
+  #"riot-rs-rp/threading",
+  #"riot-rs-stm32/threading",
+]
+
 wifi-cyw43 = ["riot-rs-rp/wifi-cyw43"]
 wifi-esp = ["riot-rs-esp/wifi-esp"]
 

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -86,7 +86,7 @@ wifi = []
 wifi-cyw43 = ["riot-rs-arch/wifi-cyw43", "net", "wifi"]
 wifi-esp = ["riot-rs-arch/wifi-esp", "net", "wifi"]
 
-threading = ["dep:riot-rs-threads"]
+threading = ["dep:riot-rs-threads", "riot-rs-esp/threading"]
 override-network-config = []
 override-usb-config = []
 

--- a/src/riot-rs-embassy/Cargo.toml
+++ b/src/riot-rs-embassy/Cargo.toml
@@ -86,7 +86,7 @@ wifi = []
 wifi-cyw43 = ["riot-rs-arch/wifi-cyw43", "net", "wifi"]
 wifi-esp = ["riot-rs-arch/wifi-esp", "net", "wifi"]
 
-threading = ["dep:riot-rs-threads", "riot-rs-esp/threading"]
+threading = ["dep:riot-rs-threads", "riot-rs-arch/threading"]
 override-network-config = []
 override-usb-config = []
 

--- a/src/riot-rs-esp/Cargo.toml
+++ b/src/riot-rs-esp/Cargo.toml
@@ -30,6 +30,8 @@ once_cell = { workspace = true }
 paste = { workspace = true }
 riot-rs-debug = { workspace = true }
 riot-rs-embassy-common = { workspace = true }
+riot-rs-macros = { path = "../riot-rs-macros", optional = true }
+riot-rs-threads = { path = "../riot-rs-threads", optional = true }
 riot-rs-utils = { workspace = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
@@ -93,3 +95,7 @@ wifi-esp = ["dep:embassy-time", "dep:esp-alloc", "dep:esp-wifi", "wifi"]
 executor-interrupt = ["embassy-executor/executor-interrupt"]
 ## Enables the single thread-mode executor.
 executor-single-thread = ["esp-hal-embassy/executors"]
+
+## Enables threading support.
+# Required for the usage of esp-wifi together with `riot-rs-threads`.
+threading = ["dep:riot-rs-macros", "dep:riot-rs-threads"]

--- a/src/riot-rs-esp/src/lib.rs
+++ b/src/riot-rs-esp/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(doc_auto_cfg)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(type_alias_impl_trait)]
+#![feature(used_with_arg)]
 
 pub mod gpio;
 

--- a/src/riot-rs-esp/src/wifi/esp_wifi.rs
+++ b/src/riot-rs-esp/src/wifi/esp_wifi.rs
@@ -19,6 +19,9 @@ pub type NetworkDevice = WifiDevice<'static, WifiStaDevice>;
 // sure.
 pub static WIFI_INIT: OnceCell<EspWifiInitialization> = OnceCell::new();
 
+#[cfg(feature = "threading")]
+pub static WIFI_THREAD_ID: OnceCell<riot_rs_threads::ThreadId> = OnceCell::new();
+
 pub fn init(peripherals: &mut crate::OptionalPeripherals, spawner: Spawner) -> NetworkDevice {
     let wifi = peripherals.WIFI.take().unwrap();
     let init = WIFI_INIT.get().unwrap();
@@ -31,6 +34,18 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals, spawner: Spawner) -> N
 
 #[embassy_executor::task]
 async fn connection(mut controller: WifiController<'static>) {
+    #[cfg(feature = "threading")]
+    {
+        let thread_id = WIFI_THREAD_ID.get().unwrap();
+
+        // Disable esp-wifi interrupts that are initialized in esp-wifi
+        // until the `esp_wifi_thread` runs.
+        interrupt::disable(esp_hal::Cpu::ProCpu, Interrupt::FROM_CPU_INTR3);
+        interrupt::disable(esp_hal::Cpu::ProCpu, Interrupt::SYSTIMER_TARGET0);
+        // Wake-up the `esp_wifi_thread`.
+        riot_rs_threads::thread_flags::set(*thread_id, 0b1);
+    }
+
     debug!("start connection task");
 
     #[cfg(not(feature = "defmt"))]
@@ -65,6 +80,80 @@ async fn connection(mut controller: WifiController<'static>) {
                 info!("Failed to connect to Wi-Fi: {:?}", e);
                 Timer::after(Duration::from_millis(5000)).await
             }
+        }
+    }
+}
+
+#[cfg(feature = "threading")]
+mod wifi_thread {
+    use esp_hal::{
+        interrupt,
+        peripherals::{Interrupt, SYSTIMER},
+    };
+
+    #[cfg(context = "esp32c6")]
+    use esp_hal::peripherals::INTPRI as SystemPeripheral;
+    #[cfg(context = "esp32c3")]
+    use esp_hal::peripherals::SYSTEM as SystemPeripheral;
+
+    use super::*;
+
+    // Handle the systimer alarm 0 interrupt, configured in esp-wifi.
+    extern "C" fn systimer_target0_() {
+        // SAFETY: constant pointer to register block is valid.
+        let systimer = unsafe { &*SYSTIMER::PTR };
+        // Clear interrupt.
+        systimer.int_clr().write(|w| w.target0().clear_bit_by_one());
+        // Wake up `esp_wifi_thread`.
+        if !riot_rs_threads::wakeup(*WIFI_THREAD_ID.get().unwrap()) {
+            // We're already in the context of `esp_wifi_thread`, so yield
+            // directly.
+            yield_to_esp_wifi_scheduler();
+        }
+    }
+
+    fn yield_to_esp_wifi_scheduler() {
+        // SAFETY: constant pointer to register block is valid.
+        let ptr = unsafe { &*SystemPeripheral::PTR };
+        // CPU Interrupt 3 triggers the scheduler in `esp-wifi`.
+        ptr.cpu_intr_from_cpu_3()
+            .modify(|_, w| w.cpu_intr_from_cpu_3().set_bit());
+    }
+
+    // Thread that runs the esp-wifi scheduler.
+    ///
+    /// Because it runs at highest priority, it can't be preempted by any riot-rs threads and therefore
+    /// the two schedulers won't interleave.
+    #[riot_rs_macros::thread(autostart, priority = riot_rs_threads::SCHED_PRIO_LEVELS as u8 - 1)]
+    fn esp_wifi_thread() {
+        WIFI_THREAD_ID
+            .set(riot_rs_threads::current_pid().unwrap())
+            .unwrap();
+
+        // Wait until `embassy` is initialized.
+        riot_rs_threads::thread_flags::wait_one(0b1);
+
+        // Bind the periodic systimer that is configured in esp-wifi to our own handler.
+        //
+        // SAFETY: This overwrites the existing handler from esp-wifi, which is okay because
+        // we want to handle the interrupt differently. It needs to be done after the esp-hal
+        // initialization finished.
+        unsafe {
+            interrupt::bind_interrupt(
+                Interrupt::SYSTIMER_TARGET0,
+                core::mem::transmute(systimer_target0_ as *const ()),
+            );
+        }
+        interrupt::enable(Interrupt::SYSTIMER_TARGET0, interrupt::Priority::Priority2).unwrap();
+
+        loop {
+            interrupt::enable(Interrupt::FROM_CPU_INTR3, interrupt::Priority::Priority1).unwrap();
+            // Yield to the esp-wifi scheduler tasks, so that they get a chance to run.
+            yield_to_esp_wifi_scheduler();
+            // Disable esp-wifi scheduler so that it won't interleave with the riot-rs-threads scheduler.
+            interrupt::disable(esp_hal::Cpu::ProCpu, Interrupt::FROM_CPU_INTR3);
+            // Sleep until the systimer alarm 0 interrupts again.
+            riot_rs_threads::sleep()
         }
     }
 }


### PR DESCRIPTION
This implements an example that uses `esp-wifi` together with `riot-rs-threads`.

I don't intend for this to be merged, but rather to get feedback on the idea, and to start the discussion on how we can solve it directly inside `riot-rs-embassy`.

## Problem when using `esp-wifi` and RIOT-rs threading together

As documented in #289, using the two components together is non trivial because `esp-wifi` internally runs a preemptive scheduler for wif-/ bluetooth related tasks.  This scheduler uses the periodic systemtimer alarm0 to switch between its tasks, in addition to cooperative yielding using CPU interrupt 3.
The preemptive systemtimer-triggered context switch conflicts with our riot-rs-threads scheduler because it would interleave both schedulers, resulting in undefined behavior.

## Proposed Solution

The idea in this PR is to solve the problem as follows:

- We create one high priority thread (`esp_wifi_thread`) that drives the esp-wifi tasks in a loop. A loop iteration essentially consists of the following two steps:
    - yield the execution cooperatively to the esp-wifi scheduler, so that it can run all of its tasks once
    - go to sleep
- As mentioned above, esp-wifi configures an period alarm0. In the original implementation, the interrupt from this alarm would cause a context switch, so that all esp-wifi tasks get a chance to run. In my implementation, I remapped the interrupt from this alarm0 to a new handler that instead wakes up the above `esp_wifi_thread`. 
   - This maintains the functionality that  every \<alarm0-frequency\> the esp-wifi tasks get a chance to run, but realized through our threading.
- The application logic can then run in another thread.
- The riots-rs-rt usually initializes embassy. With the `threading` feature enabled however, this doesn't happen anymore because [threading is started before the call to `riot_rs_embassy_init`](https://github.com/future-proof-iot/RIOT-rs/blob/9de46ca204bcec1d73b3d87875e1db1c03ac5f37/src/riot-rs-rt/src/lib.rs#L80-L94). Thus the <s>`esp-wifi-thread`</s> application thread has to explicitly call this initialization function. This will also spawn the executor that runs the `tcp_echo` task.

## Limitations when using `embassy-time`

_Not relevant for this PR anymore with the change described in https://github.com/future-proof-iot/RIOT-rs/pull/300#issuecomment-2129033999. Nevertheless, I still think it's something to consider when we talk about spawning multiple embassy executors in different threads._

Independently of the conflict between the `esp-wifi` scheduler and our `riot-rs-threads` scheduler, there is an issue with timers when using embassy together with our threads on esp.
If `embassy-time` is required (which is the case in `riot_rs_embassy::wifi::esp_wifi`), the embassy executor tries to allocate a timer upon creation.

The concrete timer driver implementation for this is configured through a feature flag on `esp-hal`.
Right now, we are using the Timer Group Timer 0 (TIMG0) through the  `embassy-time-timg0` feature. The problem is that this gives exactly one timer. So as soon as we start a second embassy executor in a second `riot-rs-thread` Thread, the timer allocation panics.

<s>I now switched to using the system timer. However, this also only gives us 3 timers in total. One is already used as described above by `esp-wifi` for alarm0. So only 2 remain, which means that we can only ever have two embassy executors if the `time` feature is enabled.
Thoughts on this @kaspar030 @ROMemories? </s>

Fixes #289.