### PR TITLE
refactor(threads)!: rename `Guard` to `MutexGuard` for consistency

### DIFF
--- a/src/ariel-os-threads/src/sync/mod.rs
+++ b/src/ariel-os-threads/src/sync/mod.rs
@@ -7,4 +7,4 @@ mod mutex;
 pub use channel::Channel;
 pub use event::Event;
 pub use lock::Lock;
-pub use mutex::{Guard, Mutex};
+pub use mutex::{Mutex, MutexGuard};


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
`MutexGuard` is consistent with `std::sync::MutexGuard` and `embassy_sync::mutex::MutexGuard`.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
