### PR TITLE
refactor(threading)!: use "TID" instead of "PID" for threads

### DIFF
--- a/examples/threading-channel/src/main.rs
+++ b/examples/threading-channel/src/main.rs
@@ -9,14 +9,14 @@ static CHANNEL: Channel<u8> = Channel::new();
 
 #[ariel_os::thread(autostart)]
 fn thread0() {
-    let my_id = ariel_os::thread::current_pid().unwrap();
+    let my_id = ariel_os::thread::current_tid().unwrap();
     info!("[Thread {}] Sending a message...", my_id);
     CHANNEL.send(&42);
 }
 
 #[ariel_os::thread(autostart, stacksize = 4096, priority = 2)]
 fn thread1() {
-    let my_id = ariel_os::thread::current_pid().unwrap();
+    let my_id = ariel_os::thread::current_tid().unwrap();
     info!("[Thread {}] Waiting to receive a message...", my_id);
     let recv = CHANNEL.recv();
     info!(

--- a/examples/threading-event/src/main.rs
+++ b/examples/threading-event/src/main.rs
@@ -8,7 +8,7 @@ use ariel_os::thread::{sync::Event, ThreadId};
 static EVENT: Event = Event::new();
 
 fn waiter() {
-    let my_id = ariel_os::thread::current_pid().unwrap();
+    let my_id = ariel_os::thread::current_tid().unwrap();
     let my_prio = ariel_os::thread::get_priority(my_id).unwrap();
     info!("[{:?}@{}] Waiting for event...", my_id, my_prio);
     EVENT.wait();
@@ -42,7 +42,7 @@ fn thread3() {
 
 #[ariel_os::thread(autostart, priority = 1)]
 fn thread4() {
-    let my_id = ariel_os::thread::current_pid().unwrap();
+    let my_id = ariel_os::thread::current_tid().unwrap();
     let my_prio = ariel_os::thread::get_priority(my_id).unwrap();
     info!("[{:?}@{}] Setting event...", my_id, my_prio);
     EVENT.set();

--- a/examples/threading-multicore/src/main.rs
+++ b/examples/threading-multicore/src/main.rs
@@ -11,15 +11,15 @@ use ariel_os::{
 #[ariel_os::thread(autostart, affinity = CoreAffinity::one(CoreId::new(1)))]
 fn thread0() {
     let core = ariel_os::thread::core_id();
-    let pid = ariel_os::thread::current_pid().unwrap();
-    info!("Hello from {:?} on {:?}", pid, core);
+    let tid = ariel_os::thread::current_tid().unwrap();
+    info!("Hello from {:?} on {:?}", tid, core);
     loop {}
 }
 
 #[ariel_os::thread(autostart)]
 fn thread1() {
     let core = ariel_os::thread::core_id();
-    let pid = ariel_os::thread::current_pid().unwrap();
-    info!("Hello from {:?} on {:?}", pid, core);
+    let tid = ariel_os::thread::current_tid().unwrap();
+    info!("Hello from {:?} on {:?}", tid, core);
     loop {}
 }

--- a/src/ariel-os-embassy/src/asynch/blocker.rs
+++ b/src/ariel-os-embassy/src/asynch/blocker.rs
@@ -1,6 +1,6 @@
 //! Provides a [`block_on()`] function to use futures from a thread.
 
-use ariel_os_threads::{current_pid, flags, flags::ThreadFlags, ThreadId};
+use ariel_os_threads::{current_tid, flags, flags::ThreadFlags, ThreadId};
 use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
@@ -32,7 +32,7 @@ pub fn block_on<F: Future>(mut fut: F) -> F::Output {
     // safety: we don't move the future after this line.
     let mut fut = unsafe { Pin::new_unchecked(&mut fut) };
 
-    let raw_waker = RawWaker::new(usize::from(current_pid().unwrap()) as *const (), &VTABLE);
+    let raw_waker = RawWaker::new(usize::from(current_tid().unwrap()) as *const (), &VTABLE);
     let waker = unsafe { Waker::from_raw(raw_waker) };
     let mut cx = Context::from_waker(&waker);
     loop {

--- a/src/ariel-os-embassy/src/thread_executor.rs
+++ b/src/ariel-os-embassy/src/thread_executor.rs
@@ -5,7 +5,7 @@
 
 use core::marker::PhantomData;
 
-use ariel_os_threads::{current_pid, thread_flags, thread_flags::ThreadFlags, ThreadId};
+use ariel_os_threads::{current_tid, thread_flags, thread_flags::ThreadFlags, ThreadId};
 use embassy_executor::{raw, Spawner};
 
 // This is only used between `__pender` and `Executor::run( )`, actual flag
@@ -42,7 +42,7 @@ impl Executor {
     /// This function panics when called without a running thread.
     #[expect(clippy::new_without_default)]
     pub fn new() -> Self {
-        let current_thread = current_pid().unwrap();
+        let current_thread = current_tid().unwrap();
         Self {
             inner: raw::Executor::new(usize::from(current_thread) as *mut ()),
             not_send: PhantomData,

--- a/src/ariel-os-runqueue/src/runqueue.rs
+++ b/src/ariel-os-runqueue/src/runqueue.rs
@@ -71,7 +71,7 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
         }
     }
 
-    /// Adds thread with pid `n` to runqueue number `rq`.
+    /// Adds thread with tid `n` to runqueue number `rq`.
     pub fn add(&mut self, n: ThreadId, rq: RunqueueId) {
         debug_assert!(usize::from(n) < N_THREADS);
         debug_assert!(usize::from(rq) < N_QUEUES);
@@ -84,7 +84,7 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
         self.queues.peek_head(rq.0).map(ThreadId::new)
     }
 
-    /// Removes thread with pid `n` from runqueue number `rq`.
+    /// Removes thread with tid `n` from runqueue number `rq`.
     ///
     /// # Panics
     ///
@@ -101,22 +101,22 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
         }
     }
 
-    /// Removes thread with pid `n`.
+    /// Removes thread with tid `n`.
     pub fn del(&mut self, n: ThreadId) {
         if let Some(empty_runqueue) = self.queues.del(n.0) {
             self.bitcache &= !(1 << empty_runqueue);
         }
     }
 
-    /// Returns the pid that should run next.
+    /// Returns the tid that should run next.
     ///
     /// Returns the next runnable thread of
     /// the runqueue with the highest index.
     pub fn get_next(&self) -> Option<ThreadId> {
-        self.get_next_with_rq().map(|(pid, _)| pid)
+        self.get_next_with_rq().map(|(tid, _)| tid)
     }
 
-    /// Returns the pid that should run next and the runqueue it is in.
+    /// Returns the tid that should run next and the runqueue it is in.
     pub fn get_next_with_rq(&self) -> Option<(ThreadId, RunqueueId)> {
         let rq_ffs = ffs(self.bitcache);
         if rq_ffs == 0 {

--- a/src/ariel-os-threads/src/arch/riscv.rs
+++ b/src/ariel-os-threads/src/arch/riscv.rs
@@ -131,26 +131,26 @@ unsafe fn sched(trap_frame: &mut TrapFrame) {
             #[cfg(feature = "multi-core")]
             scheduler.add_current_thread_to_rq();
 
-            let next_pid = match scheduler.get_next_pid() {
-                Some(pid) => pid,
+            let next_tid = match scheduler.get_next_tid() {
+                Some(tid) => tid,
                 None => {
                     Cpu::wfi();
                     return false;
                 }
             };
 
-            if let Some(current_pid) = scheduler.current_pid() {
-                if next_pid == current_pid {
+            if let Some(current_tid) = scheduler.current_tid() {
+                if next_tid == current_tid {
                     return true;
                 }
                 copy_registers(
                     trap_frame,
-                    &mut scheduler.threads[usize::from(current_pid)].data,
+                    &mut scheduler.threads[usize::from(current_tid)].data,
                 );
             }
-            *scheduler.current_pid_mut() = Some(next_pid);
+            *scheduler.current_tid_mut() = Some(next_tid);
 
-            copy_registers(&scheduler.get_unchecked(next_pid).data, trap_frame);
+            copy_registers(&scheduler.get_unchecked(next_tid).data, trap_frame);
             true
         }) {
             break;

--- a/src/ariel-os-threads/src/arch/xtensa.rs
+++ b/src/ariel-os-threads/src/arch/xtensa.rs
@@ -106,19 +106,19 @@ unsafe fn sched(trap_frame: &mut TrapFrame) {
             #[cfg(feature = "multi-core")]
             scheduler.add_current_thread_to_rq();
 
-            let Some(next_pid) = scheduler.get_next_pid() else {
+            let Some(next_tid) = scheduler.get_next_tid() else {
                 return false;
             };
 
-            if let Some(current_pid) = scheduler.current_pid() {
-                if next_pid == current_pid {
+            if let Some(current_tid) = scheduler.current_tid() {
+                if next_tid == current_tid {
                     return true;
                 }
-                scheduler.threads[usize::from(current_pid)].data = *trap_frame;
+                scheduler.threads[usize::from(current_tid)].data = *trap_frame;
             }
-            *scheduler.current_pid_mut() = Some(next_pid);
+            *scheduler.current_tid_mut() = Some(next_tid);
 
-            *trap_frame = scheduler.threads[usize::from(next_pid)].data;
+            *trap_frame = scheduler.threads[usize::from(next_tid)].data;
             true
         }) {
             break;

--- a/src/ariel-os-threads/src/sync/mutex.rs
+++ b/src/ariel-os-threads/src/sync/mutex.rs
@@ -42,7 +42,7 @@ impl LockState {
             let current = scheduler
                 .current()
                 .expect("Function should be called inside a thread context.");
-            (current.pid, current.prio)
+            (current.tid, current.prio)
         });
         LockState::Locked {
             waiters: ThreadList::new(),
@@ -156,10 +156,10 @@ impl<T> Mutex<T> {
                     scheduler.set_priority(*owner_id, *owner_prio);
                 });
                 // Pop next thread from waitlist so that it can acquire the mutex.
-                if let Some((pid, _)) = waiters.pop(cs) {
+                if let Some((tid, _)) = waiters.pop(cs) {
                     SCHEDULER.with_mut_cs(cs, |scheduler| {
-                        *owner_id = pid;
-                        *owner_prio = scheduler.get_unchecked(pid).prio;
+                        *owner_id = tid;
+                        *owner_prio = scheduler.get_unchecked(tid).prio;
                     });
                 } else {
                     // Unlock if waitlist was empty.

--- a/src/ariel-os-threads/src/thread.rs
+++ b/src/ariel-os-threads/src/thread.rs
@@ -15,7 +15,7 @@ pub struct Thread {
     pub prio: RunqueueId,
     /// Id of the thread between 0..[`super::THREADS_NUMOF`].
     /// Ids are unique while a thread is alive but reused after a thread finished.
-    pub pid: ThreadId,
+    pub tid: ThreadId,
     /// Flags set for the thread.
     pub flags: ThreadFlags,
     /// Arch-specific thread data.
@@ -57,7 +57,7 @@ impl Thread {
             data: Cpu::DEFAULT_THREAD_DATA,
             flags: 0,
             prio: RunqueueId::new(0),
-            pid: ThreadId::new(0),
+            tid: ThreadId::new(0),
             #[cfg(feature = "core-affinity")]
             core_affinity: crate::CoreAffinity::no_affinity(),
         }

--- a/src/ariel-os-threads/src/thread_flags.rs
+++ b/src/ariel-os-threads/src/thread_flags.rs
@@ -113,7 +113,7 @@ impl Scheduler {
             thread.flags &= !mask;
             Some(mask)
         } else {
-            let thread_id = thread.pid;
+            let thread_id = thread.tid;
             self.set_state(thread_id, ThreadState::FlagBlocked(WaitMode::All(mask)));
             None
         }
@@ -126,7 +126,7 @@ impl Scheduler {
             thread.flags &= !res;
             Some(res)
         } else {
-            let thread_id = thread.pid;
+            let thread_id = thread.tid;
             self.set_state(thread_id, ThreadState::FlagBlocked(WaitMode::Any(mask)));
             None
         }
@@ -141,7 +141,7 @@ impl Scheduler {
             thread.flags &= !res;
             Some(res)
         } else {
-            let thread_id = thread.pid;
+            let thread_id = thread.tid;
             self.set_state(thread_id, ThreadState::FlagBlocked(WaitMode::Any(mask)));
             None
         }

--- a/src/ariel-os-threads/src/threadlist.rs
+++ b/src/ariel-os-threads/src/threadlist.rs
@@ -24,7 +24,7 @@ impl ThreadList {
     /// Panics if this is called outside of a thread context.
     pub fn put_current(&mut self, cs: CriticalSection, state: ThreadState) -> Option<RunqueueId> {
         SCHEDULER.with_mut_cs(cs, |mut scheduler| {
-            let &mut Thread { pid, prio, .. } = scheduler
+            let &mut Thread { tid, prio, .. } = scheduler
                 .current()
                 .expect("Function should be called inside a thread context.");
             let mut curr = None;
@@ -36,18 +36,18 @@ impl ThreadList {
                 curr = next;
                 next = scheduler.thread_blocklist[usize::from(n)];
             }
-            scheduler.thread_blocklist[usize::from(pid)] = next;
+            scheduler.thread_blocklist[usize::from(tid)] = next;
             let inherit_priority = match curr {
                 Some(curr) => {
-                    scheduler.thread_blocklist[usize::from(curr)] = Some(pid);
+                    scheduler.thread_blocklist[usize::from(curr)] = Some(tid);
                     None
                 }
                 None => {
-                    self.head = Some(pid);
+                    self.head = Some(tid);
                     Some(prio)
                 }
             };
-            scheduler.set_state(pid, state);
+            scheduler.set_state(tid, state);
             inherit_priority
         })
     }

--- a/tests/benchmarks/bench_sched_flags/src/main.rs
+++ b/tests/benchmarks/bench_sched_flags/src/main.rs
@@ -5,18 +5,18 @@
 
 use ariel_os::{
     debug::log::*,
-    thread::{current_pid, sync::Channel, thread_flags, ThreadId},
+    thread::{current_tid, sync::Channel, thread_flags, ThreadId},
 };
 
 static ID_EXCHANGE: Channel<ThreadId> = Channel::new();
 
 #[ariel_os::thread(autostart)]
 fn thread0() {
-    let target_pid = ID_EXCHANGE.recv();
-    ID_EXCHANGE.send(&current_pid().unwrap());
+    let target_tid = ID_EXCHANGE.recv();
+    ID_EXCHANGE.send(&current_tid().unwrap());
 
     match ariel_os::bench::benchmark(1000, || {
-        thread_flags::set(target_pid, 1);
+        thread_flags::set(target_tid, 1);
         thread_flags::wait_any(1);
     }) {
         Ok(ticks) => info!("took {} ticks per iteration", ticks),
@@ -26,11 +26,11 @@ fn thread0() {
 
 #[ariel_os::thread(autostart)]
 fn thread1() {
-    ID_EXCHANGE.send(&current_pid().unwrap());
-    let target_pid = ID_EXCHANGE.recv();
+    ID_EXCHANGE.send(&current_tid().unwrap());
+    let target_tid = ID_EXCHANGE.recv();
 
     loop {
-        thread_flags::set(target_pid, 1);
+        thread_flags::set(target_tid, 1);
         thread_flags::wait_any(1);
     }
 }

--- a/tests/threading-dynamic-prios/src/main.rs
+++ b/tests/threading-dynamic-prios/src/main.rs
@@ -16,20 +16,20 @@ static TEMP_THREAD1_PRIO: RunqueueId = RunqueueId::new(5);
 
 #[ariel_os::thread(autostart, priority = 2)]
 fn thread0() {
-    let pid = ariel_os::thread::current_pid().unwrap();
+    let tid = ariel_os::thread::current_tid().unwrap();
     assert_eq!(
-        ariel_os::thread::get_priority(pid),
+        ariel_os::thread::get_priority(tid),
         Some(RunqueueId::new(2))
     );
 
     assert_eq!(RUN_ORDER.fetch_add(1, Ordering::AcqRel), 0);
 
-    let thread1_pid = ThreadId::new(1);
+    let thread1_tid = ThreadId::new(1);
     assert_eq!(
-        ariel_os::thread::get_priority(thread1_pid),
+        ariel_os::thread::get_priority(thread1_tid),
         Some(RunqueueId::new(1))
     );
-    ariel_os::thread::set_priority(thread1_pid, TEMP_THREAD1_PRIO);
+    ariel_os::thread::set_priority(thread1_tid, TEMP_THREAD1_PRIO);
 
     // thread1 runs now.
 
@@ -43,8 +43,8 @@ fn thread1() {
     // Thread can only run after thread0 increased its prio.
     assert_eq!(RUN_ORDER.fetch_add(1, Ordering::AcqRel), 1);
     // Prio is the temp increased prio.
-    let pid = ariel_os::thread::current_pid().unwrap();
-    assert_eq!(ariel_os::thread::get_priority(pid), Some(TEMP_THREAD1_PRIO));
+    let tid = ariel_os::thread::current_tid().unwrap();
+    assert_eq!(ariel_os::thread::get_priority(tid), Some(TEMP_THREAD1_PRIO));
     // Other thread prios didn't change.
     assert_eq!(
         ariel_os::thread::get_priority(ThreadId::new(0)),
@@ -52,7 +52,7 @@ fn thread1() {
     );
 
     // Reset priority.
-    ariel_os::thread::set_priority(pid, RunqueueId::new(1));
+    ariel_os::thread::set_priority(tid, RunqueueId::new(1));
 
     unreachable!("Core should be blocked by higher prio thread.")
 }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
PIDs are for processes, which of cours we don't have, so this PR replaces occurrences of "pid" with "tid" (thread ID).
The only remaining occurrences are in test files where "PID" comes from an external library, and from a configuration file which specifies an external symbol.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
