### PR TITLE
ci(docs): render manufacturer-specific docs

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           toolchain: ${{ steps.get_toolchain.outputs.toolchain }}
 
+      # Docs of HAL crates must be generated after that of the main crate,
+      # otherwise this would result in broken links, as they use `--no-deps` for
+      # faster generation.
       - name: Build rustdoc docs
         run: |
           cargo doc \
@@ -68,8 +71,48 @@ jobs:
                   usb,
                   usb-hid,
                   "
+          RUSTDOCFLAGS='-D warnings --cfg context="esp32c6"' cargo doc \
+              --target=riscv32imac-unknown-none-elf \
+              --no-deps \
+              --features "
+                  esp-hal-embassy/esp32c6,
+                  esp-hal/esp32c6,
+                  external-interrupts,
+                  i2c,
+                  spi,
+                  " \
+              -p ariel-os-esp
+          RUSTDOCFLAGS='-D warnings --cfg context="rp2040"' cargo doc \
+              --no-deps \
+              --features "
+                  embassy-rp/rp2040,
+                  external-interrupts,
+                  i2c,
+                  spi,
+                  " \
+              -p ariel-os-rp
+          RUSTDOCFLAGS='-D warnings --cfg context="nrf52840"' cargo doc \
+              --no-deps \
+              --features "
+                  embassy-nrf/nrf52840,
+                  external-interrupts,
+                  i2c,
+                  spi,
+                  " \
+              -p ariel-os-nrf
+          RUSTDOCFLAGS='-D warnings --cfg context="stm32wb55rgvx"' cargo doc \
+              --no-deps \
+              --features "
+                  embassy-stm32/stm32wb55rg,
+                  external-interrupts,
+                  i2c,
+                  spi,
+                  " \
+              -p ariel-os-stm32
           echo "<meta http-equiv=\"refresh\" content=\"0; url=ariel_os\">" > target/doc/index.html
