### PR TITLE
test: add `embedded-test` integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,6 @@ dependencies = [
 name = "ariel-os-rt"
 version = "0.1.0"
 dependencies = [
- "ariel-os-boards",
  "ariel-os-debug",
  "ariel-os-threads",
  "ariel-os-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,8 +279,11 @@ dependencies = [
 name = "ariel-os-identity"
 version = "0.1.0"
 dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
  "ariel-os-embassy",
  "ariel-os-embassy-common",
+ "embedded-test",
 ]
 
 [[package]]
@@ -1820,6 +1823,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1763775e2323b7d5f0aa6090657f5e21cfa02ede71f5dc40eead06d64dcd15cc"
 dependencies = [
  "embedded-storage",
+]
+
+[[package]]
+name = "embedded-test"
+version = "0.5.0"
+source = "git+https://github.com/ariel-os/embedded-test?branch=for-ariel-os-2024-10-21#58ed8dc6a29f491da062cbe10772cd2d99ca109b"
+dependencies = [
+ "embassy-executor",
+ "embedded-test-macros",
+ "heapless 0.8.0",
+ "semihosting",
+ "serde",
+ "serde-json-core 0.5.1",
+]
+
+[[package]]
+name = "embedded-test-macros"
+version = "0.5.0"
+source = "git+https://github.com/ariel-os/embedded-test?branch=for-ariel-os-2024-10-21#58ed8dc6a29f491da062cbe10772cd2d99ca109b"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3372,7 +3399,7 @@ dependencies = [
  "lhash",
  "ryu",
  "serde",
- "serde-json-core",
+ "serde-json-core 0.6.0",
 ]
 
 [[package]]
@@ -3963,6 +3990,17 @@ dependencies = [
 
 [[package]]
 name = "serde-json-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c9e1ab533c0bc414c34920ec7e5f097101d126ed5eac1a1aac711222e0bbb33"
+dependencies = [
+ "heapless 0.7.17",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde-json-core"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b81787e655bd59cecadc91f7b6b8651330b2be6c33246039a65e5cd6f4e0828"
@@ -4392,11 +4430,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "testing"
+version = "0.1.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+ "embedded-test",
+]
+
+[[package]]
 name = "tests_gpio"
 version = "0.1.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
+ "embedded-test",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,9 @@ embedded-hal-async = { version = "1.0.0", default-features = false }
 embedded-nal-coap = "0.1.0-alpha.4"
 embedded-storage = { version = "0.3.1" }
 embedded-storage-async = { version = "0.4.1" }
+embedded-test = { version = "0.5.0", default-features = false, features = [
+  "ariel-os",
+] }
 
 esp-alloc = { version = "0.5.0", default-features = false }
 esp-hal = { version = "0.21.1", default-features = false }

--- a/ariel-os-cargo.toml
+++ b/ariel-os-cargo.toml
@@ -44,3 +44,6 @@ esp-storage = { git = "https://github.com/ariel-os/esp-hal", branch = "for-ariel
 
 # patched to use portable-atomics <https://github.com/seanmonstar/try-lock/pull/11>
 try-lock = { git = "https://github.com/seanmonstar/try-lock", rev = "a1aadfac9840fe23672159c12af7272e44bc684c" }
+
+# added Ariel OS support
+embedded-test = { git = "https://github.com/ariel-os/embedded-test", branch = "for-ariel-os-2024-10-21" }

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -18,6 +18,7 @@ subdirs:
   - random
   - storage
   - tcp-echo
+  - testing
   - thread-async-interop
   - threading
   - threading-channel

--- a/examples/testing/Cargo.toml
+++ b/examples/testing/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "testing"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+ariel-os = { path = "../../src/ariel-os" }
+ariel-os-boards = { path = "../../src/ariel-os-boards" }
+
+[dev-dependencies]
+embedded-test = { workspace = true }
+
+[[test]]
+name = "test"
+harness = false

--- a/examples/testing/README.md
+++ b/examples/testing/README.md
@@ -1,0 +1,12 @@
+# testing
+
+## About
+
+This application shows how to use the `embedded-test`-based testing framework
+with Ariel OS applications.
+
+## How to run
+
+In this folder, run
+
+    laze build -b nrf52840dk test

--- a/examples/testing/laze.yml
+++ b/examples/testing/laze.yml
@@ -1,0 +1,5 @@
+apps:
+  - name: testing
+    selects:
+      - defmt
+      - embedded-test-only

--- a/examples/testing/tests/test.rs
+++ b/examples/testing/tests/test.rs
@@ -1,0 +1,34 @@
+#![no_main]
+#![no_std]
+#![feature(impl_trait_in_assoc_type)]
+#![feature(used_with_arg)]
+
+#[cfg(test)]
+#[embedded_test::tests]
+mod tests {
+    // Optional: An init function which is called before every test
+    #[init]
+    fn init() -> u32 {
+        return 42;
+    }
+
+    // A test which takes the state returned by the init function (optional)
+    // This is an async function, it will be executed on the system executor.
+    #[test]
+    async fn trivial_async(n: u32) {
+        assert!(n == 42)
+    }
+
+    // A test which takes the state returned by the init function (optional)
+    #[test]
+    fn trivial(n: u32) {
+        assert!(n == 42)
+    }
+
+    // A test which is "ignored".
+    #[test]
+    #[ignore]
+    fn trivial_ignored(n: u32) {
+        assert!(n == 42)
+    }
+}

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -682,6 +682,16 @@ modules:
         RUSTFLAGS:
           - --cfg capability=\"hw/usb-device-port\"
 
+  - name: hw/device-identity
+    help: provided if the device implements ariel-os-identity
+    context:
+      - nrf
+      - stm32
+    env:
+      global:
+        RUSTFLAGS:
+          - --cfg capability=\"hw/device-identity\"
+
   - name: hwrng
     help: The board's peripherals are suitable for passing into ariel_os_random::construct_rng.
     context:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -96,11 +96,6 @@ contexts:
         cmd:
           - cd ${appdir} && ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS} clippy ${FEATURES}
 
-      cargo-test:
-        cmd:
-          - cd ${relpath} && ${CARGO_ENV} cargo test --${PROFILE} --features=ariel-os-boards/${builder},ariel-os-rt/debug-console --manifest-path ${app}/Cargo.toml
-        build: false
-
       debug:
         cmd:
           - cd ${appdir} && ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --${PROFILE} ${FEATURES}
@@ -236,8 +231,8 @@ contexts:
         - --cfg context=\"esp\"
         # linkall first
         - -Clink-arg=-Tlinkall.x
-        # this might be needed for backtraces
-        # - -C force-frame-pointers
+        # this might be needed for backtraces. it is needed for probe-rs.
+        - -C force-frame-pointers
       CARGO_ARGS:
         - -Zbuild-std=core,alloc
 
@@ -543,7 +538,7 @@ modules:
 
     env:
       global:
-        CARGO_RUNNER: "'probe-rs run ${PROBE_RS_PROTOCOL} --chip ${PROBE_RS_CHIP}'"
+        CARGO_RUNNER: "'probe-rs run ${PROBE_RS_PROTOCOL} --chip ${PROBE_RS_CHIP} --preverify'"
 
     tasks:
       flash-erase-all:
@@ -840,7 +835,7 @@ modules:
           - ariel-os/semihosting
 
   - name: host-test-only
-    help: This application produces no .elf (it only has tests)
+    help: This application produces no .elf (it only has *cargo* tests)
     context:
       - host
     env:
@@ -857,6 +852,40 @@ modules:
         build: false
         cmd:
           - cd ${appdir} && cargo test --features _test
+
+  - name: embedded-test
+    context: ariel-os
+    selects:
+      # There is an issue with multi-core on esp.
+      - ?esp-single-core
+      - sw/threading
+      - rtt-target
+      - probe-rs
+    tasks:
+      test:
+        cmd:
+          - ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS} -Z unstable-options -C${appdir} test ${FEATURES}
+        build: false
+
+    env:
+      global:
+        RUSTFLAGS:
+          - -Clink-arg=-Tembedded-test.x
+
+  # This helper module works around laze not supporting sth like "if context == foo then depend on bar".
+  - name: esp-single-core
+    help: force single core only on esp
+    context: esp
+    selects:
+      - single-core
+
+  - name: embedded-test-only
+    help: This application produces no .elf (it only has *embedded* tests)
+    selects:
+      - embedded-test
+    env:
+      global:
+        SKIP_CARGO_BUILD: "1"
 
 builders:
   # host builder (for housekeeping tasks)

--- a/src/ariel-os-identity/Cargo.toml
+++ b/src/ariel-os-identity/Cargo.toml
@@ -5,6 +5,9 @@ license.workspace = true
 edition.workspace = true
 repository.workspace = true
 
+[lib]
+harness = false
+
 [lints]
 workspace = true
 
@@ -12,6 +15,11 @@ workspace = true
 ariel-os-embassy = { workspace = true }
 ariel-os-embassy-common = { workspace = true }
 
+[target.'cfg(context = "ariel-os")'.dev-dependencies]
+ariel-os = { path = "../../src/ariel-os" }
+ariel-os-boards = { path = "../../src/ariel-os-boards" }
+
+embedded-test = { workspace = true }
 
 [features]
 _test = ["ariel-os-embassy/executor-none"]

--- a/src/ariel-os-identity/laze.yml
+++ b/src/ariel-os-identity/laze.yml
@@ -1,4 +1,5 @@
 apps:
   - name: crates/ariel-os-identity
     selects:
-      - host-test-only
+      - ?hw/device-identity
+      - embedded-test-only

--- a/src/ariel-os-identity/src/lib.rs
+++ b/src/ariel-os-identity/src/lib.rs
@@ -27,6 +27,10 @@
 #![no_std]
 #![deny(missing_docs)]
 #![deny(clippy::pedantic)]
+// required for tests:
+#![cfg_attr(test, no_main)]
+#![cfg_attr(test, feature(impl_trait_in_assoc_type))]
+#![cfg_attr(test, feature(used_with_arg))]
 
 pub use ariel_os_embassy_common::identity::Eui48;
 
@@ -72,4 +76,19 @@ pub fn interface_eui48(if_index: u32) -> Result<Eui48, impl core::error::Error> 
     use ariel_os_embassy_common::identity::DeviceId;
 
     ariel_os_embassy::hal::identity::DeviceId::get().map(|d| d.interface_eui48(if_index))
+}
+
+#[cfg(test)]
+#[embedded_test::tests]
+mod tests {
+    #[test]
+    async fn has_device_id() {
+        let device_id = ariel_os::identity::device_id_bytes();
+
+        if cfg!(capability = "hw/device-identity") {
+            assert!(device_id.is_ok());
+        } else {
+            assert!(device_id.is_err());
+        }
+    }
 }

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -49,6 +49,3 @@ _esp32 = []
 _esp32c3 = []
 _esp32c6 = []
 _esp32s3 = []
