### PR TITLE
feat(buildinfo): introduce a `const` with the OS name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ dependencies = [
 name = "ariel-os-embassy"
 version = "0.1.0"
 dependencies = [
+ "ariel-os-buildinfo",
  "ariel-os-debug",
  "ariel-os-embassy-common",
  "ariel-os-hal",

--- a/examples/usb-keyboard/src/main.rs
+++ b/examples/usb-keyboard/src/main.rs
@@ -33,7 +33,7 @@ const HID_WRITER_BUFFER_SIZE: usize = 8;
 #[ariel_os::config(usb)]
 const USB_CONFIG: ariel_os::reexports::embassy_usb::Config = {
     let mut config = ariel_os::reexports::embassy_usb::Config::new(0xc0de, 0xcafe);
-    config.manufacturer = Some("Ariel OS");
+    config.manufacturer = Some(ariel_os::buildinfo::OS_NAME);
     config.product = Some("HID keyboard example");
     config.serial_number = Some("12345678");
     config.max_power = 100;

--- a/examples/usb-serial/src/main.rs
+++ b/examples/usb-serial/src/main.rs
@@ -19,7 +19,7 @@ const MAX_FULL_SPEED_PACKET_SIZE: u8 = 64;
 #[ariel_os::config(usb)]
 const USB_CONFIG: ariel_os::reexports::embassy_usb::Config = {
     let mut config = ariel_os::reexports::embassy_usb::Config::new(0xc0de, 0xcafe);
-    config.manufacturer = Some("Ariel OS");
+    config.manufacturer = Some(ariel_os::buildinfo::OS_NAME);
     config.product = Some("USB serial example");
     config.serial_number = Some("12345678");
     config.max_power = 100;

--- a/src/ariel-os-buildinfo/src/lib.rs
+++ b/src/ariel-os-buildinfo/src/lib.rs
@@ -12,3 +12,6 @@ pub const BOARD: &str = ariel_os_utils::str_from_env_or!(
     "unknown",
     "board name provided by the build system"
 );
+
+/// The operating system's name.
+pub const OS_NAME: &str = "Ariel OS";

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -28,6 +28,7 @@ embassy-usb = { workspace = true, optional = true }
 embedded-hal = { workspace = true }
 embedded-hal-async = { workspace = true }
 
+ariel-os-buildinfo = { workspace = true }
 ariel-os-embassy-common = { workspace = true }
 ariel-os-hal = { path = "../ariel-os-hal" }
 ariel-os-threads = { path = "../ariel-os-threads", optional = true }

--- a/src/ariel-os-embassy/src/usb.rs
+++ b/src/ariel-os-embassy/src/usb.rs
@@ -45,7 +45,7 @@ pub(crate) fn config() -> embassy_usb::Config<'static> {
     {
         // Create embassy-usb Config
         let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
-        config.manufacturer = Some("Embassy");
+        config.manufacturer = Some(ariel_os_buildinfo::OS_NAME);
         config.product = Some("USB-Ethernet example");
         config.serial_number = Some("12345678");
         config.max_power = 100;


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Now that `buildinfo` has been extracted as its own crate in #613, we can provide a constant with the OS name for use in examples and in our default USB configuration.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
