### PR TITLE
feat(threads): add mutex with priority inheritance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4485,6 +4485,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "threading-mutex"
+version = "0.1.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+ "embassy-executor",
+ "portable-atomic",
+]
+
+[[package]]
 name = "time"
 version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
   "tests/spi-main",
   "tests/threading-dynamic-prios",
   "tests/threading-lock",
+  "tests/threading-mutex",
 ]
 
 exclude = ["src/lib"]

--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -24,6 +24,7 @@
 #![cfg_attr(not(test), no_std)]
 #![feature(naked_functions)]
 #![feature(used_with_arg)]
+#![feature(negative_impls)]
 #![cfg_attr(target_arch = "xtensa", feature(asm_experimental_arch))]
 // Disable indexing lints for now, possible panics are documented or rely on internally-enforced
 // invariants

--- a/src/ariel-os-threads/src/sync/mod.rs
+++ b/src/ariel-os-threads/src/sync/mod.rs
@@ -2,7 +2,9 @@
 mod channel;
 mod event;
 mod lock;
+mod mutex;
 
 pub use channel::Channel;
 pub use event::Event;
 pub use lock::Lock;
+pub use mutex::{Guard, Mutex};

--- a/src/ariel-os-threads/src/sync/mutex.rs
+++ b/src/ariel-os-threads/src/sync/mutex.rs
@@ -1,0 +1,207 @@
+#![deny(missing_docs)]
+#![deny(clippy::pedantic)]
+
+use core::{
+    cell::UnsafeCell,
+    ops::{Deref, DerefMut},
+};
+
+use ariel_os_runqueue::{RunqueueId, ThreadId};
+use critical_section::CriticalSection;
+
+use crate::{thread::ThreadState, threadlist::ThreadList, SCHEDULER};
+
+/// A basic mutex with priority inheritance.
+pub struct Mutex<T> {
+    state: UnsafeCell<LockState>,
+    inner: UnsafeCell<T>,
+}
+
+/// State of a [`Mutex`].
+enum LockState {
+    Unlocked,
+    Locked {
+        //. The current owner of the lock.
+        owner_id: ThreadId,
+        /// The original priority of the current owner (without priority inheritance).
+        owner_prio: RunqueueId,
+        //. Waiters for the mutex.
+        waiters: ThreadList,
+    },
+}
+
+impl LockState {
+    /// Returns a [`LockState::Locked`] with the current thread as the owner
+    /// and an empty waitlist.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside of a thread context.
+    fn locked_with_current(cs: CriticalSection) -> Self {
+        let (owner_id, owner_prio) = SCHEDULER.with_mut_cs(cs, |mut scheduler| {
+            let current = scheduler
+                .current()
+                .expect("Function should be called inside a thread context.");
+            (current.pid, current.prio)
+        });
+        LockState::Locked {
+            waiters: ThreadList::new(),
+            owner_id,
+            owner_prio,
+        }
+    }
+}
+
+impl<T> Mutex<T> {
+    /// Creates a new **unlocked** [`Mutex`].
+    pub const fn new(value: T) -> Self {
+        Self {
+            state: UnsafeCell::new(LockState::Unlocked),
+            inner: UnsafeCell::new(value),
+        }
+    }
+}
+
+impl<T> Mutex<T> {
+    /// Returns whether the mutex is locked.
+    pub fn is_locked(&self) -> bool {
+        critical_section::with(|_| {
+            let state = unsafe { &*self.state.get() };
+            !matches!(state, LockState::Unlocked)
+        })
+    }
+
+    /// Acquires a mutex, blocking the current thread until it is able to do so.
+    ///
+    /// If the mutex was unlocked, it will be locked and a [`Guard`] is returned.
+    /// If the mutex is locked, this function will block the current thread until the mutex gets
+    /// unlocked elsewhere.
+    ///
+    /// If the current owner of the mutex has a lower priority than the current thread, it will inherit
+    /// the waiting thread's priority.
+    /// The priority is reset once the mutex is released. This means that a **user can not change a thread's
+    /// priority while it holds the lock**, because it will be changed back after release!
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside of a thread context.
+    pub fn lock(&self) -> Guard<T> {
+        critical_section::with(|cs| {
+            // SAFETY: access to the state only happens in critical sections, so it's always unique.
+            let state = unsafe { &mut *self.state.get() };
+            match state {
+                LockState::Unlocked => {
+                    *state = LockState::locked_with_current(cs);
+                }
+                LockState::Locked {
+                    waiters,
+                    owner_id,
+                    owner_prio,
+                } => {
+                    // Insert thread in waitlist, which also triggers the scheduler.
+                    match waiters.put_current(cs, ThreadState::LockBlocked) {
+                        // `Some` when the inserted thread is the highest priority
+                        // thread in the waitlist.
+                        Some(waiter_prio) if waiter_prio > *owner_prio => {
+                            // Current mutex owner inherits the priority.
+                            SCHEDULER.with_mut_cs(cs, |mut scheduler| {
+                                scheduler.set_priority(*owner_id, waiter_prio);
+                            });
+                        }
+                        _ => {}
+                    }
+                    // Context switch happens here as soon as we leave the critical section.
+                }
+            }
+        });
+        // Mutex was either directly acquired because it was unlocked, or the current thread was entered
+        // to the waitlist. In the latter case, it only continues running here after it was popped again
+        // from the waitlist and the thread acquired the mutex.
+
+        Guard { mutex: self }
+    }
+
+    /// Attempts to acquire this lock, in a non-blocking fashion.
+    ///
+    /// If the mutex was unlocked, it will be locked and a [`Guard`] is returned.
+    /// If the mutex was locked `None` is returned.
+    pub fn try_lock(&self) -> Option<Guard<T>> {
+        critical_section::with(|cs| {
+            // SAFETY: access to the state only happens in critical sections, so it's always unique.
+            let state = unsafe { &mut *self.state.get() };
+            if let LockState::Unlocked = *state {
+                *state = LockState::locked_with_current(cs);
+                Some(Guard { mutex: self })
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Releases the mutex.
+    ///
+    /// If there are waiters, the first waiter will be woken up.
+    fn release(&self) {
+        critical_section::with(|cs| {
+            // SAFETY: access to the state only happens in critical sections, so it's always unique.
+            let state = unsafe { &mut *self.state.get() };
+            if let LockState::Locked {
+                waiters,
+                owner_id,
+                owner_prio,
+            } = state
+            {
+                // Reset original priority of owner.
+                SCHEDULER.with_mut_cs(cs, |mut scheduler| {
+                    scheduler.set_priority(*owner_id, *owner_prio);
+                });
+                // Pop next thread from waitlist so that it can acquire the mutex.
+                if let Some((pid, _)) = waiters.pop(cs) {
+                    SCHEDULER.with_mut_cs(cs, |scheduler| {
+                        *owner_id = pid;
+                        *owner_prio = scheduler.get_unchecked(pid).prio;
+                    });
+                } else {
+                    // Unlock if waitlist was empty.
+                    *state = LockState::Unlocked;
+                }
+            }
+        });
+    }
+}
+
+unsafe impl<T> Sync for Mutex<T> {}
+
+/// Grants access to the [`Mutex`] inner data.
+///
+/// Dropping the [`Guard`] will unlock the [`Mutex`];
+pub struct Guard<'a, T> {
+    mutex: &'a Mutex<T>,
+}
+
+impl<'a, T> Deref for Guard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: Guard always has unique access.
+        unsafe { &*self.mutex.inner.get() }
+    }
+}
+
+impl<'a, T> DerefMut for Guard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: Guard always has unique access.
+        unsafe { &mut *self.mutex.inner.get() }
+    }
+}
+
+impl<'a, T> Drop for Guard<'a, T> {
+    fn drop(&mut self) {
+        // Unlock the mutex when the guard is dropped.
+        self.mutex.release();
+    }
+}
+
+impl<T> !Send for Guard<'_, T> {}
+
+unsafe impl<T: Sync> Sync for Guard<'_, T> {}

