### PR TITLE
feat(build): initial Ferrocene support

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -13,6 +13,7 @@
 - [Debug Logging](./debug_logging.md)
 - [Tooling](./tooling/index.md)
   - [CoAP](./tooling/coap.md)
+  - [Ferrocene](./tooling/ferrocene.md)
 - [Glossary](./glossary.md)
 
 # Developer Guide

--- a/book/src/tooling/ferrocene.md
+++ b/book/src/tooling/ferrocene.md
@@ -1,0 +1,27 @@
+# [Ferrocene]
+
+> Ferrocene is the open-source qualified Rust compiler toolchain for safety- and mission-critical. Qualified for automotive, industrial and medical development.
+
+Note: Ferrocene requires a (paid) licence to use.
+
+Ferrocene uses [`criticalup`][criticalup], its variant of `rustup`, to manage installing its toolchain and components. Once installed, wrapping regular Rust commands like `cargo` and `rustc` with `criticalup run` enables using the qualified tooling.
+
+The Ariel OS build system seamlessly integrates this for targets supported by Ferrocene (currently all Cortex-M).
+
+## Installing Ferrocene
+
+Please refer to the official [Ferrocene documentation][ferrocene-docs] and the [`criticalup` User Guide][criticalup] for instructions.
+
+## Using Ferrocene with Ariel OS
+
+To select the Ferrocene toolchain, enable the `ferrocene` laze module.
+
+Example:
+
+    $ laze -Cexamples/hello-world build --builders nrf52830dk --select ferrocene
+
+Alternatively, add `ferrocene` to the laze modules of your application.
+
+[Ferrocene]: https://ferrocene.dev
+[ferrocene-docs]: https://public-docs.ferrocene.dev/main/user-manual/index.html
+[criticalup]: https://criticalup.ferrocene.dev

--- a/criticalup.toml
+++ b/criticalup.toml
@@ -1,0 +1,19 @@
+#
+# This file configures "criticalup", the Ferrocene qualified Rust toolchain.
+#
+manifest-version = 1
+
+[products.ferrocene]
+release = "nightly-2024-12-10"
+packages = [
+  "rust-std-thumbv6m-none-eabi",
+  "rust-std-thumbv7em-none-eabi",
+  "rust-std-thumbv8m.main-none-eabi",
+  "rust-std-${rustc-host}",
+  "cargo-${rustc-host}",
+  "clippy-${rustc-host}",
+  "rustfmt-${rustc-host}",
+  "llvm-tools-${rustc-host}",
+  "rustc-${rustc-host}",
+  "rust-src",
+]

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -5,6 +5,9 @@ contexts:
   - name: default
     env:
       bindir: "${build-dir}/bin/${builder}/${app}"
+      CARGO:
+        - ${CARGO_WRAPPER}
+        - cargo
 
   # base context for all Ariel OS applications
   - name: ariel-os
@@ -69,7 +72,7 @@ contexts:
         always: true
         cmd: >-
           test "${SKIP_CARGO_BUILD}" = "1" && exit 0;
-          cd ${relpath} && ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS} build --${PROFILE} ${FEATURES}
+          cd ${relpath} && ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} build --${PROFILE} ${FEATURES}
           && cp ${relroot}/${build-dir}/bin/${builder}/cargo/${RUSTC_TARGET}/${PROFILE}/${riot_binary} ${relroot}/${out}
 
       - name: GIT_DOWNLOAD
@@ -83,22 +86,22 @@ contexts:
 
       cargo:
         cmd:
-          - cd ${relpath} && ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS}
+          - cd ${relpath} && ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS}
         build: false
 
       run:
         build: false
         cmd:
-          - cd ${appdir} && ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --${PROFILE} ${FEATURES}
+          - cd ${appdir} && ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --${PROFILE} ${FEATURES}
 
       clippy:
         build: false
         cmd:
-          - cd ${appdir} && ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS} clippy ${FEATURES}
+          - cd ${appdir} && ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} clippy ${FEATURES}
 
       debug:
         cmd:
-          - cd ${appdir} && ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --${PROFILE} ${FEATURES}
+          - cd ${appdir} && ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --${PROFILE} ${FEATURES}
         build: false
         ignore_ctrl_c: true
 
@@ -110,12 +113,12 @@ contexts:
 
       bloat:
         cmd:
-          - cd ${appdir} && ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS} bloat --${PROFILE} ${FEATURES}
+          - cd ${appdir} && ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} bloat --${PROFILE} ${FEATURES}
         build: false
 
       tree:
         cmd:
-          - cd ${appdir} && ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS} tree ${FEATURES}
+          - cd ${appdir} && ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} tree ${FEATURES}
         build: false
 
       size:
@@ -881,7 +884,7 @@ modules:
           - RUSTDOCFLAGS
         build: false
         cmd:
-          - cd ${appdir} && cargo test --features _test
+          - cd ${appdir} && ${CARGO} test --features _test
 
   - name: embedded-test
     context: ariel-os
@@ -894,7 +897,7 @@ modules:
     tasks:
       test:
         cmd:
-          - ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS} -Z unstable-options -C${appdir} test ${FEATURES}
+          - ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} -Z unstable-options -C${appdir} test ${FEATURES}
         build: false
 
     env:
@@ -916,6 +919,20 @@ modules:
     env:
       global:
         SKIP_CARGO_BUILD: "1"
+
+  - name: ferrocene
+    help: build using Ferrocene qualified Rust compiler
+    context:
+      # actually, all Cortex-M currently supported by Ariel OS
+      - nrf
+      - rp
+      - stm32
+      # running the host tooling with ferrocene is also supported
+      - host
+    env:
+      global:
+        CARGO_WRAPPER:
+          - criticalup run
 
 builders:
   # host builder (for housekeeping tasks)


### PR DESCRIPTION
# Description

This is my draft branch for building with Ferrocene.
For our current nightly version, Ferrocene only seems to support thumbv7 from our set of toolchains.
Other than that, this was as drop-in as expected, cargo just needs to be started as `criticalup run cargo`.

To use / test this, get [criticalup](https://criticalup.ferrocene.dev/install.html), then build RIOT-rs as usual but select the `ferrocene` feature:

    laze -Cexamples/hello-world build -b nrf52840dk -s ferrocene

TODO:

- [x] wrap all cargo uses
- [x] document

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://future-proof-iot.github.io/RIOT-rs/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
