### PR TITLE
docs(threading-event): Clean up the threading-event example

### DIFF
--- a/examples/threading-event/README.md
+++ b/examples/threading-event/README.md
@@ -2,8 +2,18 @@
 
 ## About
 
-This application demonstrates the usage of an `Event` as synchronization method for
-threads.
+This application demonstrates the usage of an
+[`Event`](https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/thread/sync/struct.Event.html)
+as synchronization method for threads.
+
+The example starts five threads (0 through 4).
+A static `Event` is created as synchronization mechanism for the threads.
+All threads wait for the event to get set,
+printing output before and after the event is set.
+Only thread 4 is different in that
+it sets the event before waiting on that same event.
+All threads must thus wait for thread 4 to set the event
+before they can continue.
 
 ## How to run
 
@@ -11,5 +21,23 @@ In this folder, run
 
     laze build -b nrf52840dk run
 
-The application will start five threads with different priorities. All but one
-threads block on a global `Event` until the one thread sets it.
+The application will start five threads with different priorities.
+All but one threads block on a global `Event` until the one thread sets it.
+
+## Example output
+
+When run, this example shows the following output:
+
+    INFO  [ThreadId(3)@RunqueueId(3)] Waiting for event...
+    INFO  [ThreadId(2)@RunqueueId(2)] Waiting for event...
+    INFO  [ThreadId(1)@RunqueueId(1)] Waiting for event...
+    INFO  [ThreadId(4)@RunqueueId(1)] Setting event...
+    INFO  [ThreadId(3) Done.
+    INFO  [ThreadId(2) Done.
+    INFO  [ThreadId(4)@RunqueueId(1)] Event set.
+    INFO  [ThreadId(4)@RunqueueId(1)] Waiting for event...
+    INFO  [ThreadId(4) Done.
+    INFO  [ThreadId(1) Done.
+    INFO  [ThreadId(0)@RunqueueId(0)] Waiting for event...
+    INFO  [ThreadId(0) Done.
+    INFO  All five threads should have reported "Done.". exiting.

--- a/examples/threading-event/src/main.rs
+++ b/examples/threading-event/src/main.rs
@@ -10,12 +10,15 @@ static EVENT: Event = Event::new();
 fn waiter() {
     let my_id = ariel_os::thread::current_tid().unwrap();
     let my_prio = ariel_os::thread::get_priority(my_id).unwrap();
-    info!("[{:?}@{}] Waiting for event...", my_id, my_prio);
+    info!("[{}@{}] Waiting for event...", my_id, my_prio);
     EVENT.wait();
-    info!("[{:?} Done.", my_id);
+    info!("[{}@{}] Done.", my_id, my_prio);
 
     if my_id == ThreadId::new(0) {
-        info!("All five threads should have reported \"Done.\". exiting.");
+        info!(
+            "[{}@{}] All five threads should have reported \"Done.\". exiting.",
+            my_id, my_prio
+        );
         ariel_os::debug::exit(ExitCode::SUCCESS);
     }
 }
@@ -44,8 +47,8 @@ fn thread3() {
 fn thread4() {
     let my_id = ariel_os::thread::current_tid().unwrap();
     let my_prio = ariel_os::thread::get_priority(my_id).unwrap();
-    info!("[{:?}@{}] Setting event...", my_id, my_prio);
+    info!("[{}@{}] Setting event...", my_id, my_prio);
     EVENT.set();
-    info!("[{:?}@{}] Event set.", my_id, my_prio);
+    info!("[{}@{}] Event set.", my_id, my_prio);
     waiter();
 }


### PR DESCRIPTION
# Description

As part of #410, this PR:
- Extend the readme with some clarification
- Makes the logging more uniform

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