-
-[dev-dependencies]
-ariel-os-boards = { path = "../ariel-os-boards" }

--- a/src/ariel-os-rt/laze.yml
+++ b/src/ariel-os-rt/laze.yml
@@ -1,3 +1,0 @@
-apps:
-  - selects:
-      - "disabled_until_test_framework_fixed"

--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -73,6 +73,9 @@ fn startup() -> ! {
 
     debug!("ariel_os_rt::startup()");
 
+    #[cfg(test)]
+    debug!("ariel_os_rt::startup() cfg(test)");
+
     for f in INIT_FUNCS {
         f();
     }

--- a/src/laze.yml
+++ b/src/laze.yml
@@ -6,7 +6,6 @@ subdirs:
   - ariel-os-macros
   - ariel-os-nrf
   - ariel-os-rp
-  - ariel-os-rt
   - ariel-os-runqueue
   - ariel-os-stm32
   - ariel-os-threads

--- a/tests/gpio-interrupt-nrf/src/main.rs
+++ b/tests/gpio-interrupt-nrf/src/main.rs
@@ -4,7 +4,7 @@
 #![feature(used_with_arg)]
 
 use ariel_os::{
-    debug::log::info,
+    debug::{exit, log::info, ExitCode},
     gpio::{self, Input, Pull},
     hal::peripherals,
 };
@@ -91,4 +91,5 @@ async fn main(peripherals: ButtonPeripherals) {
     }
 
     info!("Test passed!");
+    exit(ExitCode::Success);
 }

