### PR TITLE
feat(identity): generate MAC addresses from device identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,8 @@ dependencies = [
 name = "ariel-os-embassy-common"
 version = "0.1.0"
 dependencies = [
+ "ariel-os-buildinfo",
+ "const-sha1",
  "defmt",
  "embassy-futures",
  "embassy-time",

--- a/examples/device-metadata/README.md
+++ b/examples/device-metadata/README.md
@@ -20,3 +20,4 @@ For example:
     INFO  Available information:
     INFO  Board type: nrf52840dk
     INFO  Device ID: [80, 6a, ec, 55, 8c, c2, 43, 8e]
+    INFO  Device's first EUI-48 address: [02, 9a, 05, d7, 38, e9]

--- a/examples/device-metadata/README.md
+++ b/examples/device-metadata/README.md
@@ -20,4 +20,4 @@ For example:
     INFO  Available information:
     INFO  Board type: nrf52840dk
     INFO  Device ID: [80, 6a, ec, 55, 8c, c2, 43, 8e]
-    INFO  Device's first EUI-48 address: [02, 9a, 05, d7, 38, e9]
+    INFO  Device's first EUI-48 address: 02:9a:05:d7:38:e9

--- a/examples/device-metadata/src/main.rs
+++ b/examples/device-metadata/src/main.rs
@@ -13,6 +13,9 @@ fn main() {
     } else {
         info!("Device ID is unavailable.");
     }
+    if let Ok(eui48) = ariel_os::identity::interface_eui48(0) {
+        info!("Device's first EUI-48 address: {=[u8]:02x}", eui48.as_ref());
+    }
 
     exit(EXIT_SUCCESS);
 }

--- a/examples/device-metadata/src/main.rs
+++ b/examples/device-metadata/src/main.rs
@@ -14,7 +14,7 @@ fn main() {
         info!("Device ID is unavailable.");
     }
     if let Ok(eui48) = ariel_os::identity::interface_eui48(0) {
-        info!("Device's first EUI-48 address: {=[u8]:02x}", eui48.as_ref());
+        info!("Device's first EUI-48 address: {}", eui48);
     }
 
     exit(EXIT_SUCCESS);

--- a/src/ariel-os-embassy-common/Cargo.toml
+++ b/src/ariel-os-embassy-common/Cargo.toml
@@ -9,12 +9,14 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+ariel-os-buildinfo = { workspace = true }
 defmt = { workspace = true, optional = true }
 fugit = { workspace = true, optional = true }
 embassy-futures = { workspace = true }
 embassy-time = { workspace = true }
 embedded-hal = { workspace = true }
 embedded-hal-async = { workspace = true }
+const-sha1 = { version = "0.3.0", default-features = false }
 
 [features]
 ## Enables GPIO interrupt support.

--- a/src/ariel-os-embassy-common/src/identity.rs
+++ b/src/ariel-os-embassy-common/src/identity.rs
@@ -125,6 +125,10 @@ pub trait DeviceId: Sized {
     }
 }
 
+#[expect(
+    clippy::missing_panics_doc,
+    reason = "False positive. Clippy does not see that `u32::from_le_bytes(eui48[1..5].try_into().unwrap())` can not panic, even though the compiler produces panic free code."
+)]
 fn generate_aai_mac_address(
     truncated_board_hash: [u8; 6],
     device_id_bytes: impl AsRef<[u8]>,

--- a/src/ariel-os-embassy-common/src/identity.rs
+++ b/src/ariel-os-embassy-common/src/identity.rs
@@ -43,6 +43,13 @@ pub trait DeviceId: Sized {
 
     /// The device identifier in serialized bytes format.
     fn bytes(&self) -> Self::Bytes;
+
+    /// Generates an EUI-48 identifier ("6-byte MAC address") based on the device identity.
+    ///
+    /// See `ariel_os::identity::interface_eu48` for details.
+    fn interface_eui48(&self, if_index: u32) -> [u8; 6] {
+        todo!()
+    }
 }
 
 /// An uninhabited type implementing [`DeviceId`] that always errs.

--- a/src/ariel-os-embassy-common/src/lib.rs
+++ b/src/ariel-os-embassy-common/src/lib.rs
@@ -2,6 +2,14 @@
 
 #![no_std]
 #![feature(doc_auto_cfg)]
+#![cfg_attr(
+    not(context = "xtensa"),
+    expect(
+        stable_features,
+        reason = "feature(const_option) is needed for Xtensa toolchain that is held behind"
+    )
+)]
+#![feature(const_option)]
 #![deny(clippy::pedantic)]
 #![deny(missing_docs)]
 

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -237,7 +237,7 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
 
         // Host's MAC addr. This is the MAC the host "thinks" its USB-to-ethernet adapter has.
         let host_mac_addr = crate::hal::identity::DeviceId::get()
