### PR TITLE
feat(boards): add initial support for Espressif ESP32-C3-LCDkit

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -143,6 +143,21 @@ chips:
       storage: supported
       wifi: not_available
 
+  esp32c3:
+    name: ESP32-C3
+    support:
+      gpio: supported
+      debug_output: supported
+      hwrng: supported
+      i2c_controller: supported
+      spi_main: supported
+      logging: supported
+      storage: not_currently_supported
+      wifi:
+        status: supported_with_caveats
+        comments:
+          - not currently compatible with threading
+
   esp32c6:
     name: ESP32-C6
     support:
@@ -309,6 +324,14 @@ boards:
       user_usb: supported
       wifi: supported
       ethernet_over_usb: supported
+
+  espressif-esp32-c3-lcdkit:
+    name: Espressif ESP32-C3-LCDkit
+    url: https://web.archive.org/web/20250408100740/https://www.espressif.com/en/dev-board/esp32-c3-lcdkit-en
+    chip: esp32c3
+    support:
+      user_usb: not_currently_supported
+      ethernet_over_usb: not_currently_supported
 
   espressif-esp32-c6-devkitc-1:
     name: Espressif ESP32-C6-DevKitC-1

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -339,6 +339,9 @@ contexts:
   - name: esp-wroom-32
     parent: esp32
 
+  - name: esp32-c3-mini-1
+    parent: esp32c3
+
   - name: esp32c3
     parent: esp
     selects:
@@ -1377,6 +1380,9 @@ builders:
 
   - name: ai-c3
     parent: esp-c3-01m
+
+  - name: espressif-esp32-c3-lcdkit
+    parent: esp32-c3-mini-1
 
   - name: espressif-esp32-devkitc
     parent: esp-wroom-32


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This adds initial support for the Espressif ESP32-C3-LCDkit. This does *not* add support for the onboard display.

## Testing

Successfully tested in hardware:

- `examples/gpio`
- `examples/random`
- `examples/log` with defmt
- `examples/http-client`
- `tests/i2c-controller`
- `tests/spi-main`
- `tests/spi-loopback`

Logging with `log` is not supported, but this is out-of-scope.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