--- a/tests/gpio-interrupt-stm32/src/main.rs
+++ b/tests/gpio-interrupt-stm32/src/main.rs
@@ -4,7 +4,7 @@
 #![feature(used_with_arg)]
 
 use ariel_os::{
-    debug::log::info,
+    debug::{exit, log::info, ExitCode},
     gpio::{self, Input, Pull},
     hal::peripherals,
 };
@@ -38,4 +38,5 @@ async fn main(peripherals: ButtonPeripherals) {
     ));
 
     info!("Test passed!");
+    exit(ExitCode::Success);
 }

--- a/tests/gpio/Cargo.toml
+++ b/tests/gpio/Cargo.toml
@@ -8,6 +8,12 @@ publish = false
 [lints]
 workspace = true
 
+[[test]]
+name = "test"
+path = "src/test.rs"
+harness = false
+
 [dependencies]
 ariel-os = { path = "../../src/ariel-os", features = ["external-interrupts"] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
+embedded-test = { workspace = true }

--- a/tests/gpio/laze.yml
+++ b/tests/gpio/laze.yml
@@ -1,2 +1,4 @@
 apps:
   - name: tests_gpio
+    selects:
+      - embedded-test-only

--- a/tests/gpio/src/test.rs
+++ b/tests/gpio/src/test.rs
@@ -7,7 +7,7 @@ mod pins;
 
 #[allow(unused_imports)]
 use ariel_os::{
-    debug::log::info,
+    debug::{exit, log::info, EXIT_SUCCESS},
     gpio::{DriveStrength, Input, Level, Output, Pull, Speed},
 };
 
@@ -35,4 +35,5 @@ async fn main(peripherals: pins::Peripherals) {
     let _led_1 = led_1_builder.build();
 
     info!("Test passed!");
+    ariel_os::debug::exit_success();
 }

--- a/tests/gpio/src/test.rs
+++ b/tests/gpio/src/test.rs
@@ -7,7 +7,7 @@ mod pins;
 
 #[allow(unused_imports)]
 use ariel_os::{
-    debug::{exit, log::info, EXIT_SUCCESS},
+    debug::{exit, log::info, ExitCode},
     gpio::{DriveStrength, Input, Level, Output, Pull, Speed},
 };
 
@@ -35,5 +35,5 @@ async fn main(peripherals: pins::Peripherals) {
     let _led_1 = led_1_builder.build();
 
     info!("Test passed!");
-    ariel_os::debug::exit_success();
+    exit(ExitCode::Success);
 }

--- a/tests/spi-main/src/main.rs
+++ b/tests/spi-main/src/main.rs
@@ -24,6 +24,7 @@ use ariel_os::{
         Mode,
     },
 };
