### PR TITLE
ci(build): skip the `Build` workflow when only docs are modified

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,22 +1,30 @@
 name: Build
 
-common-paths-ignore: &common-paths-ignore
-  - 'book/**'
-  - 'doc/**'
-  - _typos.toml
-  - '*.md'
-
+# TODO: factor this out when GA support YAML Anchors
+# https://github.com/actions/runner/issues/1182#issuecomment-2317953582
 on:
   push:
     branches:
       - main
-    paths-ignore: *common-paths-ignore
+    paths-ignore:
+      - 'book/**'
+      - 'doc/**'
+      - _typos.toml
+      - '*.md'
   pull_request:
     branches:
       - main
-    paths-ignore: *common-paths-ignore
+    paths-ignore:
+      - 'book/**'
+      - 'doc/**'
+      - _typos.toml
+      - '*.md'
   merge_group:
-    paths-ignore: *common-paths-ignore
+    paths-ignore:
+      - 'book/**'
+      - 'doc/**'
+      - _typos.toml
+      - '*.md'
   schedule:
     # run every morning at 3:17am
     - cron: '17 3 * * *'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,22 @@
 name: Build
 
+common-paths-ignore: &common-paths-ignore
+  - 'book/**'
+  - 'doc/**'
+  - _typos.toml
+  - '*.md'
+
 on:
   push:
     branches:
       - main
+    paths-ignore: *common-paths-ignore
   pull_request:
     branches:
       - main
+    paths-ignore: *common-paths-ignore
   merge_group:
+    paths-ignore: *common-paths-ignore
   schedule:
     # run every morning at 3:17am
     - cron: '17 3 * * *'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ on:
     branches:
       - main
     paths-ignore:
+      - '.github/**' # FIXME: obviously a bad idea, this is only a test
       - 'book/**'
       - 'doc/**'
       - _typos.toml


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Following #567, this skips the `Build` workflow when only docs are modified.
[Documentation page of `paths-ignore`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) for reference.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
