### PR TITLE
refactor(hal)!: move the peripheral-related macros

### DIFF
--- a/book/src/application.md
+++ b/book/src/application.md
@@ -22,14 +22,14 @@ The [`group_peripherals!`][group_peripherals-docs] macro can also be useful.
 The [`define_peripherals!`][define_peripherals-docs] macro allows to define a *Ariel OS peripheral struct*, an instance of which can be obtained with [`spawner` or `task`][spawner-or-task]:
 
 ```rust,ignore
-ariel_os::define_peripherals!(LedPeripherals { led: P0_13 });
+ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_13 });
 ```
 
 Multiple Ariel OS peripheral structs can be grouped into another Ariel OS peripheral struct using the [`group_peripherals!`][group_peripherals-docs] macro:
 
 <!-- TODO: this needs to be kept up to date -->
 ```rust,ignore
-ariel_os::group_peripherals!(Peripherals {
+ariel_os::hal::group_peripherals!(Peripherals {
     leds: LedPeripherals,
     buttons: ButtonPeripherals,
 });
@@ -80,5 +80,5 @@ TODO
 [task-attr-docs]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/attr.task.html
 [spawner-or-task]: #the-spawner-and-task-ariel-os-macros
 [blinky-example-src]: https://github.com/ariel-os/ariel-os/tree/main/examples/blinky
-[define_peripherals-docs]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/macro.define_peripherals.html
-[group_peripherals-docs]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/macro.group_peripherals.html
+[define_peripherals-docs]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/hal/macro.define_peripherals.html
+[group_peripherals-docs]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/hal/macro.group_peripherals.html

--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -1,28 +1,28 @@
 use ariel_os::hal::peripherals;
 
 #[cfg(context = "microbit-v2")]
-ariel_os::define_peripherals!(LedPeripherals {
+ariel_os::hal::define_peripherals!(LedPeripherals {
     led_col1: P0_28,
     led: P0_21,
 });
 
 #[cfg(context = "nrf52840dk")]
-ariel_os::define_peripherals!(LedPeripherals { led: P0_13 });
+ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_13 });
 
 #[cfg(context = "nrf5340dk")]
-ariel_os::define_peripherals!(LedPeripherals { led: P0_28 });
+ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_28 });
 
 #[cfg(context = "rp")]
-ariel_os::define_peripherals!(LedPeripherals { led: PIN_1 });
+ariel_os::hal::define_peripherals!(LedPeripherals { led: PIN_1 });
 
 #[cfg(context = "esp")]
-ariel_os::define_peripherals!(LedPeripherals { led: GPIO_0 });
+ariel_os::hal::define_peripherals!(LedPeripherals { led: GPIO_0 });
 
 #[cfg(context = "st-nucleo-f401re")]
-ariel_os::define_peripherals!(LedPeripherals { led: PA5 });
+ariel_os::hal::define_peripherals!(LedPeripherals { led: PA5 });
 
 #[cfg(context = "st-nucleo-h755zi-q")]
-ariel_os::define_peripherals!(LedPeripherals { led: PB0 });
+ariel_os::hal::define_peripherals!(LedPeripherals { led: PB0 });
 
 #[cfg(context = "st-nucleo-wb55")]
-ariel_os::define_peripherals!(LedPeripherals { led: PB5 });
+ariel_os::hal::define_peripherals!(LedPeripherals { led: PB5 });

--- a/examples/gpio/src/pins.rs
+++ b/examples/gpio/src/pins.rs
@@ -1,50 +1,50 @@
 use ariel_os::hal::peripherals;
 
 #[cfg(context = "nrf52840dk")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     led1: P0_13,
     btn1: P0_11
 });
 
 #[cfg(context = "microbit-v2")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     led_col1: P0_28,
     led1: P0_21,
     btn1: P0_14
 });
 
 #[cfg(context = "nrf5340dk")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     led1: P0_28,
     btn1: P0_23
 });
 
 #[cfg(context = "rp")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     led1: PIN_1,
     btn1: PIN_2
 });
 
 #[cfg(context = "esp")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     led1: GPIO_0,
     btn1: GPIO_1
 });
 
 #[cfg(context = "st-nucleo-f401re")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     led1: PA5,
     btn1: PC13
 });
 
 #[cfg(context = "st-nucleo-h755zi-q")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     btn1: PC13,
     led1: PB0
 });
 
 #[cfg(context = "st-nucleo-wb55")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     led1: PB5,
     btn1: PC4
 });

--- a/examples/http-server/src/pins.rs
+++ b/examples/http-server/src/pins.rs
@@ -2,15 +2,15 @@
 use ariel_os::hal::peripherals;
 
 #[cfg(all(feature = "button-reading", builder = "nrf52840dk"))]
-ariel_os::define_peripherals!(Button { btn1: P0_11 });
+ariel_os::hal::define_peripherals!(Button { btn1: P0_11 });
 
 #[cfg(context = "nrf5340dk")]
-ariel_os::define_peripherals!(Button { btn1: P0_23 });
+ariel_os::hal::define_peripherals!(Button { btn1: P0_23 });
 
 #[cfg(context = "st-nucleo-wb55")]
-ariel_os::define_peripherals!(Button { btn1: PC4 });
+ariel_os::hal::define_peripherals!(Button { btn1: PC4 });
 
-ariel_os::group_peripherals!(Peripherals {
+ariel_os::hal::group_peripherals!(Peripherals {
     #[cfg(feature = "button-reading")]
     button: Button,
 });

--- a/examples/usb-keyboard/src/pins.rs
+++ b/examples/usb-keyboard/src/pins.rs
@@ -1,7 +1,7 @@
 use ariel_os::hal::peripherals;
 
 #[cfg(builder = "nrf52840dk")]
-ariel_os::define_peripherals!(Buttons {
+ariel_os::hal::define_peripherals!(Buttons {
     btn1: P0_11,
     btn2: P0_12,
     btn3: P0_24,
@@ -9,7 +9,7 @@ ariel_os::define_peripherals!(Buttons {
 });
 
 #[cfg(builder = "nrf5340dk")]
-ariel_os::define_peripherals!(Buttons {
+ariel_os::hal::define_peripherals!(Buttons {
     btn1: P0_23,
     btn2: P0_24,
     btn3: P0_08,

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -5,7 +5,6 @@
 #![feature(used_with_arg)]
 #![feature(doc_auto_cfg)]
 
-pub mod define_peripherals;
 pub mod gpio;
 
 pub use ariel_os_hal as hal;
@@ -33,9 +32,7 @@ pub use static_cell::{ConstStaticCell, StaticCell};
 
 // All items of this module are re-exported at the root of `ariel_os`.
 pub mod api {
-    pub use crate::{
-        asynch, define_peripherals, delegate, gpio, group_peripherals, hal, EMBASSY_TASKS,
-    };
+    pub use crate::{asynch, delegate, gpio, hal, EMBASSY_TASKS};
 
     #[cfg(feature = "time")]
     pub mod time {

--- a/src/ariel-os-hal/src/define_peripherals.rs
+++ b/src/ariel-os-hal/src/define_peripherals.rs
@@ -1,5 +1,5 @@
-/// This macro allows to obtain peripherals from the one listed in the `peripherals` module of the
-/// target's HAL crate (selected by [`ariel_os::hal`](ariel_os_hal)).
+/// This macro allows to obtain peripherals from the one listed in the `peripherals` module
+/// exported by this crate.
 ///
 /// It makes sense to use this macro multiple times, coupled with conditional compilation (using
 /// the [`cfg`
@@ -8,7 +8,8 @@
 ///
 /// # Note
 ///
-/// The `define_peripherals!` macro expects the `ariel_os::hal::peripherals` module to be in scope.
+/// The [`define_peripherals!`](crate::define_peripherals!) macro expects the
+/// `ariel_os::hal::peripherals` module to be in scope.
 ///
 // Inspired by https://github.com/adamgreig/assign-resources/tree/94ad10e2729afdf0fd5a77cd12e68409a982f58a
 // under MIT license
@@ -38,7 +39,7 @@ macro_rules! define_peripherals {
             pub type $peripheral_alias = peripherals::$peripheral_field;
         )?)*
 
-        impl $crate::define_peripherals::TakePeripherals<$peripherals> for &mut $crate::hal::OptionalPeripherals {
+        impl $crate::TakePeripherals<$peripherals> for &mut $crate::OptionalPeripherals {
             fn take_peripherals(&mut self) -> $peripherals {
                 $peripherals {
                     $(
@@ -51,8 +52,8 @@ macro_rules! define_peripherals {
     }
 }
 
-/// This macro allows to group peripheral structs defined with `define_peripherals!` into a single
-/// peripheral struct.
+/// This macro allows to group peripheral structs defined with
+/// [`define_peripherals!`](crate::define_peripherals!) into a single peripheral struct.
 #[macro_export]
 macro_rules! group_peripherals {
     (
@@ -74,7 +75,7 @@ macro_rules! group_peripherals {
             ),*
         }
 
-        impl $crate::define_peripherals::TakePeripherals<$group> for &mut $crate::hal::OptionalPeripherals {
+        impl $crate::TakePeripherals<$group> for &mut $crate::OptionalPeripherals {
             fn take_peripherals(&mut self) -> $group {
                 $group {
                     $(
@@ -87,6 +88,7 @@ macro_rules! group_peripherals {
     }
 }
 
+#[doc(hidden)]
 pub trait TakePeripherals<T> {
     fn take_peripherals(&mut self) -> T;
 }

--- a/src/ariel-os-hal/src/lib.rs
+++ b/src/ariel-os-hal/src/lib.rs
@@ -25,6 +25,11 @@
 #![no_std]
 #![deny(clippy::pedantic)]
 
+#[doc(hidden)]
+pub mod define_peripherals;
+
+pub use define_peripherals::*;
+
 cfg_if::cfg_if! {
     if #[cfg(context = "nrf")] {
         pub use ariel_os_nrf::*;

--- a/src/ariel-os-macros/src/spawner.rs
+++ b/src/ariel-os-macros/src/spawner.rs
@@ -5,7 +5,7 @@
 /// - a `Spawner` as first parameter,
 /// - a peripheral struct, as optional second parameter.
 ///
-/// The peripheral struct must be defined with the `ariel_os::define_peripherals!` macro.
+/// The peripheral struct must be defined with the `ariel_os::hal::define_peripherals!` macro.
 ///
 /// See [`macro@task`] to use a long-lived async function instead.
 ///
@@ -91,7 +91,7 @@ pub fn spawner(args: TokenStream, item: TokenStream) -> TokenStream {
             spawner: #ariel_os_crate::asynch::Spawner,
             mut peripherals: &mut #ariel_os_crate::hal::OptionalPeripherals,
         ) {
-            use #ariel_os_crate::define_peripherals::TakePeripherals;
+            use #ariel_os_crate::hal::define_peripherals::TakePeripherals;
             #spawner_function_name(spawner #peripheral_param);
         }
 

--- a/src/ariel-os-macros/src/task.rs
+++ b/src/ariel-os-macros/src/task.rs
@@ -11,7 +11,8 @@
 ///     - `peripherals`: (*optional*) provide the function with a peripheral struct as the first
 ///         parameter.
 ///         The `peripherals` parameter can only be used on `autostart` tasks.
-///         The peripheral struct must be defined with the `ariel_os::define_peripherals!` macro.
+///         The peripheral struct must be defined with the `ariel_os::hal::define_peripherals!`
+///         macro.
 ///     - hooks: (*optional*) available hooks are:
 ///         - `usb_builder_hook`: when present, the macro will define a static `USB_BUILDER_HOOK`
 ///           of type `UsbBuilderHook`, allowing to access and modify the system-provided
@@ -103,7 +104,7 @@ pub fn task(args: TokenStream, item: TokenStream) -> TokenStream {
                 spawner: #ariel_os_crate::asynch::Spawner,
                 mut peripherals: &mut #ariel_os_crate::hal::OptionalPeripherals,
             ) {
-                use #ariel_os_crate::define_peripherals::TakePeripherals;
+                use #ariel_os_crate::hal::TakePeripherals;
                 let task = #task_function_name(#peripheral_param);
                 spawner.spawn(task).unwrap();
             }

--- a/tests/gpio-interrupt-nrf/src/main.rs
+++ b/tests/gpio-interrupt-nrf/src/main.rs
@@ -13,7 +13,7 @@ use ariel_os::{
 todo!();
 
 #[cfg(context = "nrf52")]
-ariel_os::define_peripherals!(ButtonPeripherals {
+ariel_os::hal::define_peripherals!(ButtonPeripherals {
     btn_0: P0_00,
     btn_1: P0_01,
     btn_2: P0_02,
@@ -26,7 +26,7 @@ ariel_os::define_peripherals!(ButtonPeripherals {
 });
 
 #[cfg(context = "nrf5340")]
-ariel_os::define_peripherals!(ButtonPeripherals {
+ariel_os::hal::define_peripherals!(ButtonPeripherals {
     btn_0: P0_00,
     btn_1: P0_01,
     btn_2: P0_04,

--- a/tests/gpio-interrupt-stm32/src/main.rs
+++ b/tests/gpio-interrupt-stm32/src/main.rs
@@ -11,7 +11,7 @@ use ariel_os::{
 
 // These pins should be available on all STM32 chips.
 #[cfg(context = "stm32")]
-ariel_os::define_peripherals!(ButtonPeripherals {
+ariel_os::hal::define_peripherals!(ButtonPeripherals {
     btn_a0: PA0,
     btn_a1: PA1,
     btn_b0: PB0,

--- a/tests/gpio/src/pins.rs
+++ b/tests/gpio/src/pins.rs
@@ -1,7 +1,7 @@
 use ariel_os::hal::peripherals;
 
 #[cfg(context = "nrf52")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     pin_0: P0_00,
     pin_1: P0_01,
     pin_2: P0_02,
@@ -9,7 +9,7 @@ ariel_os::define_peripherals!(Peripherals {
 });
 
 #[cfg(context = "nrf5340")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     pin_0: P0_00,
     pin_1: P0_01,
     pin_2: P0_04,
@@ -17,7 +17,7 @@ ariel_os::define_peripherals!(Peripherals {
 });
 
 #[cfg(context = "rp2040")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     pin_0: PIN_0,
     pin_1: PIN_1,
     pin_2: PIN_2,
@@ -25,7 +25,7 @@ ariel_os::define_peripherals!(Peripherals {
 });
 
 #[cfg(context = "esp32")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     pin_0: GPIO_16,
     pin_1: GPIO_17,
     pin_2: GPIO_18,
@@ -33,7 +33,7 @@ ariel_os::define_peripherals!(Peripherals {
 });
 
 #[cfg(all(context = "esp", not(context = "esp32")))]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     pin_0: GPIO_0,
     pin_1: GPIO_1,
     pin_2: GPIO_2,
@@ -41,7 +41,7 @@ ariel_os::define_peripherals!(Peripherals {
 });
 
 #[cfg(context = "stm32")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     pin_0: PA0,
     pin_1: PA1,
     pin_2: PA2,

--- a/tests/i2c-controller/src/pins.rs
+++ b/tests/i2c-controller/src/pins.rs
@@ -3,7 +3,7 @@ use ariel_os::hal::{i2c, peripherals};
 #[cfg(context = "esp")]
 pub type SensorI2c = i2c::controller::I2C0;
 #[cfg(context = "esp")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: GPIO_2,
     i2c_scl: GPIO_0,
 });
@@ -13,12 +13,12 @@ pub type SensorI2c = i2c::controller::TWISPI0;
 #[cfg(context = "nrf5340")]
 pub type SensorI2c = i2c::controller::SERIAL0;
 #[cfg(all(context = "nrf", not(context = "microbit-v2")))]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: P0_00,
     i2c_scl: P0_01,
 });
 #[cfg(context = "microbit-v2")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: P0_16,
     i2c_scl: P0_08,
 });
@@ -26,7 +26,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "rp")]
 pub type SensorI2c = i2c::controller::I2C0;
 #[cfg(context = "rp")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: PIN_12,
     i2c_scl: PIN_13,
 });
@@ -34,7 +34,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "stm32h755zitx")]
 pub type SensorI2c = i2c::controller::I2C1;
 #[cfg(context = "stm32h755zitx")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: PB9,
     i2c_scl: PB8,
 });
@@ -42,7 +42,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "stm32wb55rgvx")]
 pub type SensorI2c = i2c::controller::I2C1;
 #[cfg(context = "stm32wb55rgvx")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: PB9,
     i2c_scl: PB8,
 });

--- a/tests/spi-loopback/src/pins.rs
+++ b/tests/spi-loopback/src/pins.rs
@@ -3,7 +3,7 @@ use ariel_os::hal::{peripherals, spi};
 #[cfg(context = "esp")]
 pub type SensorSpi = spi::main::SPI2;
 #[cfg(context = "esp")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: GPIO_0,
     spi_miso: GPIO_1,
     spi_mosi: GPIO_2,
@@ -13,7 +13,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "nrf52833")]
 pub type SensorSpi = spi::main::SPI3;
 #[cfg(context = "nrf52833")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: P0_17,  // SPI_EXT_SCK on the microbit-v2
     spi_miso: P0_01, // SPI_EXT_MISO on the microbit-v2
     spi_mosi: P0_13, // SPI_EXT_MOSI on the microbit-v2
@@ -24,7 +24,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "nrf52840")]
 pub type SensorSpi = spi::main::SPI3;
 #[cfg(context = "nrf52840")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: P1_15,
     spi_miso: P1_14,
     spi_mosi: P1_13,
@@ -35,7 +35,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "nrf5340")]
 pub type SensorSpi = spi::main::SERIAL2;
 #[cfg(context = "nrf5340")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: P1_15,
     spi_miso: P1_14,
     spi_mosi: P1_13,
@@ -45,7 +45,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "rp")]
 pub type SensorSpi = spi::main::SPI0;
 #[cfg(context = "rp")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: PIN_18,
     spi_miso: PIN_16,
     spi_mosi: PIN_19,
@@ -56,7 +56,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "stm32h755zitx")]
 pub type SensorSpi = spi::main::SPI1;
 #[cfg(context = "stm32h755zitx")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: PA5,
     spi_miso: PA6,
     spi_mosi: PB5,
@@ -67,7 +67,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "stm32wb55rgvx")]
 pub type SensorSpi = spi::main::SPI1;
 #[cfg(context = "stm32wb55rgvx")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: PA5,
     spi_miso: PA6,
     spi_mosi: PA7,
@@ -78,7 +78,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "stm32f401retx")]
 pub type SensorSpi = spi::main::SPI1;
 #[cfg(context = "stm32f401retx")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: PA5,
     spi_miso: PA6,
     spi_mosi: PA7,

--- a/tests/spi-main/src/pins.rs
+++ b/tests/spi-main/src/pins.rs
@@ -3,7 +3,7 @@ use ariel_os::hal::{peripherals, spi};
 #[cfg(context = "esp")]
 pub type SensorSpi = spi::main::SPI2;
 #[cfg(context = "esp")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: GPIO_0,
     spi_miso: GPIO_1,
     spi_mosi: GPIO_2,
@@ -14,7 +14,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "nrf52840")]
 pub type SensorSpi = spi::main::SPI3;
 #[cfg(context = "nrf52840")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: P1_15,
     spi_miso: P1_14,
     spi_mosi: P1_13,
@@ -25,7 +25,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "nrf5340")]
 pub type SensorSpi = spi::main::SERIAL2;
 #[cfg(context = "nrf5340")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: P1_15,
     spi_miso: P1_14,
     spi_mosi: P1_13,
@@ -35,7 +35,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "rp")]
 pub type SensorSpi = spi::main::SPI0;
 #[cfg(context = "rp")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: PIN_18,
     spi_miso: PIN_16,
     spi_mosi: PIN_19,
@@ -46,7 +46,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "stm32h755zitx")]
 pub type SensorSpi = spi::main::SPI1;
 #[cfg(context = "stm32h755zitx")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: PA5,
     spi_miso: PA6,
     spi_mosi: PB5,
@@ -57,7 +57,7 @@ ariel_os::define_peripherals!(Peripherals {
 #[cfg(context = "stm32wb55rgvx")]
 pub type SensorSpi = spi::main::SPI1;
 #[cfg(context = "stm32wb55rgvx")]
-ariel_os::define_peripherals!(Peripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: PA5,
     spi_miso: PA6,
     spi_mosi: PA7,


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This moves the `define_peripherals!` and `group_peripherals!` macros into the `ariel_os::hal` module so that they don't appear in the root of `ariel_os`.

## How to review this PR

- Generate the rustdoc docs: observe that the macros are not present in the root anymore, and that they are instead in the `ariel_os::hal` module, and that the `TakePeripherals` trait is now `doc(hidden)` on purpose (it's not meant to be user-visible).
- Generate the mdbook and observe that the macro paths are up to date, in the "Building an Application" chapter.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
