### PR TITLE
docs(macros): update the docs as `OptionalPeripherals` is now hidden

### DIFF
--- a/src/ariel-os-embassy/src/define_peripherals.rs
+++ b/src/ariel-os-embassy/src/define_peripherals.rs
@@ -1,16 +1,14 @@
-/// This macro allows to extract the specified peripherals from `OptionalPeripherals` for use in an
-/// application.
-///
-/// The generated struct can be obtained by calling the `take_peripherals()` method on
-/// `&mut OptionalPeripherals`.
-///
-/// The `define_peripherals!` macro expects a `peripherals` module to be in scope, where the
-/// peripheral types should come from.
+/// This macro allows to obtain peripherals from the one listed in the `peripherals` module of the
+/// target's HAL crate (selected by [`ariel_os::hal`](ariel_os_hal)).
 ///
 /// It makes sense to use this macro multiple times, coupled with conditional compilation (using
 /// the [`cfg`
 /// attribute](https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute)),
 /// to define different setups for different boards.
+///
+/// # Note
+///
+/// The `define_peripherals!` macro expects the `ariel_os::hal::peripherals` module to be in scope.
 ///
 // Inspired by https://github.com/adamgreig/assign-resources/tree/94ad10e2729afdf0fd5a77cd12e68409a982f58a
 // under MIT license
@@ -53,8 +51,8 @@ macro_rules! define_peripherals {
     }
 }
 
-/// This macros allows to group peripheral structs defined with `define_peripherals!` into a single
-/// struct that also implements `take_peripherals()`.
+/// This macro allows to group peripheral structs defined with `define_peripherals!` into a single
+/// peripheral struct.
 #[macro_export]
 macro_rules! group_peripherals {
     (


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
#544, #545, #550, and #551 have hidden the `OptionalPeripherals` type (found in HAL crates) from users on purpose, making sure that the `peripherals` module was however visible. This PR removes mentions to that now-hidden type.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
