### PR TITLE
refactor(config)!: use `const`s instead of fns for `#[ariel_os::config]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,7 +1127,7 @@ dependencies = [
 [[package]]
 name = "cyw43"
 version = "0.2.0"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -1144,7 +1144,7 @@ dependencies = [
 [[package]]
 name = "cyw43-pio"
 version = "0.2.0"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "cyw43",
  "embassy-rp",
@@ -1396,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.6.3"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -1409,7 +1409,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor-macros"
 version = "0.6.2"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1429,7 +1429,7 @@ dependencies = [
 [[package]]
 name = "embassy-hal-internal"
 version = "0.2.0"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -1440,7 +1440,7 @@ dependencies = [
 [[package]]
 name = "embassy-net"
 version = "0.5.0"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "defmt",
  "document-features",
@@ -1457,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.2.0"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "defmt",
 ]
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver-channel"
 version = "0.3.0"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "embassy-futures",
  "embassy-net-driver",
@@ -1475,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "embassy-nrf"
 version = "0.2.0"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -1505,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "embassy-rp"
 version = "0.2.0"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "atomic-polyfill",
  "cfg-if",
@@ -1543,7 +1543,7 @@ dependencies = [
 [[package]]
 name = "embassy-stm32"
 version = "0.1.0"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "aligned",
  "bit_field",
@@ -1601,7 +1601,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.6.1"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -1634,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.1.0"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "document-features",
 ]
@@ -1642,7 +1642,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-driver"
 version = "0.1.0"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 
 [[package]]
 name = "embassy-usb"
@@ -1663,7 +1663,7 @@ dependencies = [
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "defmt",
 ]
@@ -1671,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "embassy-usb-synopsys-otg"
 version = "0.1.0"
-source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#4d2bc5b2bab2e55b5f0fb2451032db74cea0dce5"
+source = "git+https://github.com/ariel-os/embassy?branch=for-ariel-os-2024-11-28#78161360952c2dc75c75604b8dfdbf586b7991de"
 dependencies = [
  "critical-section",
  "defmt",

--- a/examples/coap-client/src/main.rs
+++ b/examples/coap-client/src/main.rs
@@ -5,6 +5,17 @@
 
 use ariel_os::debug::log::info;
 
+#[ariel_os::config(network)]
+const NETWORK_CONFIG: ariel_os::reexports::embassy_net::Config = {
+    use ariel_os::reexports::embassy_net::{self, Ipv4Address};
+
+    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
+        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
+        dns_servers: heapless::Vec::new(),
+        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
+    })
+};
+
 /// Run a CoAP stack without serving any actual resources.
 #[ariel_os::task(autostart)]
 async fn coap_run() {
@@ -36,16 +47,4 @@ async fn run_client_operations() {
         });
     let response = client.to(demoserver).request(request).await;
     info!("Response {:?}", response.map_err(|_| "TransportError"));
-}
-
-// So far, this is necessary boilerplate; see ../../README.md#networking for details
-#[ariel_os::config(network)]
-fn network_config() -> ariel_os::reexports::embassy_net::Config {
-    use ariel_os::reexports::embassy_net::{self, Ipv4Address};
-
-    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
-        dns_servers: heapless::Vec::new(),
-        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
-    })
 }

--- a/examples/coap-server/src/main.rs
+++ b/examples/coap-server/src/main.rs
@@ -3,6 +3,17 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 
+#[ariel_os::config(network)]
+const NETWORK_CONFIG: ariel_os::reexports::embassy_net::Config = {
+    use ariel_os::reexports::embassy_net::{self, Ipv4Address};
+
+    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
+        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
+        dns_servers: heapless::Vec::new(),
+        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
+    })
+};
+
 #[ariel_os::task(autostart)]
 async fn coap_run() {
     use coap_handler_implementations::{
@@ -15,16 +26,4 @@ async fn coap_run() {
         .with_wkc();
 
     ariel_os::coap::coap_run(handler).await;
-}
-
-// So far, this is necessary boilerplate; see ../../README.md#networking for details
-#[ariel_os::config(network)]
-fn network_config() -> ariel_os::reexports::embassy_net::Config {
-    use ariel_os::reexports::embassy_net::{self, Ipv4Address};
-
-    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
-        dns_servers: heapless::Vec::new(),
-        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
-    })
 }

--- a/examples/http-server/src/main.rs
+++ b/examples/http-server/src/main.rs
@@ -20,6 +20,17 @@ const SERVER_CONFIG: picoserve::Config<Duration> = picoserve::Config::new(picose
     write: Some(Duration::from_secs(1)),
 });
 
+#[ariel_os::config(network)]
+const NETWORK_CONFIG: ariel_os::reexports::embassy_net::Config = {
+    use ariel_os::reexports::embassy_net::{self, Ipv4Address};
+
+    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
+        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
+        dns_servers: heapless::Vec::new(),
+        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
+    })
+};
+
 static APP: StaticCell<picoserve::Router<routes::AppRouter>> = StaticCell::new();
 
 #[cfg(feature = "button-reading")]
@@ -64,15 +75,4 @@ fn main(spawner: Spawner, peripherals: pins::Peripherals) {
     for task_id in 0..WEB_TASK_POOL_SIZE {
         spawner.spawn(web_task(task_id, app)).unwrap();
     }
-}
-
-#[ariel_os::config(network)]
-fn network_config() -> ariel_os::reexports::embassy_net::Config {
-    use ariel_os::reexports::embassy_net::{self, Ipv4Address};
-
-    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
-        dns_servers: heapless::Vec::new(),
-        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
-    })
 }

--- a/examples/tcp-echo/src/main.rs
+++ b/examples/tcp-echo/src/main.rs
@@ -6,6 +6,17 @@
 use ariel_os::{debug::log::*, network, reexports::embassy_net::tcp::TcpSocket, time::Duration};
 use embedded_io_async::Write;
 
+#[ariel_os::config(network)]
+const NETWORK_CONFIG: ariel_os::reexports::embassy_net::Config = {
+    use ariel_os::reexports::embassy_net::{self, Ipv4Address};
+
+    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
+        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
+        dns_servers: heapless::Vec::new(),
+        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
+    })
+};
+
 #[ariel_os::task(autostart)]
 async fn tcp_echo() {
     let stack = network::network_stack().await.unwrap();
@@ -48,15 +59,4 @@ async fn tcp_echo() {
             };
         }
     }
-}
-
-#[ariel_os::config(network)]
-fn network_config() -> ariel_os::reexports::embassy_net::Config {
-    use ariel_os::reexports::embassy_net::{self, Ipv4Address};
-
-    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
-        dns_servers: heapless::Vec::new(),
-        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
-    })
 }

--- a/examples/udp-echo/src/main.rs
+++ b/examples/udp-echo/src/main.rs
@@ -9,6 +9,17 @@ use ariel_os::{
     reexports::embassy_net::udp::{PacketMetadata, UdpSocket},
 };
 
+#[ariel_os::config(network)]
+const NETWORK_CONFIG: ariel_os::reexports::embassy_net::Config = {
+    use ariel_os::reexports::embassy_net::{self, Ipv4Address};
+
+    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
+        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
+        dns_servers: heapless::Vec::new(),
+        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
+    })
+};
+
 #[ariel_os::task(autostart)]
 async fn udp_echo() {
     let stack = network::network_stack().await.unwrap();
@@ -58,15 +69,4 @@ async fn udp_echo() {
             };
         }
     }
-}
-
-#[ariel_os::config(network)]
-fn network_config() -> ariel_os::reexports::embassy_net::Config {
-    use ariel_os::reexports::embassy_net::{self, Ipv4Address};
-
-    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
-        dns_servers: heapless::Vec::new(),
-        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
-    })
 }

--- a/examples/usb-keyboard/src/main.rs
+++ b/examples/usb-keyboard/src/main.rs
@@ -30,6 +30,23 @@ const KEYCODE_MAPPING: [u8; buttons::KEY_COUNT] = [KC_A, KC_C, KC_G, KC_T];
 const HID_READER_BUFFER_SIZE: usize = 1;
 const HID_WRITER_BUFFER_SIZE: usize = 8;
 
+#[ariel_os::config(usb)]
+const USB_CONFIG: ariel_os::reexports::embassy_usb::Config = {
+    let mut config = ariel_os::reexports::embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Ariel OS");
+    config.product = Some("HID keyboard example");
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = 64;
+
+    // Required for Windows support.
+    config.composite_with_iads = true;
+    config.device_class = 0xEF;
+    config.device_sub_class = 0x02;
+    config.device_protocol = 0x01;
+    config
+};
+
 static HID_STATE: ConstStaticCell<hid::State> = ConstStaticCell::new(hid::State::new());
 
 #[ariel_os::task(autostart, peripherals, usb_builder_hook)]
@@ -108,21 +125,4 @@ mod buttons {
             self.0.iter_mut()
         }
     }
-}
-
-#[ariel_os::config(usb)]
-fn usb_config() -> ariel_os::reexports::embassy_usb::Config<'static> {
-    let mut config = ariel_os::reexports::embassy_usb::Config::new(0xc0de, 0xcafe);
-    config.manufacturer = Some("Ariel OS");
-    config.product = Some("HID keyboard example");
-    config.serial_number = Some("12345678");
-    config.max_power = 100;
-    config.max_packet_size_0 = 64;
-
-    // Required for Windows support.
-    config.composite_with_iads = true;
-    config.device_class = 0xEF;
-    config.device_sub_class = 0x02;
-    config.device_protocol = 0x01;
-    config
 }

--- a/examples/usb-serial/src/main.rs
+++ b/examples/usb-serial/src/main.rs
@@ -16,6 +16,23 @@ use embassy_usb::{
 
 const MAX_FULL_SPEED_PACKET_SIZE: u8 = 64;
 
+#[ariel_os::config(usb)]
+const USB_CONFIG: ariel_os::reexports::embassy_usb::Config = {
+    let mut config = ariel_os::reexports::embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Ariel OS");
+    config.product = Some("USB serial example");
+    config.serial_number = Some("12345678");
+    config.max_power = 100;
+    config.max_packet_size_0 = MAX_FULL_SPEED_PACKET_SIZE;
+
+    // Required for Windows support.
+    config.composite_with_iads = true;
+    config.device_class = 0xEF;
+    config.device_sub_class = 0x02;
+    config.device_protocol = 0x01;
+    config
+};
+
 #[ariel_os::task(autostart, usb_builder_hook)]
 async fn main() {
     info!("Hello World!");
@@ -61,21 +78,4 @@ async fn echo(class: &mut CdcAcmClass<'static, UsbDriver>) -> Result<(), Disconn
         info!("data: {:x}", data);
         class.write_packet(data).await?;
     }
-}
-
-#[ariel_os::config(usb)]
-fn usb_config() -> embassy_usb::Config<'static> {
-    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
-    config.manufacturer = Some("Ariel OS");
-    config.product = Some("USB serial example");
-    config.serial_number = Some("12345678");
-    config.max_power = 100;
-    config.max_packet_size_0 = MAX_FULL_SPEED_PACKET_SIZE;
-
-    // Required for Windows support.
-    config.composite_with_iads = true;
-    config.device_class = 0xEF;
-    config.device_sub_class = 0x02;
-    config.device_protocol = 0x01;
-    config
 }

--- a/src/ariel-os-macros/src/config.rs
+++ b/src/ariel-os-macros/src/config.rs
@@ -1,19 +1,18 @@
-/// Registers the function this attribute macro is applied on to provide the configuration for the
-/// associated driver during initial system configuration.
+/// Allows to provide configuration for the associated driver during initial system configuration.
 ///
 /// **Important**: for this configuration to be taken into account, a specific Cargo feature may
 /// need to be enabled on the `ariel-os` dependency, for each configuration type (see table below).
 ///
-/// The name of the function does not matter as it will be renamed by the macro.
+/// There is no requirements on the constant's name.
 ///
 /// # Parameters
 ///
-/// - The name of the driver the function provides configuration for.
+/// - The name of the driver the constant provides configuration for.
 ///
-/// | Driver    | Expected return type           | Cargo feature to enable   |
+/// | Driver    | Expected type                  | Cargo feature to enable   |
 /// | --------- | ------------------------------ | ------------------------- |
 /// | `network` | `embassy_net::Config`          | `override-network-config` |
-/// | `usb`     | `embassy_usb::Config<'static>` | `override-usb-config`     |
+/// | `usb`     | `embassy_usb::Config`          | `override-usb-config`     |
 ///
 /// # Note
 ///
