### PR TITLE
feat(build): pass `[patch.crates-io]` via extra cargo toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,8 @@
-# This is needed for cbindgen to work in no_std cross compiles.
+include = "../patch.crates-io.toml"
+
 [unstable]
+# This is needed for cbindgen to work in no_std cross compiles.
 features = ['all']
+
+# This is needed so the "include" statement above works.
+config-include = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,36 +142,6 @@ opt-level = "s"
 [profile.release.package.esp-wifi]
 opt-level = 3
 
-[patch.crates-io]
-# ariel-os embassy fork
-embassy-executor = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-embassy-executor-macros = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-embassy-hal-internal = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-embassy-nrf = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-embassy-net = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-embassy-rp = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-embassy-net-driver = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-embassy-net-driver-channel = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-embassy-stm32 = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-embassy-sync = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-embassy-time-driver = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-embassy-time-queue-driver = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-embassy-usb-driver = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-embassy-usb-synopsys-otg = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-cyw43 = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-cyw43-pio = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
-
-# ariel-os esp-hal fork
-esp-alloc = { git = "https://github.com/ariel-os/esp-hal", branch = "for-ariel-os-2024-10-16-0.21.1-pr2377-nousbquirk" }
-esp-hal = { git = "https://github.com/ariel-os/esp-hal", branch = "for-ariel-os-2024-10-16-0.21.1-pr2377-nousbquirk" }
-esp-hal-embassy = { git = "https://github.com/ariel-os/esp-hal", branch = "for-ariel-os-2024-10-16-0.21.1-pr2377-nousbquirk" }
-esp-println = { git = "https://github.com/ariel-os/esp-hal", branch = "for-ariel-os-2024-10-16-0.21.1-pr2377-nousbquirk" }
-esp-wifi = { git = "https://github.com/ariel-os/esp-hal", branch = "for-ariel-os-2024-10-16-0.21.1-pr2377-nousbquirk" }
-esp-storage = { git = "https://github.com/ariel-os/esp-hal", branch = "for-ariel-os-2024-10-16-0.21.1-pr2377-nousbquirk" }
-
-# patched to use portable-atomics <https://github.com/seanmonstar/try-lock/pull/11>
-try-lock = { git = "https://github.com/seanmonstar/try-lock", rev = "a1aadfac9840fe23672159c12af7272e44bc684c" }
-
 [workspace.lints.rust]
 # rustc lints are documented here: https://doc.rust-lang.org/rustc/lints/listing/index.html
 private_interfaces = "deny"

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -21,6 +21,8 @@ contexts:
       FEATURES:
         - ariel-os-boards/${BOARD}
       SCRIPTS: ${relroot}/scripts
+      CARGO_ARGS:
+        - --config ${root}/${relroot}/patch.crates-io.toml
       # laze doesn't know the concept of "export" as make does, so each variable
       # that needs to be passed via environment needs to be listed in that rule
       # or task's command list.

--- a/patch.crates-io.toml
+++ b/patch.crates-io.toml
@@ -1,0 +1,29 @@
+[patch.crates-io]
+# ariel-os embassy fork
+embassy-executor = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+embassy-executor-macros = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+embassy-hal-internal = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+embassy-nrf = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+embassy-net = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+embassy-rp = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+embassy-net-driver = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+embassy-net-driver-channel = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+embassy-stm32 = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+embassy-sync = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+embassy-time-driver = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+embassy-time-queue-driver = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+embassy-usb-driver = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+embassy-usb-synopsys-otg = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+cyw43 = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+cyw43-pio = { git = "https://github.com/ariel-os/embassy", branch = "for-ariel-os-2024-11-28" }
+
+# ariel-os esp-hal fork
+esp-alloc = { git = "https://github.com/ariel-os/esp-hal", branch = "for-ariel-os-2024-10-16-0.21.1-pr2377-nousbquirk" }
+esp-hal = { git = "https://github.com/ariel-os/esp-hal", branch = "for-ariel-os-2024-10-16-0.21.1-pr2377-nousbquirk" }
+esp-hal-embassy = { git = "https://github.com/ariel-os/esp-hal", branch = "for-ariel-os-2024-10-16-0.21.1-pr2377-nousbquirk" }
+esp-println = { git = "https://github.com/ariel-os/esp-hal", branch = "for-ariel-os-2024-10-16-0.21.1-pr2377-nousbquirk" }
+esp-wifi = { git = "https://github.com/ariel-os/esp-hal", branch = "for-ariel-os-2024-10-16-0.21.1-pr2377-nousbquirk" }
+esp-storage = { git = "https://github.com/ariel-os/esp-hal", branch = "for-ariel-os-2024-10-16-0.21.1-pr2377-nousbquirk" }
+
+# patched to use portable-atomics <https://github.com/seanmonstar/try-lock/pull/11>
+try-lock = { git = "https://github.com/seanmonstar/try-lock", rev = "a1aadfac9840fe23672159c12af7272e44bc684c" }


### PR DESCRIPTION
# Description

This moves the crates.io patches into another file that is then be parsed to Cargo via `--config`. This allows re-using the patches in out-of-tree builds.
For local tooling, the repo's `.cargo/config.toml` is modified to include the file via the unfortunately still unstable [config-include](https://github.com/rust-lang/cargo/issues/7723).

## Issues/PRs references

Fixes #524.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

- [x] How to handle CI `cargo check/clippy/...`?
- [x] How to handle local `cargo check/clippy/...`?
- [x] How to handle tooling like rust analyzer?

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