+
 use embassy_sync::mutex::Mutex;
 use embedded_hal_async::spi::{Operation, SpiDevice as _};
 

--- a/tests/threading-dynamic-prios/src/main.rs
+++ b/tests/threading-dynamic-prios/src/main.rs
@@ -5,7 +5,10 @@
 
 use portable_atomic::{AtomicUsize, Ordering};
 
-use ariel_os::thread::{RunqueueId, ThreadId};
+use ariel_os::{
+    debug::{exit, ExitCode},
+    thread::{RunqueueId, ThreadId},
+};
 
 static RUN_ORDER: AtomicUsize = AtomicUsize::new(0);
 
@@ -32,7 +35,7 @@ fn thread0() {
 
     assert_eq!(RUN_ORDER.fetch_add(1, Ordering::AcqRel), 2);
     ariel_os::debug::log::info!("Test passed!");
-    loop {}
+    exit(ExitCode::Success);
 }
 
 #[ariel_os::thread(autostart, priority = 1)]

--- a/tests/threading-lock/src/main.rs
+++ b/tests/threading-lock/src/main.rs
@@ -3,7 +3,11 @@
 #![feature(type_alias_impl_trait)]
 #![feature(used_with_arg)]
 
-use ariel_os::thread::{sync::Lock, thread_flags, ThreadId};
+use ariel_os::{
+    debug::{exit, ExitCode},
+    thread::{sync::Lock, thread_flags, ThreadId},
+};
+
 use portable_atomic::{AtomicUsize, Ordering};
 
 static LOCK: Lock = Lock::new();
@@ -32,6 +36,7 @@ fn thread0() {
     // Wait for other threads to complete.
     thread_flags::wait_all(0b111);
     ariel_os::debug::log::info!("Test passed!");
+    exit(ExitCode::Success);
 }
 
 #[ariel_os::thread(autostart, priority = 2)]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

This PR intents to provide a seamless integration of `embedded-test`.

~~This is very WIP, basically I'm in the experimentation phase.~~
~~This is taking shape. Still waiting on a probe-rs release, though.~~

This can be tested **with probe-rs-tools >=0.25.0** as follows:

    #  laze -Cexamples/testing build -v -b nrf52840dk -s executor-thread test

## Porting existing tests

The following steps can be followed to port existing tests from the `tests` directory to use `embedded-test`:

- Add `embedded-test` in `dev-dependencies`
- Add a `test` target (keep the `test` name for every test):

```toml
[[test]]
name = "test"
path = "src/test.rs"
harness = false
```

- Rename the existing `src/main.rs` to `src/test.rs`
- In the `laze.yml` file, add the following:

```yaml
    selects:
      - embedded-test
```

## Issues/PRs references

Fixes #331.
Depends on #506, #509, #549.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

- [x] needs probe-rs from git due to https://github.com/probe-rs/probe-rs/pull/2604 => probe-rs 0.25.0 released
- [x] embedded-test allows both async and sync tests. this integration starts a thread, and inside the thread, a thread executor. that means the test cannot use non-Send stuff from the system executor (e.g., network stack).
    so, we need a way to re-use the system executor.
- [x] integration is hacked into embedded-test fork, needs cleanup (& upstream PR)
- [x] how to handle test-only "apps" in laze. no .elf so "laze build" fails on them. *this also makes CI completely fail atm*. => `embedded-test-only` makes `laze build` a noop
- [x] ariel-os-identity test needs to be fixed to expect the right thing depending on whether there should be a device id
- [ ] document ...

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
