### PR TITLE
feat: debug logs without defmt (wip)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ esp-wifi = { version = "0.10.1", default-features = false }
 esp-storage = { version = "0.3.1" }
 
 linkme = { version = "0.3.21", features = ["used_linker"] }
+log = { version = "0.4.20" }
 
 ariel-os = { path = "src/ariel-os", default-features = false }
 ariel-os-bench = { path = "src/ariel-os-bench", default-features = false }

--- a/examples/device-metadata/src/main.rs
+++ b/examples/device-metadata/src/main.rs
@@ -9,7 +9,10 @@ fn main() {
     info!("Available information:");
     info!("Board type: {}", ariel_os::buildinfo::BOARD);
     if let Ok(id) = ariel_os::identity::device_id_bytes() {
+        #[cfg(defmt)]
         info!("Device ID: {=[u8]:02x}", id.as_ref());
+        #[cfg(not(defmt))]
+        info!("Device ID: {:02x?}", id.as_ref());
     } else {
         info!("Device ID is unavailable.");
     }

--- a/examples/log/laze.yml
+++ b/examples/log/laze.yml
@@ -1,4 +1,2 @@
 apps:
   - name: log
-    selects:
-      - defmt

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -12,7 +12,7 @@ contexts:
     selects:
       - executor-default
       - ?critical-section
-      - ?defmt
+      - ?debug-console
       - ?lto
       - ?semihosting
     env:
@@ -228,7 +228,6 @@ contexts:
   - name: esp
     parent: ariel-os
     selects:
-      - ?debug-console
       - ?esp-println
     env:
       RUSTFLAGS:
@@ -423,6 +422,9 @@ modules:
 
   - name: debug-console
     context: ariel-os
+    selects:
+      - ?defmt
+      - ?debug-log
     env:
       global:
         FEATURES:
@@ -431,18 +433,33 @@ modules:
   - name: defmt
     help: Enable use of defmt
     context: ariel-os
+    selects:
+      - debug-console
     env:
       global:
         FEATURES:
           - ariel-os/defmt
         RUSTFLAGS:
           - -Clink-arg=-Tdefmt.x
+          - --cfg defmt
         ESPFLASH_LOG_FORMAT: '--log-format defmt'
         CARGO_ENV:
           # For some reason, `sccache` makes the build not realize changes to
           # `DEFMT_LOG`. Painful as it is, hard-disable `sccache` here.
           - RUSTC_WRAPPER=""
           - DEFMT_LOG=info,${LOG}
+
+  - name: debug-log
+    help: Enable non-defmt debug logger
+    context: ariel-os
+    selects:
+      - debug-console
+    conflicts:
+      - defmt
+    env:
+      global:
+        FEATURES:
+          - ariel-os/debug-log
 
   - name: silent-panic
     context: ariel-os

--- a/src/ariel-os-debug/Cargo.toml
+++ b/src/ariel-os-debug/Cargo.toml
@@ -12,8 +12,9 @@ workspace = true
 
 [dependencies]
 defmt = { workspace = true, optional = true }
-rtt-target = { workspace = true, optional = true }
+log = { workspace = true, optional = true }
 
+rtt-target = { workspace = true, optional = true }
 semihosting = { version = "0.1.16", optional = true }
 
 [target.'cfg(context = "xtensa")'.dependencies]
@@ -23,7 +24,7 @@ semihosting = { version = "0.1.16", optional = true, features = [
 
 [target.'cfg(context = "esp")'.dependencies]
 esp-println = { workspace = true, optional = true, features = ["log"] }
-log = { version = "0.4.20" }
+log = { workspace = true }
 
 [target.'cfg(context = "esp32")'.dependencies]
 esp-println = { workspace = true, features = ["esp32"] }

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -113,6 +113,8 @@ defmt = [
   "ariel-os-threads?/defmt",
   "ariel-os-bench?/defmt",
 ]
+## Enables logging support through `log` / stdout
+debug-log = [ "ariel-os-debug/log" ]
 ## Enables benchmarking facilities.
 bench = ["dep:ariel-os-bench"]
 ## Prints nothing in case of panics (may help reduce binary size).


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->

This adds a `log` crate backend to `ariel_os::debug::log`.

Putting it as draft as https://github.com/ariel-os/ariel-os/pull/629 needs to be resolved first.

## Issues/PRs references

Depends on #629

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

- [ ] when to select dependency, always but not use in defmt case
- [ ] how to allow both "debug logs" (over rtt/... for debugging) and "application logs" (runtime logging for applications)

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
