### PR TITLE
docs(hal): add a portability note regarding when to use `hal` items

### DIFF
--- a/src/ariel-os-hal/src/lib.rs
+++ b/src/ariel-os-hal/src/lib.rs
@@ -14,6 +14,13 @@
 //! To render the docs locally for the MCU of your choice, adapt [the `cargo doc` command used to
 //! generate documentation for the relevant
 //! crate](https://github.com/ariel-os/ariel-os/blob/main/.github/workflows/build-deploy-docs.yml).
+//!
+//! # Portability
+//!
+//! To ensure portability of your application, it is recommended to use the generic,
+//! MCU-family-agnostic items provided in other modules.
+//! Items from this module should only be used when MCU-specific settings are *necessary* for your
+//! application.
 
 #![no_std]
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This adds a note to the `ariel_os::hal` module, attempting to discourage usage of the settings it provides, when possible for the application.
We unfortunately cannot have internal links between the generic items and the `hal` items because it would result in cyclic crate dependencies. 

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
