### PR TITLE
build: use the inherited `edition` value

### DIFF
--- a/examples/benchmark/Cargo.toml
+++ b/examples/benchmark/Cargo.toml
@@ -3,7 +3,7 @@ name = "benchmark"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 publish = false
 

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -3,7 +3,7 @@ name = "minimal"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 publish = false
 

--- a/src/ariel-os-boards/ai-c3/Cargo.toml
+++ b/src/ariel-os-boards/ai-c3/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ai-c3"
 version = "0.1.0"
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 ariel-os-rt = { workspace = true, features = ["_esp32c3"] }

--- a/src/ariel-os-boards/dwm1001/Cargo.toml
+++ b/src/ariel-os-boards/dwm1001/Cargo.toml
@@ -3,7 +3,7 @@ name = "dwm1001"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/ariel-os-boards/espressif-esp32-c6-devkitc-1/Cargo.toml
+++ b/src/ariel-os-boards/espressif-esp32-c6-devkitc-1/Cargo.toml
@@ -2,7 +2,7 @@
 name = "espressif-esp32-c6-devkitc-1"
 version = "0.1.0"
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 ariel-os-rt = { workspace = true, features = ["_esp32c6"] }

--- a/src/ariel-os-boards/espressif-esp32-s3-wroom-1/Cargo.toml
+++ b/src/ariel-os-boards/espressif-esp32-s3-wroom-1/Cargo.toml
@@ -3,7 +3,7 @@ name = "espressif-esp32-s3-wroom-1"
 version = "0.1.0"
 authors = ["Elena Frank <elena.frank@proton.me>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 ariel-os-rt = { workspace = true, features = ["_esp32s3"] }

--- a/src/ariel-os-boards/espressif-esp32-wroom-32/Cargo.toml
+++ b/src/ariel-os-boards/espressif-esp32-wroom-32/Cargo.toml
@@ -2,7 +2,7 @@
 name = "espressif-esp32-wroom-32"
 version = "0.1.0"
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 ariel-os-rt = { workspace = true, features = ["_esp32"] }

--- a/src/ariel-os-boards/microbit-v2/Cargo.toml
+++ b/src/ariel-os-boards/microbit-v2/Cargo.toml
@@ -3,7 +3,7 @@ name = "microbit-v2"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 cortex-m-rt.workspace = true

--- a/src/ariel-os-boards/microbit/Cargo.toml
+++ b/src/ariel-os-boards/microbit/Cargo.toml
@@ -3,7 +3,7 @@ name = "microbit"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 cortex-m-rt.workspace = true

--- a/src/ariel-os-boards/nrf51/Cargo.toml
+++ b/src/ariel-os-boards/nrf51/Cargo.toml
@@ -3,7 +3,7 @@ name = "nrf51"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/ariel-os-boards/nrf52/Cargo.toml
+++ b/src/ariel-os-boards/nrf52/Cargo.toml
@@ -3,7 +3,7 @@ name = "nrf52"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 nrf52832-pac = { version = "0.12.2", default-features = false, features = [

--- a/src/ariel-os-boards/nrf52840-mdk/Cargo.toml
+++ b/src/ariel-os-boards/nrf52840-mdk/Cargo.toml
@@ -3,7 +3,7 @@ name = "nrf52840-mdk"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/ariel-os-boards/nrf5340/Cargo.toml
+++ b/src/ariel-os-boards/nrf5340/Cargo.toml
@@ -3,7 +3,7 @@ name = "nrf5340"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 ariel-os-debug = { workspace = true, features = ["rtt-target"] }

--- a/src/ariel-os-boards/particle-xenon/Cargo.toml
+++ b/src/ariel-os-boards/particle-xenon/Cargo.toml
@@ -3,7 +3,7 @@ name = "particle-xenon"
 version = "0.1.0"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 cortex-m-rt.workspace = true

--- a/src/ariel-os-boards/rpi-pico/Cargo.toml
+++ b/src/ariel-os-boards/rpi-pico/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rpi-pico"
 version = "0.1.0"
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/ariel-os-boards/st-nucleo-f401re/Cargo.toml
+++ b/src/ariel-os-boards/st-nucleo-f401re/Cargo.toml
@@ -3,7 +3,7 @@ name = "st-nucleo-f401re"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/src/ariel-os-boards/st-nucleo-h755zi-q/Cargo.toml
+++ b/src/ariel-os-boards/st-nucleo-h755zi-q/Cargo.toml
@@ -2,7 +2,7 @@
 name = "st-nucleo-h755zi-q"
 version = "0.1.0"
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 embassy-stm32 = { workspace = true, features = [

--- a/src/ariel-os-boards/st-nucleo-wb55/Cargo.toml
+++ b/src/ariel-os-boards/st-nucleo-wb55/Cargo.toml
@@ -3,7 +3,7 @@ name = "st-nucleo-wb55"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/src/ariel-os-chips/Cargo.toml
+++ b/src/ariel-os-chips/Cargo.toml
@@ -3,7 +3,7 @@ name = "ariel-os-chips"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lints]

--- a/src/ariel-os-chips/rp2040/Cargo.toml
+++ b/src/ariel-os-chips/rp2040/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rp2040"
 version = "0.1.0"
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/ariel-os-chips/stm32/Cargo.toml
+++ b/src/ariel-os-chips/stm32/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stm32"
 version = "0.1.0"
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/ariel-os-chips/stm32f4xx/Cargo.toml
+++ b/src/ariel-os-chips/stm32f4xx/Cargo.toml
@@ -3,7 +3,7 @@ name = "stm32f4xx"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 bare-metal = "1.0.0"

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ariel-os-embassy"
 version = "0.1.0"
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/src/ariel-os-hal/Cargo.toml
+++ b/src/ariel-os-hal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ariel-os-hal"
 version = "0.1.0"
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -3,7 +3,7 @@ name = "ariel-os-rt"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [lints]
 workspace = true

--- a/src/ariel-os-runqueue/Cargo.toml
+++ b/src/ariel-os-runqueue/Cargo.toml
@@ -3,7 +3,7 @@ name = "ariel-os-runqueue"
 version = "0.1.2"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2018"
+edition.workspace = true
 description = "Ariel OS runqueue implementation"
 
 [lints]

--- a/src/ariel-os-storage/Cargo.toml
+++ b/src/ariel-os-storage/Cargo.toml
@@ -3,7 +3,7 @@ name = "ariel-os-storage"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 description = "Ariel OS storage API"
 
 [lints]

--- a/src/ariel-os-threads/Cargo.toml
+++ b/src/ariel-os-threads/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ariel-os-threads"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 authors = [
   "Kaspar Schleiser <kaspar@schleiser.de>",
   "Elena Frank <elena.frank@proton.me>",

--- a/src/ariel-os-threads/et-tests/Cargo.toml
+++ b/src/ariel-os-threads/et-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "et-tests"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/clist/Cargo.toml
+++ b/src/lib/clist/Cargo.toml
@@ -3,7 +3,7 @@ name = "clist"
 version = "0.1.1"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 homepage = "https://github.com/ariel-os/ariel-os"
 description = "A hairy circular linked list for no_std environments."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib/rbi/Cargo.toml
+++ b/src/lib/rbi/Cargo.toml
@@ -3,7 +3,7 @@ name = "rbi"
 version = "0.1.1"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 
 keywords = ["api", "no_std"]
 homepage = "https://github.com/ariel-os/ariel-os"

--- a/src/lib/ringbuffer/Cargo.toml
+++ b/src/lib/ringbuffer/Cargo.toml
@@ -3,7 +3,7 @@ name = "ringbuffer"
 version = "0.1.0"
 authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
-edition = "2021"
+edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lints]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This uses the inherited version of the `edition` key.
**It also updates the `runqueue` crate to use edition 2021 (it was using edition 2018 before).**

The only remaining match for `^edition\s*=` in the repo (apart of course from the definition in the *workspace* manifest) is from the Cargo script `doc/gen_support_matrix_html.rs`.

---

This is in preparation of [trying out edition 2024](https://blog.rust-lang.org/2024/11/27/Rust-2024-public-testing.html).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
