### PR TITLE
build: share cargo target dir per builder

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -37,7 +37,7 @@ contexts:
           CARGO_BUILD_TARGET=${RUSTC_TARGET}
           ${CARGO_TARGET_PREFIX}_RUNNER=${CARGO_RUNNER}
           ${CARGO_TARGET_PREFIX}_RUSTFLAGS="${RUSTFLAGS}"
-          CARGO_TARGET_DIR=${relroot}/${build-dir}/bin/${builder}/${app}/cargo
+          CARGO_TARGET_DIR=${relroot}/${build-dir}/bin/${builder}/cargo
       BOARD: ${builder}
       PROFILE: release
       riot_binary: ${app}
@@ -69,7 +69,7 @@ contexts:
         always: true
         cmd: >-
           cd ${relpath} && ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS} build --${PROFILE} ${FEATURES}
-          && cp ${relroot}/${build-dir}/bin/${builder}/${app}/cargo/${RUSTC_TARGET}/${PROFILE}/${riot_binary} ${relroot}/${out}
+          && cp ${relroot}/${build-dir}/bin/${builder}/cargo/${RUSTC_TARGET}/${PROFILE}/${riot_binary} ${relroot}/${out}
 
       - name: GIT_DOWNLOAD
         cmd: "D=$$(dirname ${out}); rm -rf $$D && git clone ${url} $$D -n && git -C $$D reset --hard ${commit} && touch ${out}"


### PR DESCRIPTION
# Description

Previously, there was a seperate cargo target dir per builder/application tuple.
This PR relaxes this to one target dir per builder.
This should increase re-using of build artifacts, reducing build times.

*edit* this PR's build [used](https://github.com/ariel-os/ariel-os/actions/runs/12435714450/usage) 2h:14m of CI builder time, the previous PR build [used](https://github.com/ariel-os/ariel-os/actions/runs/12434603555/usage) 3h:20m.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
