### PR TITLE
refactor!: stop re-exporting `ariel-os-rt` and hide another item

### DIFF
--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -91,6 +91,7 @@ pub mod thread_executor;
 
 pub type Task = fn(asynch::Spawner, &mut hal::OptionalPeripherals);
 
+#[doc(hidden)]
 #[distributed_slice]
 pub static EMBASSY_TASKS: [Task] = [..];
 

--- a/src/ariel-os/src/lib.rs
+++ b/src/ariel-os/src/lib.rs
@@ -26,8 +26,6 @@ pub use ariel_os_identity as identity;
 #[cfg(feature = "random")]
 #[doc(inline)]
 pub use ariel_os_random as random;
-#[doc(inline)]
-pub use ariel_os_rt as rt;
 #[cfg(feature = "storage")]
 #[doc(inline)]
 pub use ariel_os_storage as storage;


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
`ariel-os-rt` does not have to be accessed by users at all.

---

These were the last two root items that we needed to hide. 

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
