### PR TITLE
feat(storage): Extend module functions with erase_all

### DIFF
--- a/src/ariel-os-storage/src/lib.rs
+++ b/src/ariel-os-storage/src/lib.rs
@@ -135,6 +135,11 @@ pub async fn remove(key: &str) -> Result<(), sequential_storage::Error<FlashErro
     lock().await.remove(key).await
 }
 
+/// Resets the flash in the entire flash range.
+pub async fn erase_all() -> Result<(), sequential_storage::Error<FlashError>> {
+    lock().await.erase_all().await
+}
+
 /// Gets a [`MutexGuard`] of the global [`Storage`] object.
 ///
 /// This can be used to implement atomic RMW (like counters).


### PR DESCRIPTION
# Description

Similar to the rest of the functions here, this wraps the storage object and expose the `erase_all()` for wiping the whole storage.

Documentation is copied from the wrapped function.

## Issues/PRs references

None

## Open Questions

Any reason this was not included in the original PR?

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
