### PR TITLE
fix(threads): handle case RISC-V + multicore enabled

### DIFF
--- a/src/ariel-os-threads/src/arch/riscv.rs
+++ b/src/ariel-os-threads/src/arch/riscv.rs
@@ -129,6 +129,9 @@ extern "C" fn FROM_CPU_INTR0(trap_frame: &mut TrapFrame) {
 unsafe fn sched(trap_frame: &mut TrapFrame) {
     loop {
         if SCHEDULER.with_mut(|mut scheduler| {
+            #[cfg(feature = "multi-core")]
+            scheduler.add_current_thread_to_rq();
+
             let next_pid = match scheduler.get_next_pid() {
                 Some(pid) => pid,
                 None => {


### PR DESCRIPTION
# Description

Even though there is currently no SMP support for any RISC-V board, it is still possible to manually enable the riot-rs-threads `multi-core` Cargo feature for a RISC-V board (which doesn't bring any benefit, but it's may still be needed sometimes, e.g. for benchmarking). 
Thus this case needs to be handled in the RISC-V scheduler code. Concretely, this concerns the need to re-add the current thread to the runqueue when it is being preempted.


## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