-          mkdir -p ./_site/dev/docs/api && mv target/doc/* ./_site/dev/docs/api
+          mkdir -p ./_site/dev/docs/api
+          mv target/riscv32imac-unknown-none-elf/doc/ariel_os_esp/ ./_site/dev/docs/api
+          mv target/doc/* ./_site/dev/docs/api
 
       - name: Install mdbook
         run: |

--- a/src/ariel-os-hal/src/dummy/executor.rs
+++ b/src/ariel-os-hal/src/dummy/executor.rs
@@ -1,5 +1,6 @@
 use embassy_executor::SpawnToken;
 
+#[doc(hidden)]
 pub struct Executor;
 
 impl Executor {
@@ -19,6 +20,7 @@ impl Executor {
     }
 }
 
+#[doc(hidden)]
 pub struct Spawner;
 
 impl Spawner {

--- a/src/ariel-os-hal/src/dummy/mod.rs
+++ b/src/ariel-os-hal/src/dummy/mod.rs
@@ -1,42 +1,51 @@
 //! Dummy module used to satisfy platform-independent tooling.
-// TODO: redirect to the manufacturer-specific crate documentation when we publish it, and
-// mark every item in this dummy module `doc(hidden)`
 
 mod executor;
+
+#[doc(hidden)]
 pub mod gpio;
 
+#[doc(hidden)]
 pub mod peripheral {
     pub use embassy_hal_internal::Peripheral;
 }
 
+#[doc(hidden)]
 #[cfg(feature = "hwrng")]
 pub mod hwrng;
 
+#[doc(hidden)]
 #[cfg(feature = "i2c")]
 pub mod i2c;
 
+#[doc(hidden)]
 pub mod identity {
     use ariel_os_embassy_common::identity;
 
     pub type DeviceId = identity::NoDeviceId<identity::NotImplemented>;
 }
 
+#[doc(hidden)]
 #[cfg(feature = "spi")]
 pub mod spi;
 
+#[doc(hidden)]
 #[cfg(feature = "storage")]
 pub mod storage;
 
+#[doc(hidden)]
 #[cfg(feature = "usb")]
 pub mod usb;
 
 pub use executor::{Executor, Spawner};
 
+#[doc(hidden)]
 /// Dummy type.
 ///
 /// See the `OptionalPeripherals` type of your Embassy HAL crate instead.
 pub struct OptionalPeripherals;
 
+#[doc(hidden)]
 /// Dummy type.
 pub struct Peripherals;
 
@@ -46,8 +55,10 @@ impl From<Peripherals> for OptionalPeripherals {
     }
 }
 
+#[doc(hidden)]
 pub fn init() -> OptionalPeripherals {
     unimplemented!();
 }
 
+#[doc(hidden)]
 pub struct SWI;

--- a/src/ariel-os-hal/src/lib.rs
+++ b/src/ariel-os-hal/src/lib.rs
@@ -1,4 +1,19 @@
-//! This module dispatches between the ariel-os HAL crates.
+//! Provides MCU-specific items.
+//!
+//! This module dispatches between one of the following crate, depending on the target MCU family:
+//!
+//! | Manufacturer         | MCU family  | Docs rendered for | Items imported                                       |
+//! | -------------------- | ----------- | ----------------- | ---------------------------------------------------- |
+//! | Espressif            | ESP32       | ESP32-C6          | [`ariel-os-esp::*`](../../ariel_os_esp/index.html)     |
+//! | Nordic Semiconductor | nRF         | nRF52840          | [`ariel-os-nrf::*`](../../ariel_os_nrf/index.html)     |
+//! | Raspberry Pi         | RP          | RP2040            | [`ariel-os-rp::*`](../../ariel_os_rp/index.html)       |
+//! | STMicroelectronics   | STM32       | STM32W55RGVX      | [`ariel-os-stm32::*`](../../ariel_os_stm32/index.html) |
+//!
+//! Documentation is only rendered for the MCUs listed in the table above, but [many others are
+//! supported](https://ariel-os.github.io/ariel-os/dev/docs/book/hardware_functionality_support.html).
+//! To render the docs locally for the MCU of your choice, adapt [the `cargo doc` command used to
+//! generate documentation for the relevant
+//! crate](https://github.com/ariel-os/ariel-os/blob/main/.github/workflows/build-deploy-docs.yml).
 
 #![no_std]
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This generates the rustdoc docs for the manufacturer-specific crates (MSCs) that were extracted as part of #392.
The doc page of the `ariel_os::hal` module provides the user with a "manual redirect" to the items relevant for the target MCU, provided by the MSCs.

The current state of the generated docs can be seen on my fork: https://romemories.github.io/ariel-os/dev/docs/api/ariel_os/hal/index.html

## Limitations

**The documentation of the MSCs are currently rendered for one MCU only (and that MCU is not currently mentioned in the docs).** This is a significant limitation, but it's unclear how solve that in the general case (e.g., `ariel-os-stm32` may end supporting 1400 different MCUs).

E.g., the nRF5340 also supports 250 kHz as an I2C frequency, but [this does not currently appear in the docs](https://romemories.github.io/ariel-os/dev/docs/api/ariel_os_nrf/i2c/controller/enum.Frequency.html) because they are currently rendered for the nrf52840 only.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
This is the continuation of #392.
Depends on #551.

## Open Questions

<!-- Unresolved questions, if any. -->
- Should we attempt to find a solution to the limitation above or roll with it for now? => We agreed to document which MCU the documentation were generated for for now, and structure the "manual dispatch table" in a way we could easily expand if we were to generate documentation for other MCUs in the future.
- Additionally, all public types of the MSCs are part of these docs; some of them are definitely to be accessed by users (e.g., MCU-specific I2C `Frequency` types) but others are completely internal. We should agree on how we go about hiding those. => *We agreed to hide the items not relevant for users for now.*

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
