### PR TITLE
doc(book): point out how multiple log levels are done

### DIFF
--- a/book/src/tooling/defmt.md
+++ b/book/src/tooling/defmt.md
@@ -5,12 +5,13 @@ Ariel OS supports [defmt] on all platforms. It is enabled by default.
 See the [defmt documentation] for general info on `defmt`.
 
 In Ariel OS, the log level defaults to `info`. It can be configured using the
-laze variable `LOG`.
+laze variable `LOG`. As usual with defmt, different levels can be given per
+crate or per module.
 
 Example:
 
 ```shell
-# laze build -C examples/log --builders nrf52840dk -DLOG=warn run
+# laze build -C examples/log --builders nrf52840dk -DLOG=warn,ariel_os_rt=trace run
 ```
 
 Then within Rust code, import `ariel_os::debug::log` items, then use `defmt` log


### PR DESCRIPTION
# Description

This extends the book documentation around `-D LOG`.

Reason we should do this explicitly is that we do comma-join LOG into DEFMT_LOG, so it's not immediately obvious to those who know defmt how this is done.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
