### PR TITLE
feat: Share code with RIOT OS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "coap-blinky"
+version = "0.1.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+ "coap-handler-implementations",
+ "embassy-sync 0.6.1",
+ "riot-coap-handler-demos",
+]
+
+[[package]]
 name = "coap-client"
 version = "0.1.0"
 dependencies = [
@@ -1735,6 +1746,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "994f7e5b5cb23521c22304927195f236813053eb9c065dd2226a32ba64695446"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "embedded-graphics"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a69991ceb896bd4810a0cf2bcc46fc94b7860573c71f965d8e5b3d66942fed"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -3118,6 +3138,20 @@ name = "minicbor"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29be4f60e41fde478b36998b88821946aafac540e53591e76db53921a0cc225b"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
 
 [[package]]
 name = "minijinja"
@@ -3834,6 +3868,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "riot-coap-handler-demos"
+version = "0.2.0"
+source = "git+https://gitlab.com/etonomy/riot-module-examples?rev=09fa2d45e92ca4e46da7f18af3db3d1bcec238d3#09fa2d45e92ca4e46da7f18af3db3d1bcec238d3"
+dependencies = [
+ "coap-handler",
+ "coap-handler-implementations",
+ "coap-message",
+ "coap-message-utils",
+ "coap-numbers",
+ "document-features",
+ "embedded-graphics",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "heapless 0.7.17",
+ "minicbor 0.24.4",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "switch-hal",
+ "try-lock",
+]
+
+[[package]]
 name = "riscv"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4061,6 +4118,15 @@ checksum = "5b81787e655bd59cecadc91f7b6b8651330b2be6c33246039a65e5cd6f4e0828"
 dependencies = [
  "heapless 0.8.0",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defbb8a83d7f34cc8380751eeb892b825944222888aff18996ea7901f24aec88"
+dependencies = [
  "serde",
 ]
 
@@ -4411,6 +4477,15 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "switch-hal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90a4adc8cbd1726249b161898e48e0f3f1ce74d34dc784cbbc98fba4ed283fbf"
+dependencies = [
+ "embedded-hal 0.2.7",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
   "tests/benchmarks/bench_sched_flags",
   "tests/benchmarks/bench_sched_yield",
   "tests/coap",
+  "tests/coap-blinky",
   "tests/gpio",
   "tests/gpio-interrupt-nrf",
   "tests/gpio-interrupt-stm32",

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,7 @@ include-dev = true
 allow = [
   "0BSD",
   "Apache-2.0",
+  "BlueOak-1.0.0",
   "BSD-3-Clause",
   "ISC",
   "MIT",

--- a/deny.toml
+++ b/deny.toml
@@ -53,6 +53,7 @@ allow-git = [
   "https://github.com/hacspec/hax",
   "https://gitlab.com/oscore/liboscore",
   "https://github.com/seanmonstar/try-lock",
+  "https://gitlab.com/etonomy/riot-module-examples",
 ]
 
 [sources.allow-org]

--- a/examples/blinky/laze.yml
+++ b/examples/blinky/laze.yml
@@ -6,6 +6,7 @@ apps:
       - microbit-v2
       - nrf52840dk
       - nrf5340dk
+      - particle-xenon
       - rp
       - st-nucleo-f401re
       - st-nucleo-h755zi-q

--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -12,6 +12,9 @@ ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_13 });
 #[cfg(context = "nrf5340dk")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_28 });
 
+#[cfg(context = "particle-xenon")]
+ariel_os::hal::define_peripherals!(LedPeripherals { led: P1_12 });
+
 #[cfg(context = "rp")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: PIN_1 });
 

--- a/tests/coap-blinky/Cargo.toml
+++ b/tests/coap-blinky/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "coap-blinky"
+version = "0.1.0"
+license.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+ariel-os = { path = "../../src/ariel-os", features = [
+  "override-network-config",
+  "coap",
+] }
+ariel-os-boards = { path = "../../src/ariel-os-boards" }
+coap-handler-implementations = "0.5.0"
+
+riot-coap-handler-demos = { git = "https://gitlab.com/etonomy/riot-module-examples", rev = "09fa2d45e92ca4e46da7f18af3db3d1bcec238d3", default-features = false, features = [
+  "gpio",
+] }

--- a/tests/coap-blinky/Cargo.toml
+++ b/tests/coap-blinky/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 ariel-os = { path = "../../src/ariel-os", features = [
   "override-network-config",
   "coap",
+  "udp",
 ] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 coap-handler-implementations = "0.5.0"
@@ -19,3 +20,6 @@ coap-handler-implementations = "0.5.0"
 riot-coap-handler-demos = { git = "https://gitlab.com/etonomy/riot-module-examples", rev = "09fa2d45e92ca4e46da7f18af3db3d1bcec238d3", default-features = false, features = [
   "gpio",
 ] }
+
+# Just for the network config
+heapless = { workspace = true }

--- a/tests/coap-blinky/README.md
+++ b/tests/coap-blinky/README.md
@@ -1,0 +1,20 @@
+# coap blinky
+
+## About
+
+This application makes the GPIO pin from the blinky example accessible over the network.
+
+## Running
+
+* Run on any board with networking, eg. `laze build -b particle-xenon run`.
+* [Set up networking](../README.md).
+* Run `pipx run --spec 'aiocoap[all]' aiocoap-client coap://10.42.0.61/led -m PUT --content-format application/cbor --payload true`
+  or `false`.
+
+## Roadmap
+
+Right now, this demonstrates how easily code written for RIOT OS can be shared with Ariel OS.
+
+In the long run, exposed LEDs should be distinguished from GPIO pins,
+exposed GPIO pins should be configurable in their direction,
+and a good default policy for this application needs to be found.

--- a/tests/coap-blinky/laze.yml
+++ b/tests/coap-blinky/laze.yml
@@ -1,0 +1,26 @@
+apps:
+  - name: coap-blinky
+    env:
+      global:
+        CARGO_ENV:
+          - CONFIG_ISR_STACKSIZE=16384
+    selects:
+      - network
+      - random
+    conflicts:
+      # see https://github.com/ariel-os/ariel-os/issues/418
+      - thumbv6m-none-eabi
+      # no xtensa / riscv gcc on CI
+      - xtensa
+      - riscv
+    context:
+      # list of contexts that have an entry in `pins.rs`
+      - esp
+      - microbit-v2
+      - nrf52840dk
+      - nrf5340dk
+      - particle-xenon
+      - rp
+      - st-nucleo-f401re
+      - st-nucleo-h755zi-q
+      - st-nucleo-wb55

--- a/tests/coap-blinky/src/main.rs
+++ b/tests/coap-blinky/src/main.rs
@@ -1,0 +1,31 @@
+#![no_main]
+#![no_std]
+#![feature(impl_trait_in_assoc_type)]
+#![feature(used_with_arg)]
+
+#[path = "../../../examples/blinky/src/pins.rs"]
+mod pins;
+
+use ariel_os::gpio::Level;
+use ariel_os::gpio::Output;
+
+#[ariel_os::task(autostart, peripherals)]
+async fn coap_run(peripherals: pins::LedPeripherals) {
+    use coap_handler_implementations::{new_dispatcher, HandlerBuilder, ReportingHandlerBuilder};
+
+    let led = Output::new(peripherals.led, Level::Low);
+
+    // The micro:bit uses an LED matrix; pull the column line low; see blinky example
+    #[cfg(context = "microbit-v2")]
+    let _led_col1 = Output::new(peripherals.led_col1, Level::Low);
+
+    let handler = new_dispatcher()
+        // We offer a single resource: /led, which CBOR true or false can be PUT into
+        .at(
+            &["led"],
+            riot_coap_handler_demos::gpio::handler_for_output(led),
+        )
+        .with_wkc();
+
+    ariel_os::coap::coap_run(handler).await;
+}

--- a/tests/coap-blinky/src/main.rs
+++ b/tests/coap-blinky/src/main.rs
@@ -9,6 +9,17 @@ mod pins;
 use ariel_os::gpio::Level;
 use ariel_os::gpio::Output;
 
+#[ariel_os::config(network)]
+const NETWORK_CONFIG: ariel_os::reexports::embassy_net::Config = {
+    use ariel_os::reexports::embassy_net::{self, Ipv4Address};
+
+    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
+        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
+        dns_servers: heapless::Vec::new(),
+        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
+    })
+};
+
 #[ariel_os::task(autostart, peripherals)]
 async fn coap_run(peripherals: pins::LedPeripherals) {
     use coap_handler_implementations::{new_dispatcher, HandlerBuilder, ReportingHandlerBuilder};

--- a/tests/coap/Cargo.toml
+++ b/tests/coap/Cargo.toml
@@ -9,12 +9,12 @@ publish = false
 workspace = true
 
 [dependencies]
-embassy-net = { workspace = true, features = ["udp"] }
 embassy-sync = { workspace = true }
 heapless = { workspace = true }
 ariel-os = { path = "../../src/ariel-os", features = [
   "override-network-config",
   "coap",
+  "udp",
 ] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 embassy-futures = "0.1.1"

--- a/tests/coap/src/main.rs
+++ b/tests/coap/src/main.rs
@@ -4,8 +4,8 @@
 #![feature(used_with_arg)]
 
 #[ariel_os::config(network)]
-const NETWORK_CONFIG: embassy_net::Config = {
-    use embassy_net::Ipv4Address;
+const NETWORK_CONFIG: ariel_os::reexports::embassy_net::Config = {
+    use ariel_os::reexports::embassy_net::{self, Ipv4Address};
 
     embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
         address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),

--- a/tests/laze.yml
+++ b/tests/laze.yml
@@ -1,6 +1,7 @@
 subdirs:
   - benchmarks
   - coap
+  - coap-blinky
   - gpio
   - gpio-interrupt-nrf
   - gpio-interrupt-stm32


### PR DESCRIPTION
# Description

This adds a test that takes the RIOT CoAP demo crate (which is also used in the `rust-gcoap` example of RIOT OS), and runs it on top of ariel-os-coap.

I think this is not good example material by the criteria of pedagogics and simplicity, so it's sitting in tests right now; I think that's a good staging area for something that can become an example at some point, but isn't quite there yet.

Note that this explicitly allows using git sources for those modules. Curiously they still live at gitlab.com/etonomy, where riot-wrappers was initially developed; those modules were not moved in with github.com/riot-os yet. They probably should be, but RIOT reviewers there didn't complain; whenever that module moves, our reference will follow.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
