### PR TITLE
build: don't specify esp-storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ esp-hal = { version = "0.21.1", default-features = false }
 esp-hal-embassy = { version = "0.4.0", default-features = false }
 esp-println = { version = "0.12.0" }
 esp-wifi = { version = "0.10.1", default-features = false }
-esp-storage = { version = "0.3.1" }
+#esp-storage = { version = "0.3.1" }
 
 linkme = { version = "0.3.21", features = ["used_linker"] }
 


### PR DESCRIPTION
# Description

Mitigates `warning: Patch `esp-storage v0.3.1 (https://github.com/ariel-os/esp-hal?branch=for-ariel-os-2024-10-16-0.21.1-pr2377-nousbquirk#57f8ab94)` was not used in the 
crate graph.`.

Let's re-add once we've bumped `esp-hal` and we actually need it.

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
