### PR TITLE
fix(embassy-init): move out peripherals required for drivers earlier

### DIFF
--- a/src/riot-rs-embassy/src/arch/dummy/usb.rs
+++ b/src/riot-rs-embassy/src/arch/dummy/usb.rs
@@ -3,8 +3,6 @@ use embassy_usb::driver::{
     EndpointIn, EndpointInfo, EndpointOut, EndpointType, Event, Unsupported,
 };
 
-use crate::arch;
-
 pub struct UsbDriver;
 
 impl<'a> Driver<'a> for UsbDriver {
@@ -34,7 +32,9 @@ impl<'a> Driver<'a> for UsbDriver {
     }
 }
 
-pub fn driver(_peripherals: &mut arch::OptionalPeripherals) -> UsbDriver {
+crate::define_peripherals!(Peripherals {});
+
+pub fn driver(_peripherals: Peripherals) -> UsbDriver {
     unimplemented!();
 }
 

--- a/src/riot-rs-embassy/src/arch/nrf/usb.rs
+++ b/src/riot-rs-embassy/src/arch/nrf/usb.rs
@@ -7,8 +7,6 @@ use embassy_nrf::{
     },
 };
 
-use crate::arch;
-
 #[cfg(context = "nrf52")]
 bind_interrupts!(struct Irqs {
     USBD => usb::InterruptHandler<peripherals::USBD>;
@@ -23,7 +21,8 @@ bind_interrupts!(struct Irqs {
 
 pub type UsbDriver = Driver<'static, peripherals::USBD, HardwareVbusDetect>;
 
-pub fn driver(peripherals: &mut arch::OptionalPeripherals) -> UsbDriver {
-    let usbd = peripherals.USBD.take().unwrap();
-    Driver::new(usbd, Irqs, HardwareVbusDetect::new(Irqs))
+crate::define_peripherals!(Peripherals { usbd: USBD });
+
+pub fn driver(peripherals: Peripherals) -> UsbDriver {
+    Driver::new(peripherals.usbd, Irqs, HardwareVbusDetect::new(Irqs))
 }

--- a/src/riot-rs-embassy/src/arch/rp2040/usb.rs
+++ b/src/riot-rs-embassy/src/arch/rp2040/usb.rs
@@ -3,15 +3,14 @@ use embassy_rp::{
     usb::{Driver, InterruptHandler},
 };
 
-use crate::arch;
-
 bind_interrupts!(struct Irqs {
     USBCTRL_IRQ => InterruptHandler<peripherals::USB>;
 });
 
 pub type UsbDriver = Driver<'static, peripherals::USB>;
 
-pub fn driver(peripherals: &mut arch::OptionalPeripherals) -> UsbDriver {
-    let usb = peripherals.USB.take().unwrap();
-    Driver::new(usb, Irqs)
+crate::define_peripherals!(Peripherals { usb: USB });
+
+pub fn driver(peripherals: Peripherals) -> UsbDriver {
+    Driver::new(peripherals.usb, Irqs)
 }

--- a/src/riot-rs-embassy/src/lib.rs
+++ b/src/riot-rs-embassy/src/lib.rs
@@ -143,6 +143,7 @@ fn init() {
 
 #[embassy_executor::task]
 async fn init_task(mut peripherals: arch::OptionalPeripherals) {
+    #[allow(unused_imports)]
     use crate::define_peripherals::TakePeripherals;
 
     println!("riot-rs-embassy::init_task()");

--- a/src/riot-rs-embassy/src/wifi/esp_wifi.rs
+++ b/src/riot-rs-embassy/src/wifi/esp_wifi.rs
@@ -1,9 +1,11 @@
-use esp_wifi::{wifi::WifiStaDevice, EspWifiInitialization};
+use esp_hal::peripherals;
+use esp_wifi::{
+    wifi::{WifiController, WifiDevice, WifiStaDevice},
+    EspWifiInitialization,
+};
 use once_cell::sync::OnceCell;
 
-use crate::{arch::OptionalPeripherals, Spawner};
-
-use esp_wifi::wifi::{WifiController, WifiDevice};
+use crate::Spawner;
 
 pub type NetworkDevice = WifiDevice<'static, WifiStaDevice>;
 
@@ -14,8 +16,10 @@ pub type NetworkDevice = WifiDevice<'static, WifiStaDevice>;
 // sure.
 pub static WIFI_INIT: OnceCell<EspWifiInitialization> = OnceCell::new();
 
-pub fn init(peripherals: &mut OptionalPeripherals, spawner: Spawner) -> NetworkDevice {
-    let wifi = peripherals.WIFI.take().unwrap();
+crate::define_peripherals!(Peripherals { wifi: WIFI });
+
+pub fn init(peripherals: Peripherals, spawner: Spawner) -> NetworkDevice {
+    let wifi = peripherals.wifi;
     let init = WIFI_INIT.get().unwrap();
     let (device, controller) = esp_wifi::wifi::new_with_mode(init, wifi, WifiStaDevice).unwrap();
 

--- a/src/riot-rs-macros/tests/ui/task/incorrect_fn_peripheral_param_type.stderr
+++ b/src/riot-rs-macros/tests/ui/task/incorrect_fn_peripheral_param_type.stderr
@@ -1,7 +1,14 @@
-error[E0599]: no method named `take_peripherals` found for mutable reference `&mut OptionalPeripherals` in the current scope
+error[E0308]: mismatched types
  --> tests/ui/task/incorrect_fn_peripheral_param_type.rs:7:1
   |
 7 | #[riot_rs::task(autostart, peripherals)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `&mut OptionalPeripherals`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Bar`, found `Peripherals`
+8 | async fn main(_foo: Bar) {}
+  |          ---- arguments to this function are incorrect
   |
+note: function defined here
+ --> tests/ui/task/incorrect_fn_peripheral_param_type.rs:8:10
+  |
+8 | async fn main(_foo: Bar) {}
+  |          ^^^^ ---------
   = note: this error originates in the attribute macro `riot_rs::task` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Previously, it would have been possible for user tasks to take peripherals out of `OptionalPeripherals` *before* the required peripherals had been extracted for drivers.
This now takes the peripherals before starting the user tasks, making this impossible for tasks.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #533.

## Open Questions

<!-- Unresolved questions, if any. -->
None.

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