@@ -21,13 +20,13 @@
 ///
 /// # Examples
 ///
-/// The following function provides configuration for the network stack:
+/// The following provides configuration for the network stack:
 ///
 /// ```ignore
 /// use ariel_os::reexports::embassy_net;
 ///
 /// #[ariel_os::config(network)]
-/// fn network_config() -> embassy_net::Config {
+/// const NETWORK_CONFIG: embassy_net::Config = {
 ///     use embassy_net::Ipv4Address;
 ///
 ///     embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
@@ -35,7 +34,7 @@
 ///         dns_servers: heapless::Vec::new(),
 ///         gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
 ///     })
-/// }
+/// };
 /// ```
 ///
 /// # Panics
@@ -50,11 +49,11 @@ pub fn config(args: TokenStream, item: TokenStream) -> TokenStream {
     use quote::{format_ident, quote};
 
     let mut attrs = ConfigAttributes::default();
-    let thread_parser = syn::meta::parser(|meta| attrs.parse(&meta));
-    syn::parse_macro_input!(args with thread_parser);
+    let config_attr_parser = syn::meta::parser(|meta| attrs.parse(&meta));
+    syn::parse_macro_input!(args with config_attr_parser);
 
-    let config_function = syn::parse_macro_input!(item as syn::ItemFn);
-    let config_function_name = &config_function.sig.ident;
+    let config_const = syn::parse_macro_input!(item as syn::ItemConst);
+    let config_const_name = &config_const.ident;
 
     let ariel_os_crate = utils::ariel_os_crate();
 
@@ -72,15 +71,14 @@ pub fn config(args: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
-    // Place the provided function into another function whose type signature we enforce.
+    // Place the provided constant into a function whose type signature we enforce.
     // This is important as that function will be called unsafely via FFI.
     let expanded = quote! {
+        #config_const
+
         #[no_mangle]
         fn #config_fn_name() -> #return_type {
-            #[inline(always)]
-            #config_function
-
-            #config_function_name()
+            #config_const_name
         }
     };
 
@@ -127,7 +125,7 @@ mod config_macro {
         fn check_only_one_kind(&self, param: &str) {
             assert!(
                 self.kind.is_none(),
-                "only one configuration is supported at a time, use a separate function for `{param}` configuration",
+                "only one configuration is supported at a time, use a separate constant for `{param}` configuration",
             );
         }
     }

--- a/src/ariel-os-macros/tests/ui/config/conflicting_config_kind.rs
+++ b/src/ariel-os-macros/tests/ui/config/conflicting_config_kind.rs
@@ -7,7 +7,7 @@ use ariel_os::reexports::embassy_net;
 
 // FAIL: network and usb cannot be used at the same time
 #[ariel_os::config(network, usb)]
-fn network_config() -> embassy_net::Config {
+const NETWORK_CONFIG: embassy_net::Config = {
     use embassy_net::Ipv4Address;
 
     embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
@@ -15,4 +15,4 @@ fn network_config() -> embassy_net::Config {
         dns_servers: heapless::Vec::new(),
         gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
     })
-}
+};

