### PR TITLE
ci: use laze for `cargo-test`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,65 +29,18 @@ jobs:
         with:
           toolchain: ${{ steps.get_toolchain.outputs.toolchain }}
 
-      # TODO: we'll eventually want to test the whole workspace with --workspace
-      # TODO: we'll eventually want to enable relevant features
-      - name: Run crate tests
-        run: |
-            RUSTFLAGS='-D warnings' cargo test \
-                --no-default-features \
-                --features "
-                    external-interrupts,
-                    i2c,
-                    no-boards,
-                    spi,
-                    " \
-                -p ariel-os \
-                -p ariel-os-embassy \
-                -p ariel-os-embassy-common \
-                -p ariel-os-identity \
-                -p ariel-os-macros \
-                -p ariel-os-runqueue \
-                -p ariel-os-threads \
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-binstall
 
-            cargo test \
-                -p coapcore \
-                -p rbi \
-                -p ringbuffer \
-
-      # We need to set `RUSTDOCFLAGS` as well in the following jobs, because it
-      # is used for doc tests.
-      - name: cargo test for RP
+      - name: Install prerequisites
         run: |
-            RUSTDOCFLAGS='--cfg context="rp2040"' RUSTFLAGS='-D warnings --cfg context="rp2040"' cargo test \
-                --features "
-                    embassy-rp/rp2040,
-                    external-interrupts,
-                    i2c,
-                    spi,
-                    " \
-                -p ariel-os-rp
+          cargo binstall --no-confirm --no-symlinks --force --no-discover-github-token laze
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          sudo apt-get install ninja-build gcc-arm-none-eabi
 
-      - name: cargo test for nRF
-        run: |
-            RUSTDOCFLAGS='--cfg context="nrf52840"' RUSTFLAGS='-D warnings --cfg context="nrf52840"' cargo test \
-                --features "
-                    embassy-nrf/nrf52840,
-                    external-interrupts,
-                    i2c,
-                    spi,
-                    " \
-                -p ariel-os-nrf
-
-      - name: cargo test for STM32
-        run: |
-            RUSTDOCFLAGS='--cfg context="stm32wb55rgvx"' RUSTFLAGS='-D warnings --cfg context="stm32wb55rgvx"' cargo test \
-                --features "
-                    embassy-stm32/stm32wb55rg,
-                    external-interrupts,
-                    i2c,
-                    spi,
-                    " \
-                -p ariel-os-stm32
+      - name: Run host-side crate tests
+        run: laze build --builders host --multiple-tasks --global --keep-going=0 test
 
   lint:
     runs-on: ubuntu-latest

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -68,6 +68,7 @@ contexts:
         pool: console
         always: true
         cmd: >-
+          test "${SKIP_CARGO_BUILD}" = "1" && exit 0;
           cd ${relpath} && ${CARGO_ENV} cargo ${CARGO_TOOLCHAIN} ${CARGO_ARGS} build --${PROFILE} ${FEATURES}
           && cp ${relroot}/${build-dir}/bin/${builder}/cargo/${RUSTC_TARGET}/${PROFILE}/${riot_binary} ${relroot}/${out}
 
@@ -437,7 +438,7 @@ modules:
           - ariel-os/defmt
         RUSTFLAGS:
           - -Clink-arg=-Tdefmt.x
-        ESPFLASH_LOG_FORMAT: '--log-format defmt'
+        ESPFLASH_LOG_FORMAT: "--log-format defmt"
         CARGO_ENV:
           # For some reason, `sccache` makes the build not realize changes to
           # `DEFMT_LOG`. Painful as it is, hard-disable `sccache` here.
@@ -837,6 +838,25 @@ modules:
       global:
         FEATURES:
           - ariel-os/semihosting
+
+  - name: host-test-only
+    help: This application produces no .elf (it only has tests)
+    context:
+      - host
+    env:
+      global:
+        SKIP_CARGO_BUILD: "1"
+        RUSTFLAGS:
+          - -Dwarnings
+    tasks:
+      test:
+        help: runs `cargo test` for this crate
+        export:
+          - RUSTFLAGS
+          - RUSTDOCFLAGS
+        build: false
+        cmd:
+          - cd ${appdir} && cargo test --features _test
 
 builders:
   # host builder (for housekeeping tasks)