-            .map(|d| d.interface_eui48(1))
+            .map(|d| d.interface_eui48(1).0)
             .unwrap_or([0x8A, 0x88, 0x88, 0x88, 0x88, 0x88]);
 
         // Create classes on the builder.
@@ -250,7 +250,7 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
         );
 
         let our_mac_addr = crate::hal::identity::DeviceId::get()
-            .map(|d| d.interface_eui48(0))
+            .map(|d| d.interface_eui48(0).0)
             .unwrap_or([0xCA, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC]);
 
         static NET_STATE: StaticCell<NetState<{ network::ETHERNET_MTU }, 4, 4>> = StaticCell::new();

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -230,12 +230,15 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
 
     #[cfg(feature = "usb-ethernet")]
     let device = {
+        use ariel_os_embassy_common::identity::DeviceId;
         use embassy_usb::class::cdc_ncm::{
             embassy_net::State as NetState, CdcNcmClass, State as CdcNcmState,
         };
 
         // Host's MAC addr. This is the MAC the host "thinks" its USB-to-ethernet adapter has.
-        let host_mac_addr = [0x8A, 0x88, 0x88, 0x88, 0x88, 0x88];
+        let host_mac_addr = crate::hal::identity::DeviceId::get()
+            .map(|d| d.interface_eui48(1))
+            .unwrap_or([0x8A, 0x88, 0x88, 0x88, 0x88, 0x88]);
 
         // Create classes on the builder.
         static CDC_ECM_STATE: StaticCell<CdcNcmState> = StaticCell::new();
@@ -246,7 +249,9 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
             64,
         );
 
-        let our_mac_addr = [0xCA, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC];
+        let our_mac_addr = crate::hal::identity::DeviceId::get()
+            .map(|d| d.interface_eui48(0))
+            .unwrap_or([0xCA, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC]);
 
         static NET_STATE: StaticCell<NetState<{ network::ETHERNET_MTU }, 4, 4>> = StaticCell::new();
         let (runner, device) = usb_cdc_ecm

--- a/src/ariel-os-identity/src/lib.rs
+++ b/src/ariel-os-identity/src/lib.rs
@@ -1,6 +1,6 @@
 //! Access to unique identifiers provided by the device.
 //!
-//! This module provides [`device_id_bytes()`], which returns an identifier for the
+//! This module provides [`device_id_bytes()`] and related functions, which returns an identifier for the
 //! concrete piece of hardware that the software is running on in byte serialized form.
 //!
 //! Concrete properties of a device identity are:
@@ -21,6 +21,9 @@
 //!
 //! It is considered a breaking change in Ariel OS if a device's identifier changes or becomes an
 //! error. Errors changing to valid identifiers is a compatible change.
+//!
+//! Other identifiers, such as the EUI-48 addresses provided by [`interface_eui48()`], are usually
+//! derived from the main identity, but have different properties.
 #![no_std]
 #![deny(missing_docs)]
 #![deny(clippy::pedantic)]