--- a/src/ariel-os-macros/tests/ui/config/conflicting_config_kind.stderr
+++ b/src/ariel-os-macros/tests/ui/config/conflicting_config_kind.stderr
@@ -4,4 +4,4 @@ error: custom attribute panicked
 9 | #[ariel_os::config(network, usb)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = help: message: only one configuration is supported at a time, use a separate function for `usb` configuration
+  = help: message: only one configuration is supported at a time, use a separate constant for `usb` configuration

--- a/src/ariel-os-macros/tests/ui/config/misspelled_config_kind.rs
+++ b/src/ariel-os-macros/tests/ui/config/misspelled_config_kind.rs
@@ -7,7 +7,7 @@ use ariel_os::reexports::embassy_net;
 
 // FAIL: misspelled config kind
 #[ariel_os::config(networkk)]
-fn network_config() -> embassy_net::Config {
+const NETWORK_CONFIG: embassy_net::Config = {
     use embassy_net::Ipv4Address;
 
     embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
@@ -15,4 +15,4 @@ fn network_config() -> embassy_net::Config {
         dns_servers: heapless::Vec::new(),
         gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
     })
-}
+};

--- a/src/ariel-os-macros/tests/ui/config/no_parameters.rs
+++ b/src/ariel-os-macros/tests/ui/config/no_parameters.rs
@@ -7,7 +7,7 @@ use ariel_os::reexports::embassy_net;
 
 // FAIL: this attribute macro requires parameters
 #[ariel_os::config]