--- a/src/ariel-os-embassy-common/Cargo.toml
+++ b/src/ariel-os-embassy-common/Cargo.toml
@@ -29,3 +29,5 @@ i2c = ["dep:fugit"]
 spi = ["dep:fugit"]
 
 defmt = ["dep:defmt", "fugit?/defmt"]
+
+_test = ["i2c", "spi", "external-interrupts"]

--- a/src/ariel-os-embassy-common/laze.yml
+++ b/src/ariel-os-embassy-common/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: crates/ariel-os-embassy-common
+    selects:
+      - host-test-only

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -116,3 +116,5 @@ defmt = [
   "ariel-os-embassy-common/defmt",
   "usbd-hid?/defmt",
 ]
+
+_test = ["executor-none", "i2c", "spi", "external-interrupts"]

--- a/src/ariel-os-embassy/laze.yml
+++ b/src/ariel-os-embassy/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: crates/ariel-os-embassy
+    selects:
+      - host-test-only

--- a/src/ariel-os-identity/Cargo.toml
+++ b/src/ariel-os-identity/Cargo.toml
@@ -11,3 +11,7 @@ workspace = true
 [dependencies]
 ariel-os-embassy = { workspace = true }
 ariel-os-embassy-common = { workspace = true }
+
+
+[features]
+_test = ["ariel-os-embassy/executor-none"]

--- a/src/ariel-os-identity/laze.yml
+++ b/src/ariel-os-identity/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: crates/ariel-os-identity
+    selects:
+      - host-test-only

--- a/src/ariel-os-macros/Cargo.toml
+++ b/src/ariel-os-macros/Cargo.toml
@@ -31,3 +31,6 @@ trybuild = "1.0.89"
 
 [lib]
 proc-macro = true
+
+[features]
+_test = []

--- a/src/ariel-os-macros/laze.yml
+++ b/src/ariel-os-macros/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: crates/ariel-os-macros
+    selects:
+      - host-test-only

--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -74,3 +74,5 @@ defmt = ["dep:defmt", "embassy-nrf/defmt"]
 
 ## Enables the interrupt executor.
 executor-interrupt = ["embassy-executor/executor-interrupt"]
+
+_test = ["embassy-nrf/nrf52840", "external-interrupts", "i2c", "spi"]

