### PR TITLE
chore(manifests): remove the `authors` key from all crates' manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ resolver = "2"
 
 [workspace.package]
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/ariel-os/ariel-os"

--- a/examples/benchmark/Cargo.toml
+++ b/examples/benchmark/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "benchmark"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 

--- a/examples/blinky/Cargo.toml
+++ b/examples/blinky/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "blinky"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/coap-client/Cargo.toml
+++ b/examples/coap-client/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "coap-client"
 version = "0.1.0"
-authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/coap-server/Cargo.toml
+++ b/examples/coap-server/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "coap-server"
 version = "0.1.0"
-authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/device-metadata/Cargo.toml
+++ b/examples/device-metadata/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "device-metadata"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/embassy-http-server/Cargo.toml
+++ b/examples/embassy-http-server/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "embassy-http-server"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/gpio/Cargo.toml
+++ b/examples/gpio/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "gpio"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/hello-world-threading/Cargo.toml
+++ b/examples/hello-world-threading/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello-world-threading"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hello-world"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/log/Cargo.toml
+++ b/examples/log/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "log"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "minimal"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 

--- a/examples/random/Cargo.toml
+++ b/examples/random/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "example-random"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/storage/Cargo.toml
+++ b/examples/storage/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "storage"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/tcp-echo/Cargo.toml
+++ b/examples/tcp-echo/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tcp-echo"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/thread-async-interop/Cargo.toml
+++ b/examples/thread-async-interop/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "thread-async-interop"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/threading-channel/Cargo.toml
+++ b/examples/threading-channel/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "threading-channel"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/threading-event/Cargo.toml
+++ b/examples/threading-event/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "threading-event"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/threading-multicore/Cargo.toml
+++ b/examples/threading-multicore/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "threading-multicore"
 version = "0.1.0"
-authors = ["Elena Frank <elena.frank@proton.me>"]
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/examples/threading/Cargo.toml
+++ b/examples/threading/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "threading"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/udp-echo/Cargo.toml
+++ b/examples/udp-echo/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "udp-echo"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/usb-keyboard/Cargo.toml
+++ b/examples/usb-keyboard/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "usb-keyboard"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/usb-serial/Cargo.toml
+++ b/examples/usb-serial/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "usb-serial"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/src/ariel-os-bench/Cargo.toml
+++ b/src/ariel-os-bench/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-bench"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-boards/Cargo.toml
+++ b/src/ariel-os-boards/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-boards"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/dwm1001/Cargo.toml
+++ b/src/ariel-os-boards/dwm1001/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "dwm1001"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/espressif-esp32-s3-wroom-1/Cargo.toml
+++ b/src/ariel-os-boards/espressif-esp32-s3-wroom-1/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "espressif-esp32-s3-wroom-1"
 version = "0.1.0"
-authors = ["Elena Frank <elena.frank@proton.me>"]
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/microbit-v2/Cargo.toml
+++ b/src/ariel-os-boards/microbit-v2/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "microbit-v2"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/microbit/Cargo.toml
+++ b/src/ariel-os-boards/microbit/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "microbit"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/nrf51/Cargo.toml
+++ b/src/ariel-os-boards/nrf51/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "nrf51"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/nrf52/Cargo.toml
+++ b/src/ariel-os-boards/nrf52/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "nrf52"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/nrf52840-mdk/Cargo.toml
+++ b/src/ariel-os-boards/nrf52840-mdk/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "nrf52840-mdk"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/nrf52840dk/Cargo.toml
+++ b/src/ariel-os-boards/nrf52840dk/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "nrf52840dk"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/nrf52dk/Cargo.toml
+++ b/src/ariel-os-boards/nrf52dk/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "nrf52dk"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/nrf5340/Cargo.toml
+++ b/src/ariel-os-boards/nrf5340/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "nrf5340"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/nrf5340dk/Cargo.toml
+++ b/src/ariel-os-boards/nrf5340dk/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "nrf5340dk"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/particle-xenon/Cargo.toml
+++ b/src/ariel-os-boards/particle-xenon/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "particle-xenon"
 version = "0.1.0"
-authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/st-nucleo-f401re/Cargo.toml
+++ b/src/ariel-os-boards/st-nucleo-f401re/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "st-nucleo-f401re"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/ariel-os-boards/st-nucleo-wb55/Cargo.toml
+++ b/src/ariel-os-boards/st-nucleo-wb55/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "st-nucleo-wb55"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/ariel-os-chips/Cargo.toml
+++ b/src/ariel-os-chips/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-chips"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/ariel-os-chips/stm32f4xx/Cargo.toml
+++ b/src/ariel-os-chips/stm32f4xx/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "stm32f4xx"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-coap/Cargo.toml
+++ b/src/ariel-os-coap/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-coap"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-debug/Cargo.toml
+++ b/src/ariel-os-debug/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-debug"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-embassy-common/Cargo.toml
+++ b/src/ariel-os-embassy-common/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-embassy-common"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-esp"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-identity/Cargo.toml
+++ b/src/ariel-os-identity/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-identity"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-macros/Cargo.toml
+++ b/src/ariel-os-macros/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-macros"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-nrf"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-random/Cargo.toml
+++ b/src/ariel-os-random/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-random"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-rp"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-rt"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-runqueue/Cargo.toml
+++ b/src/ariel-os-runqueue/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-runqueue"
 version = "0.1.2"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 description = "Ariel OS runqueue implementation"

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-stm32"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-storage/Cargo.toml
+++ b/src/ariel-os-storage/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-storage"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 description = "Ariel OS storage API"

--- a/src/ariel-os-threads/Cargo.toml
+++ b/src/ariel-os-threads/Cargo.toml
@@ -2,10 +2,6 @@
 name = "ariel-os-threads"
 version = "0.1.0"
 edition.workspace = true
-authors = [
-  "Kaspar Schleiser <kaspar@schleiser.de>",
-  "Elena Frank <elena.frank@proton.me>",
-]
 license.workspace = true
 description = "generic embedded scheduler & IPC"
 include = ["src/**/*", "README.md"]

--- a/src/ariel-os-utils/Cargo.toml
+++ b/src/ariel-os-utils/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os-utils"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ariel-os"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 

--- a/src/lib/clist/Cargo.toml
+++ b/src/lib/clist/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "clist"
 version = "0.1.1"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 homepage = "https://github.com/ariel-os/ariel-os"

--- a/src/lib/rbi/Cargo.toml
+++ b/src/lib/rbi/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rbi"
 version = "0.1.1"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 

--- a/src/lib/ringbuffer/Cargo.toml
+++ b/src/lib/ringbuffer/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ringbuffer"
 version = "0.1.0"
-authors = ["Kaspar Schleiser <kaspar@schleiser.de>"]
 license.workspace = true
 edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/benchmarks/bench_sched_flags/Cargo.toml
+++ b/tests/benchmarks/bench_sched_flags/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "bench_sched_flags"
 version = "0.1.0"
-authors = ["Elena Frank <elena.frank@proton.me>"]
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/benchmarks/bench_sched_yield/Cargo.toml
+++ b/tests/benchmarks/bench_sched_yield/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "bench_sched_yield"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/coap/Cargo.toml
+++ b/tests/coap/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "coap"
 version = "0.1.0"
-authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/gpio-interrupt-nrf/Cargo.toml
+++ b/tests/gpio-interrupt-nrf/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "gpio-interrupt-nrf"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/gpio-interrupt-stm32/Cargo.toml
+++ b/tests/gpio-interrupt-stm32/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "gpio-interrupt-stm32"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/gpio/Cargo.toml
+++ b/tests/gpio/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tests_gpio"
 version = "0.1.0"
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/i2c-controller/Cargo.toml
+++ b/tests/i2c-controller/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "i2c-controller"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/tests/spi-loopback/Cargo.toml
+++ b/tests/spi-loopback/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "spi-loopback"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/tests/spi-main/Cargo.toml
+++ b/tests/spi-main/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "spi-main"
 version.workspace = true
-authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/tests/threading-dynamic-prios/Cargo.toml
+++ b/tests/threading-dynamic-prios/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "threading-dynamic-prios"
 version = "0.1.0"
-authors = ["Elena Frank <elena.frank@proton.me>"]
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/tests/threading-lock/Cargo.toml
+++ b/tests/threading-lock/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "threading-lock"
 version = "0.1.0"
-authors = ["Elena Frank <elena.frank@proton.me>"]
 edition.workspace = true
 license.workspace = true
 publish = false


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
As discussed in #574 , the `authors` key has been soft-deprecated since 2021 [1], is not included by `cargo new` anymore [2], and is not displayed by crate registry pages.

[1]: https://github.com/rust-lang/rust/issues/83227
[2]: https://github.com/rust-lang/cargo/pull/9282

There is no remaining matches for `authors\s*=`, except for one in `book/book.toml`, which is not a crate manifest.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