-fn network_config() -> embassy_net::Config {
+const NETWORK_CONFIG: embassy_net::Config = {
     use embassy_net::Ipv4Address;
 
     embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
@@ -15,4 +15,4 @@ fn network_config() -> embassy_net::Config {
         dns_servers: heapless::Vec::new(),
         gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
     })
-}
+};

--- a/tests/coap/src/main.rs
+++ b/tests/coap/src/main.rs
@@ -3,6 +3,17 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 
+#[ariel_os::config(network)]
+const NETWORK_CONFIG: embassy_net::Config = {
+    use embassy_net::Ipv4Address;
+
+    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
+        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
+        dns_servers: heapless::Vec::new(),
+        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
+    })
+};
+
 #[ariel_os::task(autostart)]
 async fn coap_run() {
     use coap_handler_implementations::HandlerBuilder;
@@ -83,16 +94,4 @@ async fn run_client_operations(mut stdout: impl core::fmt::Write) {
         response.map_err(|_| "TransportError")
     )
     .unwrap();
-}
-
-// FIXME: So far, this is necessary boilerplate; see ../README.md#networking for details
-#[ariel_os::config(network)]
-fn network_config() -> embassy_net::Config {
-    use embassy_net::Ipv4Address;
-
-    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
-        dns_servers: heapless::Vec::new(),
-        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
-    })
 }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This changes the API of the `#[config]` macro to use a `const` instead of a function, making the intent and behavior clearer for users.

This modifies the macro, and updates the tests and examples that use it.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on https://github.com/ariel-os/embassy/pull/1

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
