### PR TITLE
fix(cortex_m): don't rely on u128 ABI

### DIFF
--- a/src/ariel-os-threads/src/arch/cortex_m.rs
+++ b/src/ariel-os-threads/src/arch/cortex_m.rs
@@ -96,26 +96,26 @@ unsafe extern "C" fn PendSV() {
         asm!(
             "
             bl {sched}
+
+            // r0 == 0 means that
+            // a) there was no previous thread, or
+            // This is only the case if the scheduler was triggered for the first time,
+            // which also means that next thread has no stored context yet.
+            // b) the current thread didn't change.
+            //
+            // In both cases, storing and loading of r4-r11 can be skipped.
             cmp r0, #0
+
             /* label rules:
              * - number only
              * - no combination of *only* [01]
              * - add f or b for 'next matching forward/backward'
-             * so let's use '99' forward ('99f')
              */
             beq 99f
 
-            msr.n psp, r0
+            stmia r0, {{r4-r11}}
+            ldmia r1, {{r4-r11}}
 
-            // r1 == 0 means that there was no previous thread.
-            // This is only the case if the scheduler was triggered for the first time,
-            // which also means that next thread has no stored context yet.
-            // Storing and loading of r4-r11 therefore can be skipped.
-            cmp r1, #0
-            beq 99f
-
-            stmia r1, {{r4-r11}}
-            ldmia r2, {{r4-r11}}
             99:
             movw LR, #0xFFFd
             movt LR, #0xFFFF
@@ -136,41 +136,39 @@ unsafe extern "C" fn PendSV() {
         asm!(
             "
             bl {sched}
-            cmp r0, #0
-            beq 99f
 
-            msr.n psp, r0
-
-            // r1 == 0 means that there was no previous thread.
+            // r0 == 0 means that
+            // a) there was no previous thread, or
             // This is only the case if the scheduler was triggered for the first time,
             // which also means that next thread has no stored context yet.
-            // Storing and loading of r4-r11 therefore can be skipped.
-            cmp r1, #0
-            beq 99f
+            // b) the current thread didn't change.
+            //
+            // In both cases, storing and loading of r4-r11 can be skipped.
+            cmp r0, #0
 
             //stmia r1!, {{r4-r7}}
-            str r4, [r1, #16]
-            str r5, [r1, #20]
-            str r6, [r1, #24]
-            str r7, [r1, #28]
+            str r4, [r0, #16]
+            str r5, [r0, #20]
+            str r6, [r0, #24]
+            str r7, [r0, #28]
 
             mov  r4, r8
             mov  r5, r9
             mov  r6, r10
             mov  r7, r11
 
-            str r4, [r1, #0]
-            str r5, [r1, #4]
-            str r6, [r1, #8]
-            str r7, [r1, #12]
+            str r4, [r0, #0]
+            str r5, [r0, #4]
+            str r6, [r0, #8]
+            str r7, [r0, #12]
 
             //
-            ldmia r2!, {{r4-r7}}
+            ldmia r1!, {{r4-r7}}
             mov r11, r7
             mov r10, r6
             mov r9,  r5
             mov r8,  r4
-            ldmia r2!, {{r4-r7}}
+            ldmia r1!, {{r4-r7}}
 
             99:
             ldr r0, 999f
@@ -193,16 +191,14 @@ unsafe extern "C" fn PendSV() {
 /// This may be current thread, or a new one.
 ///
 /// Returns:
-/// - `0` in `r0` if the next thread in the runqueue is the currently running thread
-/// - Else it writes into the following registers:
-///   - `r1`: pointer to [`Thread::high_regs`] from old thread (to store old register state)
-///           or null pointer if there was no previously running thread.
-///   - `r2`: pointer to [`Thread::high_regs`] from new thread (to load new register state)
-///   - `r0`: stack-pointer for new thread
+///   - `r0`: pointer to [`Thread::high_regs`] from old thread (to store old register state)
+///           or null pointer if there was no previously running thread, or the currently running
+///           thread should not be changed.
+///   - `r1`: pointer to [`Thread::high_regs`] from new thread (to load new register state)
 ///
-/// This function is called in PendSV.
-unsafe fn sched() -> (u32, u64) {
-    let (next_sp, current_high_regs, next_high_regs) = loop {
+/// This function is called in PendSV from assembly, so it must be `extern "C"`.
+unsafe extern "C" fn sched() -> u64 {
+    let (current_high_regs, next_high_regs) = loop {
         if let Some(res) = critical_section::with(|cs| {
             let scheduler = unsafe { &mut *SCHEDULER.as_ptr(cs) };
 
@@ -232,7 +228,7 @@ unsafe fn sched() -> (u32, u64) {
             let mut current_high_regs = core::ptr::null();
             if let Some(ref mut current_pid_ref) = scheduler.current_pid_mut() {
                 if next_pid == *current_pid_ref {
-                    return Some((0, 0, 0));
+                    return Some((0, 0));
                 }
                 let current_pid = *current_pid_ref;
                 *current_pid_ref = next_pid;
@@ -244,25 +240,22 @@ unsafe fn sched() -> (u32, u64) {
             }
 
             let next = scheduler.get_unchecked(next_pid);
-            let next_sp = next.data.sp;
+            // SAFETY: changing the PSP as part of context switch
+            unsafe { cortex_m::register::psp::write(next.data.sp as u32) };
             let next_high_regs = next.data.high_regs.as_ptr();
 
-            Some((
-                next_sp as u32,
-                current_high_regs as u32,
-                next_high_regs as u32,
-            ))
+            Some((current_high_regs as u32, next_high_regs as u32))
         }) {
             break res;
         }
     };
 
-    // The caller (`PendSV`) expects these three pointers in r0, r1 and r2:
-    // r0 = &next.data.sp
-    // r1 = &current.data.high_regs
-    // r2 = &next.data.high_regs
-    (
-        next_sp,
-        ((current_high_regs as u64) | (next_high_regs as u64) << 32),
-    )
+    // The caller (`PendSV`) expects these two pointers in r0 and r1:
+    // r0 = &current.data.high_regs (or 0)
+    // r1 = &next.data.high_regs
+    // The C ABI on ARM (AAPCS) defines u64 to be returned in r0 and r1, so we use that to fit our
+    // values in there. `extern "C"` on this function ensures the Rust compiler adheres to those
+    // rules.
+    // See https://github.com/ARM-software/abi-aa/blob/a82eef0433556b30539c0d4463768d9feb8cfd0b/aapcs32/aapcs32.rst#6111handling-values-larger-than-32-bits
+    (current_high_regs as u64) | (next_high_regs as u64) << 32
 }

--- a/src/ariel-os-threads/src/arch/riscv.rs
+++ b/src/ariel-os-threads/src/arch/riscv.rs
@@ -31,7 +31,6 @@ impl Arch for Cpu {
         // 16 byte alignment.
         let stack_pos = (stack_start + stack.len()) & 0xFFFFFFE0;
         // Set up PC, SP, RA and first argument for function.
-        thread.sp = stack_pos;
         thread.data.sp = stack_pos;
         thread.data.a0 = arg;
         thread.data.ra = cleanup as usize;

--- a/src/ariel-os-threads/src/arch/xtensa.rs
+++ b/src/ariel-os-threads/src/arch/xtensa.rs
@@ -29,7 +29,6 @@ impl Arch for Cpu {
         // 16 byte alignment.
         let stack_pos = task_stack_ptr - (task_stack_ptr % 0x10);
 
-        thread.sp = stack_pos;
         thread.data.A1 = stack_pos as u32;
         thread.data.A6 = arg as u32;
         // Usually A0 holds the return address.

--- a/src/ariel-os-threads/src/thread.rs
+++ b/src/ariel-os-threads/src/thread.rs
@@ -8,7 +8,6 @@ pub struct Thread {
         dead_code,
         reason = "sp is used in context-specific scheduler implementation"
     )]
-    pub sp: usize,
     /// The thread's current state.
     pub state: ThreadState,
     /// Priority of the thread between 0..[`super::SCHED_PRIO_LEVELS`].
@@ -54,7 +53,6 @@ impl Thread {
     /// Creates an empty [`Thread`] object with [`ThreadState::Invalid`].
     pub const fn default() -> Thread {
         Thread {
-            sp: 0,
             state: ThreadState::Invalid,
             data: Cpu::DEFAULT_THREAD_DATA,
             flags: 0,
@@ -72,12 +70,9 @@ mod tests {
 
     #[test]
     fn check_type_sizes() {
-        // `ThreadData` is arch-specific, and is replaced with a dummy value is tests; its size is
+        // `ThreadData` is arch-specific, and is replaced with a dummy value in tests; its size is
         // non-zero otherwise.
         assert_eq!(size_of::<ThreadData>(), 0);
-        assert_eq!(
-            size_of::<Thread>(),
-            size_of::<usize>() + size_of::<ThreadData>() + 24
-        );
+        assert_eq!(size_of::<Thread>(), size_of::<ThreadData>() + 24);
     }
 }


### PR DESCRIPTION
# Description

#476 broke our threading on Cortex-M, so our assumption on a specific u128 ABI behaviour was not reliably enough.

This PR solves this by:

1. moving SP into `ThreadData` for cortexm (it was populated but not used by neither xtensa nor riscv esp)
2. set the PSP from within `sched()`
3. simplify the "maybe skip context save/restore" logic, only requiring two values, which fit into the defined u64 return
4. use an `extern "C"` function, as the previous method was [not even supported](https://rust-lang.zulipchat.com/#narrow/channel/242906-t-compiler.2Farm/topic/.E2.9C.94.20u128.20now.20returned.20via.20stack.3F)

Quick testing shows slight performance improvement (1470ticks to 1450ticks on nrf52840dk).

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

#476 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