@@ -39,4 +42,32 @@ pub fn device_id_bytes() -> Result<impl AsRef<[u8]>, impl core::error::Error> {
     use ariel_os_embassy_common::identity::DeviceId;
 
     ariel_os_embassy::hal::identity::DeviceId::get().map(|d| d.bytes())
+}
+
+/// Generates an EUI-48 identifier ("6-byte MAC address") based on the device identity.
+///
+/// The argument `if_index` allows the system to generate addresses for consecutive interfaces.
+///
+/// The default implementation creates a static random identifier based on the board name, the
+/// device ID bytes, incrementing by the interface index (following the common scheme of
+/// sequential MAC addresses being assigned to multi-interface hardware). Those take the shape
+/// `?2-??-??-??-??-??`: Their bits set to individual (I/G, unicast), administratively
+/// locally administered (U/L, not indicating any particular manufacturer), and following the
+/// SLAP (Structured Local Address Plan) semantics, they fall into the AII (Administratively
+/// Assigned Identifier) quadrant. Wikipedia has a [good description of those address
+/// details](https://en.wikipedia.org/wiki/MAC_address#Address_details).
+///
+/// The randomly generated identifiers aim to appear random, but can
+/// be traced back to the device ID it is calculated from.
+///
+/// On devices that have access to globally unique EUI-48 identifiers, those are returned
+/// for interface indices up to the number of available identifiers.
+///
+/// # Errors
+///
+/// Same as in [`device_id_bytes()`].
+pub fn interface_eui48(if_index: u32) -> Result<[u8; 6], impl core::error::Error> {
+    use ariel_os_embassy_common::identity::DeviceId;
+
+    ariel_os_embassy::hal::identity::DeviceId::get().map(|d| d.interface_eui48(if_index))
 }

--- a/src/ariel-os-identity/src/lib.rs
+++ b/src/ariel-os-identity/src/lib.rs
@@ -28,6 +28,8 @@
 #![deny(missing_docs)]
 #![deny(clippy::pedantic)]
 
+pub use ariel_os_embassy_common::identity::Eui48;
+
 /// Obtains a unique identifier of the device in its byte serialized form.
 ///
 /// See module level documentation for that identifier's properties.
@@ -66,7 +68,7 @@ pub fn device_id_bytes() -> Result<impl AsRef<[u8]>, impl core::error::Error> {
 /// # Errors
 ///
 /// Same as in [`device_id_bytes()`].
-pub fn interface_eui48(if_index: u32) -> Result<[u8; 6], impl core::error::Error> {
+pub fn interface_eui48(if_index: u32) -> Result<Eui48, impl core::error::Error> {
     use ariel_os_embassy_common::identity::DeviceId;
 
     ariel_os_embassy::hal::identity::DeviceId::get().map(|d| d.interface_eui48(if_index))


### PR DESCRIPTION
# Description

This adds generation of MAC addresses to the device identity, and uses them instead of our default 8a888888 addresses.

The addresses are random based on board name and device identity (a combination that should be unique, although we can't make hard guarantees for random numbers in a 48 bit space), and set the right bits required for a non-vendor MAC address (there's no space for random addresses, but administratively managed is the space commonly used for that).

Devices that have actually built-in MAC addresses can use the interface to provide the ones they have (but AIU, none of the chips we have right now have any burnt in).

## Issues/PRs references

SLAAC is coming up. I guess we should have some more proper MAC addresses by then.

## Open Questions

* There's one FIXME in the code I'd like to have feedback on -- but unless someone comes up with a genius solution, I think it's fine to stay in.
* Are you happy with the algorithm? I think it hits a sweet spot between "we can keep it stable", "it uses most of the entropy to avoid collisions" and "it's small at runtime".
* Do we want to do something smarter about which part picks which interface identifier? If someone enables BLE and USB at the same time, they might get the same one just because the numbers are not coordinated. System-wide enum maybe? But then what if a board has two Ethernet, and do we still want per-device consecutive ones?

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
  (AIU we don't document the MAC addresses we generate.)
