### PR TITLE
docs(book): reorganize the developer guide section

### DIFF
--- a/book/src/COC_reporting.md
+++ b/book/src/COC_reporting.md
@@ -1,3 +1,5 @@
+## Reporting Guidelines
+
 If you believe someone is violating the code of conduct we ask that you
 report it to us by emailing <conduct@ariel-os.org>.
 

--- a/book/src/CODE_OF_CONDUCT.md
+++ b/book/src/CODE_OF_CONDUCT.md
@@ -1,1 +1,3 @@
 {{#include ../../CODE_OF_CONDUCT.md}}
+
+{{#include COC_reporting.md}}

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -4,8 +4,6 @@
 - [Introduction](./introduction.md)
 - [Hardware & Functionality Support](./hardware_functionality_support.md)
 - [Multithreading](./multithreading.md)
-- [Code of Conduct](./CODE_OF_CONDUCT.md)
-  - [Reporting Guidelines](./COC_reporting.md)
 
 # User Guide
 
@@ -19,5 +17,5 @@
 
 # Developer Guide
 
-- [Appendices](./appendices.md)
-  - [Coding Conventions](./coding-conventions.md)
+- [Coding Conventions](./coding-conventions.md)
+- [Code of Conduct](./CODE_OF_CONDUCT.md)

--- a/book/src/appendices.md
+++ b/book/src/appendices.md
@@ -1,1 +1,0 @@
-# Appendices


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This merges the COC reporting page with the main COC one so it doesn't take two lines in the book sidebar.
In addition, this moves the Coding Conventions out of the Appendices chapter, which is removed. 

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
