### PR TITLE
feat(coap): Drop allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,12 +76,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-traits"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2d54853319fd101b8dd81de382bcbf3e03410a64d8928bbee85a3e7dcde483"
-
-[[package]]
 name = "anyhow"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,7 +793,6 @@ dependencies = [
  "embedded-nal-coap",
  "heapless 0.8.0",
  "scroll-ring",
- "static-alloc",
 ]
 
 [[package]]
@@ -813,7 +806,6 @@ dependencies = [
  "coap-request-implementations",
  "embedded-nal-coap",
  "heapless 0.8.0",
- "static-alloc",
 ]
 
 [[package]]
@@ -950,7 +942,6 @@ dependencies = [
  "coap-message-demos",
  "embassy-sync 0.6.0",
  "heapless 0.8.0",
- "static-alloc",
 ]
 
 [[package]]
@@ -4220,16 +4211,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static-alloc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2975e035ce16539eecee08d7c6e5626ca26f299c6e90af343b302c6dd2e61e"
-dependencies = [
- "alloc-traits",
- "atomic-polyfill",
-]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,8 +2874,8 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "liboscore"
-version = "0.1.0"
-source = "git+https://gitlab.com/oscore/liboscore/?rev=447e34fc5af427de7513f96a756babfe2f0b2c5c#447e34fc5af427de7513f96a756babfe2f0b2c5c"
+version = "0.2.0"
+source = "git+https://gitlab.com/oscore/liboscore/?rev=55d0f71075d97a5a66ee4166487c09938d5ee7c5#55d0f71075d97a5a66ee4166487c09938d5ee7c5"
 dependencies = [
  "bindgen",
  "cbindgen",
@@ -2890,8 +2890,8 @@ dependencies = [
 
 [[package]]
 name = "liboscore-cryptobackend"
-version = "0.1.0"
-source = "git+https://gitlab.com/oscore/liboscore/?rev=447e34fc5af427de7513f96a756babfe2f0b2c5c#447e34fc5af427de7513f96a756babfe2f0b2c5c"
+version = "0.2.0"
+source = "git+https://gitlab.com/oscore/liboscore/?rev=55d0f71075d97a5a66ee4166487c09938d5ee7c5#55d0f71075d97a5a66ee4166487c09938d5ee7c5"
 dependencies = [
  "aead",
  "aes",
@@ -2908,8 +2908,8 @@ dependencies = [
 
 [[package]]
 name = "liboscore-msgbackend"
-version = "0.1.0"
-source = "git+https://gitlab.com/oscore/liboscore/?rev=447e34fc5af427de7513f96a756babfe2f0b2c5c#447e34fc5af427de7513f96a756babfe2f0b2c5c"
+version = "0.2.0"
+source = "git+https://gitlab.com/oscore/liboscore/?rev=55d0f71075d97a5a66ee4166487c09938d5ee7c5#55d0f71075d97a5a66ee4166487c09938d5ee7c5"
 dependencies = [
  "coap-message",
  "coap-message-implementations",

--- a/examples/coap-client/Cargo.toml
+++ b/examples/coap-client/Cargo.toml
@@ -20,5 +20,3 @@ embedded-nal-coap = { workspace = true }
 coap-request = "0.2.0-alpha.2"
 coap-request-implementations = "0.1.0-alpha.4"
 coap-handler-implementations = "0.5.0"
-
-static-alloc = { version = "0.2.5", features = ["polyfill"] }

--- a/examples/coap-client/src/main.rs
+++ b/examples/coap-client/src/main.rs
@@ -5,15 +5,6 @@
 
 use ariel_os::debug::log::info;
 
-/// Due to mismatches between CoAP components, coapcore currently needs an allocator. This example
-/// provides the one that can be made most easily.
-mod alloc {
-    extern crate alloc;
-
-    #[global_allocator]
-    static A: static_alloc::Bump<[u8; 1 << 16]> = static_alloc::Bump::uninit();
-}
-
 /// Run a CoAP stack without serving any actual resources.
 #[ariel_os::task(autostart)]
 async fn coap_run() {

--- a/examples/coap-server/Cargo.toml
+++ b/examples/coap-server/Cargo.toml
@@ -21,5 +21,3 @@ coap-message = "0.3.2"
 coap-message-demos = { version = "0.4.0", default-features = false }
 coap-handler = "0.2.0"
 coap-handler-implementations = "0.5.0"
-
-static-alloc = { version = "0.2.5", features = ["polyfill"] }

--- a/examples/coap-server/src/main.rs
+++ b/examples/coap-server/src/main.rs
@@ -3,15 +3,6 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 
-/// Due to mismatches between CoAP components, coapcore currently needs an allocator. This example
-/// provides the one that can be made most easily.
-mod alloc {
-    extern crate alloc;
-
-    #[global_allocator]
-    static A: static_alloc::Bump<[u8; 1 << 16]> = static_alloc::Bump::uninit();
-}
-
 #[ariel_os::task(autostart)]
 async fn coap_run() {
     use coap_handler_implementations::{

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -26,10 +26,9 @@ coap-message-utils = "0.3.3"
 coap-numbers = "0.2.3"
 hexlit = "0.5.5"
 lakers-crypto-rustcrypto = "0.6.0"
-liboscore = { git = "https://gitlab.com/oscore/liboscore/", rev = "447e34fc5af427de7513f96a756babfe2f0b2c5c" }
-liboscore-msgbackend = { git = "https://gitlab.com/oscore/liboscore/", features = [
-  "alloc",
-], rev = "447e34fc5af427de7513f96a756babfe2f0b2c5c" }
+liboscore = { git = "https://gitlab.com/oscore/liboscore/", rev = "55d0f71075d97a5a66ee4166487c09938d5ee7c5" }
+liboscore-msgbackend = { git = "https://gitlab.com/oscore/liboscore/", rev = "55d0f71075d97a5a66ee4166487c09938d5ee7c5" }
+
 minicbor = "0.23.0"
 heapless = "0.8.0"
 defmt-or-log = { version = "0.2.1", default-features = false }

--- a/tests/coap/Cargo.toml
+++ b/tests/coap/Cargo.toml
@@ -27,7 +27,6 @@ coap-request-implementations = "0.1.0-alpha.4"
 coap-handler = "0.2.0"
 coap-handler-implementations = "0.5.0"
 
-static-alloc = { version = "0.2.5", features = ["polyfill"] }
 coap-scroll-ring-server = "0.2.0"
 scroll-ring = "0.1.1"
 

--- a/tests/coap/src/main.rs
+++ b/tests/coap/src/main.rs
@@ -3,13 +3,6 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 
-// because coapcore depends on it temporarily
-extern crate alloc;
-use static_alloc::Bump;
-
-#[global_allocator]
-static A: Bump<[u8; 1 << 16]> = Bump::uninit();
-
 #[ariel_os::task(autostart)]
 async fn coap_run() {
     use coap_handler_implementations::HandlerBuilder;


### PR DESCRIPTION
# Description

libOSCORE had bugs around the use of heap allocated prepared messages. With the updated version, we can drop the allocator from the examples.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
