### PR TITLE
chore: Update libOSCORE dependency to published version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2847,8 +2847,9 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "liboscore"
-version = "0.2.1"
-source = "git+https://gitlab.com/oscore/liboscore/?rev=5a39b7dbafa6aa6c6adb8e187b850f382858c401#5a39b7dbafa6aa6c6adb8e187b850f382858c401"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63dc508dbff1679752f2920bc4b083b340f3a0b4007b7d7a992636cfd0803b9d"
 dependencies = [
  "bindgen",
  "cbindgen",
@@ -2863,8 +2864,9 @@ dependencies = [
 
 [[package]]
 name = "liboscore-cryptobackend"
-version = "0.2.1"
-source = "git+https://gitlab.com/oscore/liboscore/?rev=5a39b7dbafa6aa6c6adb8e187b850f382858c401#5a39b7dbafa6aa6c6adb8e187b850f382858c401"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5af92747829a4c493c1b8e6e657f411cf293225e793ffdfa4646bbbe0ae0cac9"
 dependencies = [
  "aead",
  "aes",
@@ -2881,8 +2883,9 @@ dependencies = [
 
 [[package]]
 name = "liboscore-msgbackend"
-version = "0.2.1"
-source = "git+https://gitlab.com/oscore/liboscore/?rev=5a39b7dbafa6aa6c6adb8e187b850f382858c401#5a39b7dbafa6aa6c6adb8e187b850f382858c401"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca9f002a403f35e914deab972dbfb381b28b7fd9c43c312fbd3ba59c5b60cb2"
 dependencies = [
  "coap-message",
  "coap-message-implementations",

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -26,9 +26,8 @@ coap-message-utils = "0.3.3"
 coap-numbers = "0.2.3"
 hexlit = "0.5.5"
 lakers-crypto-rustcrypto = "0.7.2"
-# This is exactly 0.2.1, but apparently there are files in the git clone that are not in the crate as they should be.
-liboscore = { git = "https://gitlab.com/oscore/liboscore/", rev = "5a39b7dbafa6aa6c6adb8e187b850f382858c401" }
-liboscore-msgbackend = { git = "https://gitlab.com/oscore/liboscore/", rev = "5a39b7dbafa6aa6c6adb8e187b850f382858c401" }
+liboscore = "0.2.2"
+liboscore-msgbackend = "0.2.2"
 
 minicbor = "0.23.0"
 heapless = "0.8.0"


### PR DESCRIPTION
# Description

As libOSCORE is now fixed to also work from crates.io again, we can go to a released version. (We already were at the released code, using the tagged git rev, but it failed to build when checked out via crates.io).

## Issues/PRs references

Works around https://gitlab.com/oscore/liboscore/-/issues/62 on "there's a confusing git submodule skipped line in our build output" by not even using git.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
