### PR TITLE
refactor(hal)!: move some GPIO HAL items for consistency

### DIFF
--- a/src/ariel-os-embassy/src/gpio.rs
+++ b/src/ariel-os-embassy/src/gpio.rs
@@ -14,10 +14,8 @@ use crate::hal::{
     self,
     gpio::{
         input::{Input as HalInput, InputPin as HalInputPin},
-        output::{
-            DriveStrength as HalDriveStrength, Output as HalOutput, OutputPin as HalOutputPin,
-            Speed as HalSpeed,
-        },
+        output::{Output as HalOutput, OutputPin as HalOutputPin},
+        DriveStrength as HalDriveStrength, Speed as HalSpeed,
     },
     peripheral::Peripheral,
 };

--- a/src/ariel-os-esp/src/gpio.rs
+++ b/src/ariel-os-esp/src/gpio.rs
@@ -118,10 +118,7 @@ pub mod input {
 pub mod output {
     //! Output-specific types.
 
-    use ariel_os_embassy_common::gpio::FromDriveStrength;
     use esp_hal::{gpio::Level, peripheral::Peripheral};
-
-    pub use ariel_os_embassy_common::gpio::UnsupportedSpeed as Speed;
 
     #[doc(hidden)]
     pub use esp_hal::gpio::{Output, OutputPin};
@@ -135,8 +132,8 @@ pub mod output {
     pub fn new(
         pin: impl Peripheral<P: OutputPin> + 'static,
         initial_level: ariel_os_embassy_common::gpio::Level,
-        drive_strength: DriveStrength,
-        _speed: Speed, // Not supported by hardware
+        drive_strength: super::DriveStrength,
+        _speed: super::Speed, // Not supported by hardware
     ) -> Output<'static> {
         let initial_level = match initial_level {
             ariel_os_embassy_common::gpio::Level::Low => Level::Low,
@@ -146,45 +143,47 @@ pub mod output {
         output.set_drive_strength(drive_strength.into());
         output
     }
+}
 
-    /// Available drive strength settings.
-    // We do not provide a `Default` impl as not all pins have the same reset value.
-    #[derive(Copy, Clone, PartialEq, Eq)]
-    pub enum DriveStrength {
-        /// 5 mA.
-        _5mA,
-        /// 10 mA.
-        _10mA,
-        /// 20 mA.
-        _20mA,
-        /// 40 mA.
-        _40mA,
-    }
+pub use ariel_os_embassy_common::gpio::UnsupportedSpeed as Speed;
 
-    impl From<DriveStrength> for esp_hal::gpio::DriveStrength {
-        fn from(drive_strength: DriveStrength) -> Self {
-            match drive_strength {
-                DriveStrength::_5mA => esp_hal::gpio::DriveStrength::I5mA,
-                DriveStrength::_10mA => esp_hal::gpio::DriveStrength::I10mA,
-                DriveStrength::_20mA => esp_hal::gpio::DriveStrength::I20mA,
-                DriveStrength::_40mA => esp_hal::gpio::DriveStrength::I40mA,
-            }
+/// Available drive strength settings.
+// We do not provide a `Default` impl as not all pins have the same reset value.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum DriveStrength {
+    /// 5 mA.
+    _5mA,
+    /// 10 mA.
+    _10mA,
+    /// 20 mA.
+    _20mA,
+    /// 40 mA.
+    _40mA,
+}
+
+impl From<DriveStrength> for esp_hal::gpio::DriveStrength {
+    fn from(drive_strength: DriveStrength) -> Self {
+        match drive_strength {
+            DriveStrength::_5mA => Self::I5mA,
+            DriveStrength::_10mA => Self::I10mA,
+            DriveStrength::_20mA => Self::I20mA,
+            DriveStrength::_40mA => Self::I40mA,
         }
     }
+}
 
-    impl FromDriveStrength for DriveStrength {
-        fn from(drive_strength: ariel_os_embassy_common::gpio::DriveStrength<Self>) -> Self {
-            use ariel_os_embassy_common::gpio::DriveStrength::*;
+impl ariel_os_embassy_common::gpio::FromDriveStrength for DriveStrength {
+    fn from(drive_strength: ariel_os_embassy_common::gpio::DriveStrength<Self>) -> Self {
+        use ariel_os_embassy_common::gpio::DriveStrength::*;
 
-            // ESPs are able to output up to 40 mA, so we somewhat normalize this.
-            match drive_strength {
-                Hal(drive_strength) => drive_strength,
-                Lowest => DriveStrength::_5mA,
-                Standard => DriveStrength::_10mA,
-                Medium => DriveStrength::_10mA,
-                High => DriveStrength::_20mA,
-                Highest => DriveStrength::_40mA,
-            }
+        // ESPs are able to output up to 40 mA, so we somewhat normalize this.
+        match drive_strength {
+            Hal(drive_strength) => drive_strength,
+            Lowest => Self::_5mA,
+            Standard => Self::_10mA,
+            Medium => Self::_10mA,
+            High => Self::_20mA,
+            Highest => Self::_40mA,
         }
     }
 }

--- a/src/ariel-os-hal/src/dummy/gpio.rs
+++ b/src/ariel-os-hal/src/dummy/gpio.rs
@@ -1,5 +1,3 @@
-use ariel_os_embassy_common::gpio::{DriveStrength, Level, Pull, Speed};
-
 macro_rules! define_input_like {
     ($type:ident) => {
         pub struct $type<'d> {
@@ -90,7 +88,7 @@ pub mod input {
 
     pub fn new(
         _pin: impl Peripheral<P: InputPin> + 'static,
-        _pull: crate::gpio::Pull,
+        _pull: ariel_os_embassy_common::gpio::Pull,
         _schmitt_trigger: bool,
     ) -> Result<Input<'static>, ariel_os_embassy_common::gpio::input::Error> {
         unimplemented!();
@@ -99,7 +97,7 @@ pub mod input {
     #[cfg(feature = "external-interrupts")]
     pub fn new_int_enabled(
         _pin: impl Peripheral<P: InputPin> + 'static,
-        _pull: crate::gpio::Pull,
+        _pull: ariel_os_embassy_common::gpio::Pull,
         _schmitt_trigger: bool,
     ) -> Result<IntEnabledInput<'static>, ariel_os_embassy_common::gpio::input::Error> {
         unimplemented!();
@@ -118,7 +116,6 @@ pub mod input {
 }
 
 pub mod output {
-    use ariel_os_embassy_common::gpio::{FromDriveStrength, FromSpeed};
     use embedded_hal::digital::StatefulOutputPin;
 
     use crate::peripheral::Peripheral;
@@ -130,37 +127,11 @@ pub mod output {
 
     pub fn new(
         _pin: impl Peripheral<P: OutputPin> + 'static,
-        _initial_level: crate::gpio::Level,
-        _drive_strength: DriveStrength,
-        _speed: Speed,
+        _initial_level: ariel_os_embassy_common::gpio::Level,
+        _drive_strength: super::DriveStrength,
+        _speed: super::Speed,
     ) -> Output<'static> {
         unimplemented!();
-    }
-
-    /// Actual type is HAL-specific.
-    #[derive(Copy, Clone, PartialEq, Eq)]
-    pub enum DriveStrength {
-        #[doc(hidden)]
-        Hidden,
-    }
-
-    impl FromDriveStrength for DriveStrength {
-        fn from(_drive_strength: crate::gpio::DriveStrength<DriveStrength>) -> Self {
-            unimplemented!();
-        }
-    }
-
-    /// Actual type is HAL-specific.
-    #[derive(Copy, Clone, PartialEq, Eq)]
-    pub enum Speed {
-        #[doc(hidden)]
-        Hidden,
-    }
-
-    impl FromSpeed for Speed {
-        fn from(_speed: crate::gpio::Speed<Speed>) -> Self {
-            unimplemented!();
-        }
     }
 
     pub struct Output<'d> {
@@ -189,5 +160,31 @@ pub mod output {
         fn is_set_low(&mut self) -> Result<bool, Self::Error> {
             unimplemented!();
         }
+    }
+}
+
+/// Actual type is HAL-specific.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum DriveStrength {
+    #[doc(hidden)]
+    Hidden,
+}
+
+impl ariel_os_embassy_common::gpio::FromDriveStrength for DriveStrength {
+    fn from(_drive_strength: ariel_os_embassy_common::gpio::DriveStrength<Self>) -> Self {
+        unimplemented!();
+    }
+}
+
+/// Actual type is HAL-specific.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Speed {
+    #[doc(hidden)]
+    Hidden,
+}
+
+impl ariel_os_embassy_common::gpio::FromSpeed for Speed {
+    fn from(_speed: ariel_os_embassy_common::gpio::Speed<Self>) -> Self {
+        unimplemented!();
     }
 }

--- a/src/ariel-os-nrf/src/gpio.rs
+++ b/src/ariel-os-nrf/src/gpio.rs
@@ -49,13 +49,12 @@ pub mod input {
 pub mod output {
     //! Output-specific types.
 
-    use ariel_os_embassy_common::gpio::FromDriveStrength;
     use embassy_nrf::{
         gpio::{Level, OutputDrive},
         Peripheral,
     };
 
-    pub use ariel_os_embassy_common::gpio::UnsupportedSpeed as Speed;
+    use super::DriveStrength;
 
     #[doc(hidden)]
     pub use embassy_nrf::gpio::{Output, Pin as OutputPin};
@@ -70,7 +69,7 @@ pub mod output {
         pin: impl Peripheral<P: OutputPin> + 'static,
         initial_level: ariel_os_embassy_common::gpio::Level,
         drive_strength: DriveStrength,
-        _speed: Speed, // Not supported by hardware
+        _speed: super::Speed, // Not supported by hardware
     ) -> Output<'static> {
         let output_drive = match drive_strength {
             DriveStrength::Standard => OutputDrive::Standard,
@@ -82,35 +81,37 @@ pub mod output {
         };
         Output::new(pin, initial_level, output_drive)
     }
+}
 
-    /// Available drive strength settings.
-    #[derive(Copy, Clone, PartialEq, Eq)]
-    pub enum DriveStrength {
-        /// Standard.
-        Standard,
-        /// High.
-        High, // Around 10 mA
+pub use ariel_os_embassy_common::gpio::UnsupportedSpeed as Speed;
+
+/// Available drive strength settings.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum DriveStrength {
+    /// Standard.
+    Standard,
+    /// High.
+    High, // Around 10 mA
+}
+
+impl Default for DriveStrength {
+    fn default() -> Self {
+        Self::Standard
     }
+}
 
-    impl Default for DriveStrength {
-        fn default() -> Self {
-            Self::Standard
-        }
-    }
+impl ariel_os_embassy_common::gpio::FromDriveStrength for DriveStrength {
+    fn from(drive_strength: ariel_os_embassy_common::gpio::DriveStrength<Self>) -> Self {
+        use ariel_os_embassy_common::gpio::DriveStrength::*;
 
-    impl FromDriveStrength for DriveStrength {
-        fn from(drive_strength: ariel_os_embassy_common::gpio::DriveStrength<Self>) -> Self {
-            use ariel_os_embassy_common::gpio::DriveStrength::*;
-
-            // ESPs are able to output up to 40 mA, so we somewhat normalize this.
-            match drive_strength {
-                Hal(drive_strength) => drive_strength,
-                Lowest => DriveStrength::Standard,
-                Standard => DriveStrength::default(),
-                Medium => DriveStrength::Standard,
-                High => DriveStrength::High,
-                Highest => DriveStrength::High,
-            }
+        // ESPs are able to output up to 40 mA, so we somewhat normalize this.
+        match drive_strength {
+            Hal(drive_strength) => drive_strength,
+            Lowest => Self::Standard,
+            Standard => Self::default(),
+            Medium => Self::Standard,
+            High => Self::High,
+            Highest => Self::High,
         }
     }
 }

--- a/src/ariel-os-nrf/src/i2c/controller/mod.rs
+++ b/src/ariel-os-nrf/src/i2c/controller/mod.rs
@@ -21,10 +21,10 @@ pub struct Config {
     /// Whether to enable the internal pull-up resistor on the SCL pin.
     pub scl_pullup: bool,
     /// Whether to set the SDA pin's drive strength to
-    /// [`DriveStrength::High`](crate::gpio::output::DriveStrength::High).
+    /// [`DriveStrength::High`](crate::gpio::DriveStrength::High).
     pub sda_high_drive: bool,
     /// Whether to set the SCL pin's drive strength to
-    /// [`DriveStrength::High`](crate::gpio::output::DriveStrength::High).
+    /// [`DriveStrength::High`](crate::gpio::DriveStrength::High).
     pub scl_high_drive: bool,
 }
 

--- a/src/ariel-os-stm32/src/gpio.rs
+++ b/src/ariel-os-stm32/src/gpio.rs
@@ -49,13 +49,7 @@ pub mod input {
 pub mod output {
     //! Output-specific types.
 
-    use ariel_os_embassy_common::gpio::FromSpeed;
-    use embassy_stm32::{
-        gpio::{Level, Speed as StmSpeed},
-        Peripheral,
-    };
-
-    pub use ariel_os_embassy_common::gpio::UnsupportedDriveStrength as DriveStrength;
+    use embassy_stm32::{gpio::Level, Peripheral};
 
     #[doc(hidden)]
     pub use embassy_stm32::gpio::{Output, Pin as OutputPin};
@@ -69,8 +63,8 @@ pub mod output {
     pub fn new(
         pin: impl Peripheral<P: OutputPin> + 'static,
         initial_level: ariel_os_embassy_common::gpio::Level,
-        _drive_strength: DriveStrength, // Not supported by hardware
-        speed: Speed,
+        _drive_strength: super::DriveStrength, // Not supported by hardware
+        speed: super::Speed,
     ) -> Output<'static> {
         let initial_level = match initial_level {
             ariel_os_embassy_common::gpio::Level::Low => Level::Low,
@@ -78,42 +72,44 @@ pub mod output {
         };
         Output::new(pin, initial_level, speed.into())
     }
+}
 
-    /// Available output speed/slew rate settings.
-    #[derive(Copy, Clone, PartialEq, Eq)]
-    pub enum Speed {
-        /// Low.
-        Low,
-        /// Medium.
-        Medium,
-        /// High.
-        High,
-        /// Very high.
-        VeryHigh,
-    }
+pub use ariel_os_embassy_common::gpio::UnsupportedDriveStrength as DriveStrength;
 
-    impl From<Speed> for StmSpeed {
-        fn from(speed: Speed) -> Self {
-            match speed {
-                Speed::Low => StmSpeed::Low,
-                Speed::Medium => StmSpeed::Medium,
-                Speed::High => StmSpeed::High,
-                Speed::VeryHigh => StmSpeed::VeryHigh,
-            }
+/// Available output speed/slew rate settings.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Speed {
+    /// Low.
+    Low,
+    /// Medium.
+    Medium,
+    /// High.
+    High,
+    /// Very high.
+    VeryHigh,
+}
+
+impl From<Speed> for embassy_stm32::gpio::Speed {
+    fn from(speed: Speed) -> Self {
+        match speed {
+            Speed::Low => Self::Low,
+            Speed::Medium => Self::Medium,
+            Speed::High => Self::High,
+            Speed::VeryHigh => Self::VeryHigh,
         }
     }
+}
 
-    impl FromSpeed for Speed {
-        fn from(speed: ariel_os_embassy_common::gpio::Speed<Self>) -> Self {
-            use ariel_os_embassy_common::gpio::Speed::*;
+impl ariel_os_embassy_common::gpio::FromSpeed for Speed {
+    fn from(speed: ariel_os_embassy_common::gpio::Speed<Self>) -> Self {
+        use ariel_os_embassy_common::gpio::Speed::*;
 
-            match speed {
-                Hal(speed) => speed,
-                Low => Speed::Low,
-                Medium => Speed::Medium,
-                High => Speed::High,
-                VeryHigh => Speed::VeryHigh,
-            }
+        match speed {
+            Hal(speed) => speed,
+            Low => Self::Low,
+            Medium => Self::Medium,
+            High => Self::High,
+            VeryHigh => Self::VeryHigh,
         }
     }
 }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This is for consistency with the generic `gpio` module, where `DriveStrength` and `Speed` are directly in the `gpio` module, not in `gpio::output`.

Tip for reviewing: using "Split Diff view" (instead of "Unified") and hiding whitespace changes makes this much nicer to review.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
