### PR TITLE
chore(deps): another embedded-test quirk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,7 +1939,7 @@ dependencies = [
 [[package]]
 name = "embedded-test"
 version = "0.5.0"
-source = "git+https://github.com/ariel-os/embedded-test?branch=v0.5.0%2Bariel-os#b305fc1f3cb2ea7b7496ccada38fdd476ed06678"
+source = "git+https://github.com/ariel-os/embedded-test?branch=v0.5.0%2Bariel-os#a5681ead370bc3485dadafb1f1cdf2b6f086c48b"
 dependencies = [
  "embassy-executor",
  "embedded-test-macros",
@@ -1952,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "embedded-test-macros"
 version = "0.5.0"
-source = "git+https://github.com/ariel-os/embedded-test?branch=v0.5.0%2Bariel-os#b305fc1f3cb2ea7b7496ccada38fdd476ed06678"
+source = "git+https://github.com/ariel-os/embedded-test?branch=v0.5.0%2Bariel-os#a5681ead370bc3485dadafb1f1cdf2b6f086c48b"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
# Description

While updating `ariel-os-hello`, I realized that the embedded-test default features include `panic-handler`, which collide with the `ariel-os` feature, as Ariel rings a panic handler.
So, the `panic-handler` feature is now ignored when the `ariel-os` feature is enabled, in our embedded-test fork.

This PR changes our `Cargo.lock` to that fork's HEAD.

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
