### PR TITLE
doc: Use of nightly features has been reduced

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ information.
 
 ## Minimum Supported Rust Version (MSRV)
 
-Ariel OS makes heavy use of Rust unstable features. For the time being, it is
-recommended to use a current nightly.
+Ariel OS makes use of selected Rust unstable features. For the time being, it is
+recommended to use the nightly version pinned by [`rust-toolchain.toml`](rust-toolchain.toml).
 
 ## Coding Conventions
 


### PR DESCRIPTION
# Description

Back when we started the README, this made heavy use of nightly features.

Now we're down to type_alias_impl_trait / impl_trait_in_assoc_type from embassy (hopefully soon stable, or replacable with something stable in a pinch), used_with_arg (unclear), doc_auto_cfg (if all others are gone that can be cfg_attr'd), and naked_functions (unclear). "heavy use" is not the case any more.

## Open Questions

A follow-up could codify the rough consensus that I think is not documented: That we only use features that can be either rolled back if need be, or are stable enough that we don't expect trouble (and there should be stabilization within like a year or two). But that's beyond scope -- having the README right is important for first impressions.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