--- a/tests/laze.yml
+++ b/tests/laze.yml
@@ -9,3 +9,4 @@ subdirs:
   - spi-main
   - threading-dynamic-prios
   - threading-lock
+  - threading-mutex

--- a/tests/threading-mutex/Cargo.toml
+++ b/tests/threading-mutex/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "threading-mutex"
+version = "0.1.0"
+authors = ["Elena Frank <elena.frank@proton.me>"]
+license.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+embassy-executor = { workspace = true }
+ariel-os = { path = "../../src/ariel-os" }
+ariel-os-boards = { path = "../../src/ariel-os-boards" }
+portable-atomic = "1.6.0"

--- a/tests/threading-mutex/laze.yml
+++ b/tests/threading-mutex/laze.yml
@@ -1,0 +1,6 @@
+apps:
+  - name: threading-mutex
+    selects:
+      - ?release
+      - single-core
+      - sw/threading

--- a/tests/threading-mutex/src/main.rs
+++ b/tests/threading-mutex/src/main.rs
@@ -1,0 +1,106 @@
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(used_with_arg)]
+
+use ariel_os::thread::{self, sync::Mutex, thread_flags, RunqueueId, ThreadId};
+use portable_atomic::{AtomicUsize, Ordering};
+
+static MUTEX: Mutex<usize> = Mutex::new(0);
+static RUN_ORDER: AtomicUsize = AtomicUsize::new(0);
+
+#[ariel_os::thread(autostart, priority = 1)]
+fn thread0() {
+    let pid = thread::current_pid().unwrap();
+    assert_eq!(thread::get_priority(pid), Some(RunqueueId::new(1)));
+
+    assert_eq!(RUN_ORDER.fetch_add(1, Ordering::AcqRel), 0);
+
+    let mut counter = MUTEX.lock();
+
+    // Unblock other threads in the order of their IDs.
+    //
+    // Because all other threads have higher priorities, setting
+    // a flag will each time cause a context switch and give each
+    // thread the chance to run and try acquire the lock.
+    thread_flags::set(ThreadId::new(1), 0b1);
+    // Inherit prio of higher prio waiting thread.
+    assert_eq!(
+        thread::get_priority(pid),
+        thread::get_priority(ThreadId::new(1)),
+    );
+    thread_flags::set(ThreadId::new(2), 0b1);
+    // Inherit prio of highest waiting thread.
+    assert_eq!(
+        thread::get_priority(pid),
+        thread::get_priority(ThreadId::new(2)),
+    );
+    thread_flags::set(ThreadId::new(3), 0b1);
+    // Still has priority of highest waiting thread.
+    assert_eq!(
+        thread::get_priority(pid),
+        thread::get_priority(ThreadId::new(2)),
+    );
+
+    assert_eq!(*counter, 0);
+    *counter += 1;
+
+    drop(counter);
+
+    // Return to old prio.
+    assert_eq!(thread::get_priority(pid), Some(RunqueueId::new(1)));
+
+    // Wait for other threads to complete.
+    thread_flags::wait_all(0b111);
+
+    assert_eq!(*MUTEX.lock(), 4);
+    ariel_os::debug::log::info!("Test passed!");
+}
+
+#[ariel_os::thread(autostart, priority = 2)]
+fn thread1() {
+    let pid = thread::current_pid().unwrap();
+    assert_eq!(thread::get_priority(pid), Some(RunqueueId::new(2)));
+
+    thread_flags::wait_one(0b1);
+    assert_eq!(RUN_ORDER.fetch_add(1, Ordering::AcqRel), 1);
+
+    let mut counter = MUTEX.lock();
+    assert_eq!(*counter, 2);
+    *counter += 1;
+
+    thread_flags::set(ThreadId::new(0), 0b1);
+}
+
+#[ariel_os::thread(autostart, priority = 3)]
+fn thread2() {
+    let pid = thread::current_pid().unwrap();
+    assert_eq!(thread::get_priority(pid), Some(RunqueueId::new(3)));
+
+    thread_flags::wait_one(0b1);
+    assert_eq!(RUN_ORDER.fetch_add(1, Ordering::AcqRel), 2);
+
+    let mut counter = MUTEX.lock();
+    assert_eq!(*counter, 1);
+    // Priority didn't change because this thread has higher prio
+    // than all waiting threads.
+    assert_eq!(thread::get_priority(pid), Some(RunqueueId::new(3)),);
+    *counter += 1;
+
+    thread_flags::set(ThreadId::new(0), 0b10);
+}
+
+#[ariel_os::thread(autostart, priority = 2)]
+fn thread3() {
+    let pid = thread::current_pid().unwrap();
+    assert_eq!(thread::get_priority(pid), Some(RunqueueId::new(2)));
+
+    thread_flags::wait_one(0b1);
+    assert_eq!(RUN_ORDER.fetch_add(1, Ordering::AcqRel), 3);
+
+    let mut counter = MUTEX.lock();
+    assert_eq!(*counter, 3);
+    *counter += 1;
+
+    thread_flags::set(ThreadId::new(0), 0b100);
+}


### PR DESCRIPTION
# Description

Add a mutex implementation analogous to the existing `Lock`, with additional priority inheritance.
Unfortunately I don't think we can directly reuse `Lock`, because we need access to the inner `ThreadList`.

The PR also moves all synchronization primitives into a new `sync` submodule. Any objections?

## Issues/PRs references

Issue: #321.

Depends on 
- #370 
- #381
- #452 

## Open Questions


## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](../book/src/coding-conventions.md).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