--- a/src/ariel-os-nrf/laze.yml
+++ b/src/ariel-os-nrf/laze.yml
@@ -1,0 +1,10 @@
+apps:
+  - name: crates/ariel-os-nrf
+    selects:
+      - host-test-only
+    env:
+      global:
+        RUSTFLAGS:
+          - '--cfg context="nrf52840"'
+        RUSTDOCFLAGS:
+          - '--cfg context="nrf52840"'

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -77,3 +77,5 @@ wifi-cyw43 = [
 
 ## Enables the interrupt executor.
 executor-interrupt = ["embassy-executor/executor-interrupt"]
+
+_test = ["embassy-rp/rp2040", "external-interrupts", "i2c", "spi"]

--- a/src/ariel-os-rp/laze.yml
+++ b/src/ariel-os-rp/laze.yml
@@ -1,0 +1,10 @@
+apps:
+  - name: crates/ariel-os-rp
+    selects:
+      - host-test-only
+    env:
+      global:
+        RUSTFLAGS:
+          - '--cfg context="rp2040"'
+        RUSTDOCFLAGS:
+          - '--cfg context="rp2040"'

--- a/src/ariel-os-runqueue/Cargo.toml
+++ b/src/ariel-os-runqueue/Cargo.toml
@@ -16,3 +16,6 @@ defmt = { workspace = true, optional = true }
 # https://hacspec.org/book/quick_start/intro.html#setup-the-crate-you-want-to-verify
 [target.'cfg(hax)'.dependencies]
 hax-lib = { git = "https://github.com/hacspec/hax", rev = "cc29a3f8c0eee80a1682be78cb3b0447a0257d5b" }
+
+[features]
+_test = []

--- a/src/ariel-os-runqueue/laze.yml
+++ b/src/ariel-os-runqueue/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: crates/ariel-os-runqueue
+    selects:
+      - host-test-only

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -67,3 +67,5 @@ defmt = ["dep:defmt", "embassy-stm32/defmt"]
 
 ## Enables the interrupt executor.
 executor-interrupt = ["embassy-executor/executor-interrupt"]
+
+_test = ["embassy-stm32/stm32wb55rg", "external-interrupts", "i2c", "spi"]

--- a/src/ariel-os-stm32/laze.yml
+++ b/src/ariel-os-stm32/laze.yml
@@ -1,0 +1,10 @@
+apps:
+  - name: crates/ariel-os-stm32
+    selects:
+      - host-test-only
+    env:
+      global:
+        RUSTFLAGS:
+          - '--cfg context="stm32wb55rgvx"'
+        RUSTDOCFLAGS:
+          - '--cfg context="stm32wb55rgvx"'

--- a/src/ariel-os-threads/Cargo.toml
+++ b/src/ariel-os-threads/Cargo.toml
@@ -56,3 +56,5 @@ multi-core = [
   "embassy-rp/fifo-handler",
 ]
 core-affinity = ["multi-core"]
+
+_test = []

--- a/src/ariel-os-threads/laze.yml
+++ b/src/ariel-os-threads/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: crates/ariel-os-threads
+    selects:
+      - host-test-only

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -138,3 +138,6 @@ executor-thread = ["ariel-os-embassy/executor-thread", "threading"]
 # Don't start any executor automatically.
 # *Used for internal testing only.*
 executor-none = ["ariel-os-embassy/executor-none"]
+
+# features needed for `cargo test`
+_test = ["i2c", "no-boards", "spi", "external-interrupts"]

--- a/src/ariel-os/laze.yml
+++ b/src/ariel-os/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: crates/ariel-os
+    selects:
+      - host-test-only

--- a/src/laze.yml
+++ b/src/laze.yml
@@ -1,2 +1,13 @@
 subdirs:
+  - ariel-os
+  - ariel-os-embassy
+  - ariel-os-embassy-common
+  - ariel-os-identity
+  - ariel-os-macros
+  - ariel-os-nrf
+  - ariel-os-rp
   - ariel-os-rt
+  - ariel-os-runqueue
+  - ariel-os-stm32
+  - ariel-os-threads
+  - lib

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -38,3 +38,4 @@ log = { version = "0.4", optional = true }
 [features]
 defmt = ["defmt-or-log/defmt", "dep:defmt"]
 log = ["defmt-or-log/log", "dep:log"]
+_test = []

--- a/src/lib/coapcore/laze.yml
+++ b/src/lib/coapcore/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: crates/coapcore
+    selects:
+      - host-test-only

--- a/src/lib/laze.yml
+++ b/src/lib/laze.yml
@@ -1,0 +1,4 @@
+subdirs:
+  - coapcore
+  - rbi
+  - ringbuffer

--- a/src/lib/rbi/Cargo.toml
+++ b/src/lib/rbi/Cargo.toml
@@ -13,3 +13,6 @@ description = "A FIFO index queue that can be used for implementing a ring buffe
 workspace = true
 
 [dependencies]
+
+[features]
+_test = []

--- a/src/lib/rbi/laze.yml
+++ b/src/lib/rbi/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: crates/rbi
+    selects:
+      - host-test-only

--- a/src/lib/ringbuffer/Cargo.toml
+++ b/src/lib/ringbuffer/Cargo.toml
@@ -10,3 +10,6 @@ workspace = true
 
 [dependencies]
 rbi = { path = "../rbi" }
+
+[features]
+_test = []

--- a/src/lib/ringbuffer/laze.yml
+++ b/src/lib/ringbuffer/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: crates/ringbuffer
+    selects:
+      - host-test-only


### PR DESCRIPTION
# Description

This PR:

- moves the necessary features for `cargo test`ing each crate into  `ci` features
- creates test-only `laze` "apps"
- creates a `host-test-only` laze module that runs `cargo test`
- makes CI use this

The main benefit is that users can now locally do `laze build -b host test`.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
