### PR TITLE
feat(coap): add ACE EDHOC profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,6 +1107,7 @@ dependencies = [
  "log",
  "minicbor 0.25.1",
  "minicbor-adapters",
+ "p256",
  "rand_core",
 ]
 
@@ -1456,6 +1457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1510,6 +1512,19 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "nrf52",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
 ]
 
 [[package]]
@@ -3488,23 +3503,22 @@ version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29be4f60e41fde478b36998b88821946aafac540e53591e76db53921a0cc225b"
 dependencies = [
- "minicbor-derive",
+ "minicbor-derive 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "minicbor"
 version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0452a60c1863c1f50b5f77cd295e8d2786849f35883f0b9e18e7e6e1b5691b0"
+source = "git+https://github.com/chrysn-pull-requests/minicbor?branch=negativ-indices#83946a374f54c59923bb6340d83e893294495aad"
 dependencies = [
- "minicbor-derive",
+ "minicbor-derive 0.15.3 (git+https://github.com/chrysn-pull-requests/minicbor?branch=negativ-indices)",
 ]
 
 [[package]]
 name = "minicbor-adapters"
-version = "0.0.1"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c40bdee1568d1b9eaa6116cd94e3325323cea6ef916013dd7b48568f25ea122"
+checksum = "4d622b25f962a1d24f2ec19702fa9ad3b13f494e100c15fa29aa14312b68280e"
 dependencies = [
  "cboritem",
  "heapless 0.8.0",
@@ -3516,6 +3530,16 @@ name = "minicbor-derive"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.15.3"
+source = "git+https://github.com/chrysn-pull-requests/minicbor?branch=negativ-indices#83946a374f54c59923bb6340d83e893294495aad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3790,8 +3814,10 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
+ "ecdsa",
  "elliptic-curve",
  "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -4274,6 +4300,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4643,6 +4679,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
 
 [[package]]
 name = "siphasher"

--- a/_typos.toml
+++ b/_typos.toml
@@ -5,6 +5,8 @@ extint = "extint"     # External interrupt
 synopsys = "synopsys" # Manufacturer name
 COSE = "COSE"         # A technology we use
 
+negativ = "negativ" # Typo in a branch name in ariel-os-cargo.toml
+
 [default.extend-identifiers]
 celcius = "celcius" # Until embedded-aht20 is fixed
 

--- a/ariel-os-cargo.toml
+++ b/ariel-os-cargo.toml
@@ -39,3 +39,6 @@ try-lock = { git = "https://github.com/seanmonstar/try-lock", rev = "a1aadfac984
 
 # added Ariel OS support
 embedded-test = { git = "https://github.com/ariel-os/embedded-test", branch = "v0.6.0+ariel-os" }
+
+# see src/lib/coapcore/Cargo.toml: Support for negative integers <https://github.com/twittner/minicbor/pull/9>
+minicbor = { git = "https://github.com/chrysn-pull-requests/minicbor", branch = "negativ-indices" }

--- a/deny.toml
+++ b/deny.toml
@@ -57,6 +57,8 @@ allow-git = [
   "https://github.com/seanmonstar/try-lock",
   "https://gitlab.com/etonomy/riot-module-examples",
   "https://github.com/Nugine/const-str",
+  # while https://github.com/twittner/minicbor/pull/9 is open
+  "https://github.com/chrysn-pull-requests/minicbor",
 ]
 
 [sources.allow-org]

--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -90,14 +90,13 @@ pub async fn coap_run(handler: impl coap_handler::Handler + coap_handler::Report
     let own_credential = lakers::Credential::parse_ccs(demo_setup::DEVICE_CREDENTIAL)
         .expect("Credential should be processable");
 
-    let unauthenticated_scope: &[u8] = &demo_setup::UNAUTHENTICATED_SCOPE;
-    let unauthenticated_scope = coapcore::scope::AifValue::try_from(unauthenticated_scope)
-        .expect("hard-coded scope fits this type")
-        .into();
+    let unauthenticated_scope =
+        coapcore::scope::AifValue::parse(&demo_setup::UNAUTHENTICATED_SCOPE)
+            .expect("hard-coded scope fits this type")
+            .into();
     let admin_key = lakers::Credential::parse_ccs(demo_setup::ADMIN_CREDENTIAL)
         .expect("hard-coded credential fits this type");
-    let admin_scope: &[u8] = &demo_setup::ADMIN_SCOPE;
-    let admin_scope = coapcore::scope::AifValue::try_from(admin_scope)
+    let admin_scope = coapcore::scope::AifValue::parse(&demo_setup::ADMIN_SCOPE)
         .expect("hard-coded scope fits this type")
         .into();
 

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -29,8 +29,14 @@ lakers-crypto-rustcrypto = "0.7.2"
 liboscore = "0.2.2"
 liboscore-msgbackend = "0.2.2"
 
+# actually we depend on <https://github.com/twittner/minicbor/pull/9> so it
+# should be
+#     minicbor = { git = "https://github.com/chrysn-pull-requests/minicbor", branch = "negativ-indices", features = ["derive"] }
+# and it could be patched locally because it is a non-pub dependency, but as
+# minicbor-adapters needs to use the same types, this still has to go into
+# patch.crates-io to also catch minicbor-adapters.
 minicbor = { version = "0.25.1", features = ["derive"] }
-minicbor-adapters = "0.0.1"
+minicbor-adapters = "0.0.3"
 heapless = "0.8.0"
 defmt-or-log = { version = "0.2.1", default-features = false }
 defmt = { workspace = true, optional = true }
@@ -43,6 +49,8 @@ document-features = "0.2.10"
 # dependencies.
 ccm = { version = "0.5.0", default-features = false }
 aes = { version = "0.8.4", default-features = false }
+
+p256 = { version = "0.13.2", features = ["ecdsa"], default-features = false }
 
 [features]
 #! # Cargo features

--- a/src/lib/coapcore/src/ace.rs
+++ b/src/lib/coapcore/src/ace.rs
@@ -147,7 +147,6 @@ type SignedCwt<'a> = CoseSign1<'a>;
 ///
 /// Full attribute references are in the [CWT Claims
 /// registry](https://www.iana.org/assignments/cwt/cwt.xhtml#claims-registry).
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(minicbor::Decode, Debug)]
 #[allow(
     dead_code,
@@ -182,7 +181,6 @@ pub struct CwtClaimsSet<'a> {
 /// of](https://www.rfc-editor.org/rfc/rfc8747.html#name-confirmation-claim) "At most one of the
 /// `COSE_Key` and `Encrypted_COSE_Key` […] may be present", doesn't rule out that items without
 /// key material can't be attached.
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(minicbor::Decode, Debug)]
 #[cbor(map)]
 #[non_exhaustive]

--- a/src/lib/coapcore/src/ace.rs
+++ b/src/lib/coapcore/src/ace.rs
@@ -86,6 +86,10 @@ impl HeaderMap<'_> {
 /// entries.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(minicbor::Decode, Debug)]
+#[allow(
+    dead_code,
+    reason = "Presence of the item makes CBOR derive tolerate the item"
+)]
 #[cbor(map)]
 #[non_exhaustive]
 pub struct CoseKey<'a> {
@@ -145,27 +149,17 @@ type SignedCwt<'a> = CoseSign1<'a>;
 /// registry](https://www.iana.org/assignments/cwt/cwt.xhtml#claims-registry).
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(minicbor::Decode, Debug)]
+#[allow(
+    dead_code,
+    reason = "Presence of the item makes CBOR derive tolerate the item"
+)]
 #[cbor(map)]
 #[non_exhaustive]
 pub struct CwtClaimsSet<'a> {
     #[n(3)]
     pub(crate) aud: Option<&'a str>,
-    #[cfg_attr(
-        not(defmt),
-        expect(
-            dead_code,
-            reason = "Presence of the item makes CBOR derive tolerate the item"
-        )
-    )]
     #[n(4)]
     exp: u64,
-    #[cfg_attr(
-        not(defmt),
-        expect(
-            dead_code,
-            reason = "Presence of the item makes CBOR derive tolerate the item"
-        )
-    )]
     #[n(6)]
     iat: u64,
     #[b(8)]
@@ -208,16 +202,13 @@ struct Cnf<'a> {
 /// has the full set in case it gets extended.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(minicbor::Decode, Debug)]
+#[allow(
+    dead_code,
+    reason = "Presence of the item makes CBOR derive tolerate the item"
+)]
 #[cbor(map)]
 #[non_exhaustive]
 struct OscoreInputMaterial<'a> {
-    #[cfg_attr(
-        not(defmt),
-        expect(
-            dead_code,
-            reason = "Presence of the item makes CBOR derive tolerate the item"
-        )
-    )]
     #[cbor(b(0), with = "minicbor::bytes")]
     id: &'a [u8],
     #[cbor(b(2), with = "minicbor::bytes")]

--- a/src/lib/coapcore/src/ace.rs
+++ b/src/lib/coapcore/src/ace.rs
@@ -20,6 +20,8 @@ const MAX_SUPPORTED_PEER_NONCE_LEN: usize = 16;
 
 /// Maximum size a CWT processed by this module can have (at least when it needs to be copied)
 const MAX_SUPPORTED_ACCESSTOKEN_LEN: usize = 256;
+/// Maximum size of a COSE_Encrypt0 protected header (used to size the AAD buffer)
+const MAX_SUPPORTED_ENCRYPT_PROTECTED_LEN: usize = 32;
 
 /// The content of an application/ace+cbor file.
 ///
@@ -155,8 +157,8 @@ impl CoseEncrypt0<'_> {
             protected: self.protected,
             external_aad: &[],
         };
-        // FIXME: This is overkill by far; usually we get away with like 16 byte.
-        let mut aad_encoded = heapless::Vec::<u8, MAX_SUPPORTED_ACCESSTOKEN_LEN>::new();
+        const AADSIZE: usize = 1 + 1 + 8 + 1 + MAX_SUPPORTED_ENCRYPT_PROTECTED_LEN + 1;
+        let mut aad_encoded = heapless::Vec::<u8, AADSIZE>::new();
         minicbor::encode(&aad, minicbor_adapters::WriteToHeapless(&mut aad_encoded))
             .map_err(|_| CredentialErrorDetail::ConstraintExceeded)?;
         trace!("Serialized AAD: {:02x}", aad_encoded); // :02x could be :cbor

--- a/src/lib/coapcore/src/error.rs
+++ b/src/lib/coapcore/src/error.rs
@@ -1,0 +1,71 @@
+/// Error type returned from various functions that ingest any input to an authentication or
+/// authorization step.
+#[derive(Debug)]
+pub struct CredentialError {
+    #[expect(
+        dead_code,
+        reason = "This is deliberately unused: The kind is merely a debug helper, and when no logging is active, code should not behave any different no matter in which way the credential processing failed"
+    )]
+    detail: CredentialErrorDetail,
+    pub(crate) position: Option<usize>,
+}
+
+#[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
+pub(crate) enum CredentialErrorDetail {
+    /// Input data contains items that violate a protocol.
+    ///
+    /// This is somewhat fuzzy towards [`UnsupportedExtension`] if extension points are not clearly
+    /// documented or understood in a protocol.
+    ProtocolViolation,
+    /// Input data contains items that are understood in principle, but not supported by the
+    /// implementation.
+    ///
+    /// In the fuzziness towards [`ProtocolViolation`], it is preferred to err on the side of
+    /// `UnsupportedExtension`.
+    UnsupportedExtension,
+    /// Input data uses a COSE algorithm that is not supported by the implementation.
+    UnsupportedAlgorithm,
+    /// The data looks fine to a point, but exceeds the capacity of the implementation (data or
+    /// identifier too long).
+    ConstraintExceeded,
+    /// Input data is understood, but self-contradictory.
+    ///
+    /// Example: A COSE encrypted item where the nonce length does not match the algorithm's
+    /// requirements.
+    InconsistentDetails,
+    /// The peer expects to use key material which is not known to this system.
+    KeyNotPresent,
+    /// Data could be processed and keys were found, but cryptographic verification was
+    /// unsuccessful.
+    VerifyFailed,
+}
+
+impl From<CredentialErrorDetail> for CredentialError {
+    fn from(value: CredentialErrorDetail) -> Self {
+        Self {
+            detail: value,
+            position: None,
+        }
+    }
+}
+
+impl From<minicbor::decode::Error> for CredentialError {
+    fn from(_: minicbor::decode::Error) -> Self {
+        // FIXME: We could try to distinguish "extra field" (that tends to be UnsupportedExtension) from
+        // "wrong type" (that tends to be ProtocolViolation).
+        Self {
+            detail: CredentialErrorDetail::UnsupportedExtension,
+            position: None,
+        }
+    }
+}
+
+impl From<minicbor::encode::Error<minicbor_adapters::OutOfSpace>> for CredentialError {
+    fn from(_: minicbor::encode::Error<minicbor_adapters::OutOfSpace>) -> Self {
+        Self {
+            detail: CredentialErrorDetail::ConstraintExceeded,
+            position: None,
+        }
+    }
+}

--- a/src/lib/coapcore/src/iana.rs
+++ b/src/lib/coapcore/src/iana.rs
@@ -1,0 +1,25 @@
+//! Constants assigned by IANA.
+//!
+//! This includes constants that are not yet assigned, but we need some value to work with.
+//!
+//! Beware that many numbers assigned by IANA also find their way into the [`crate::ace`] module,
+//! where the minicbor map keys can use constants.
+
+/// The EDHOC External Authorization Data Registry (EAD Items)
+pub(crate) mod edhoc_ead {
+    /// ACE-OAuth Access Token
+    ///
+    /// **Not an official value yet**; described in
+    /// [Section 10.8 of the ACE-EDHOC
+    /// profile](https://datatracker.ietf.org/doc/html/draft-ietf-ace-edhoc-oscore-profile-06#section-10.8).
+    pub(crate) const ACETOKEN: u8 = 20;
+}
+
+/// The [COSE Algorithms](https://www.iana.org/assignments/cose/cose.xhtml#algorithms) registry
+pub(crate) mod cose_alg {
+    /// HMAC 256/256 (from COSE Algorithms)
+    pub(crate) const HKDF_HMAC256256: i32 = 5;
+
+    /// AES-CCM-16-64-128
+    pub(crate) const AES_CCM_16_64_128: i32 = 10;
+}

--- a/src/lib/coapcore/src/lib.rs
+++ b/src/lib/coapcore/src/lib.rs
@@ -30,6 +30,8 @@
 mod sealed;
 use sealed::{PrivateMethod, Sealed};
 
+mod iana;
+
 mod helpers;
 
 mod ace;

--- a/src/lib/coapcore/src/lib.rs
+++ b/src/lib/coapcore/src/lib.rs
@@ -43,3 +43,6 @@ pub mod seccfg;
 pub mod oluru;
 mod seccontext;
 pub use seccontext::*;
+
+mod error;
+pub use error::CredentialError;

--- a/src/lib/coapcore/src/seccontext.rs
+++ b/src/lib/coapcore/src/seccontext.rs
@@ -494,7 +494,7 @@ impl<
 
             let mut cred_i_and_authorization = None;
 
-            if let Some(lakers::EADItem { label: 20, value: Some(value), .. }) = ead_3.take() {
+            if let Some(lakers::EADItem { label: crate::iana::edhoc_ead::ACETOKEN, value: Some(value), .. }) = ead_3.take() {
                 match crate::ace::process_edhoc_token(value.as_slice(), &self.authorities) {
                     Ok(ci_and_a) => cred_i_and_authorization = Some(ci_and_a),
                     Err(e) => {
@@ -539,8 +539,8 @@ impl<
             let recipient_id = c_r.as_slice();
 
             // FIXME probe cipher suite
-            let hkdf = liboscore::HkdfAlg::from_number(5).unwrap();
-            let aead = liboscore::AeadAlg::from_number(10).unwrap();
+            let hkdf = liboscore::HkdfAlg::from_number(crate::iana::cose_alg::HKDF_HMAC256256).unwrap();
+            let aead = liboscore::AeadAlg::from_number(crate::iana::cose_alg::AES_CCM_16_64_128).unwrap();
 
             let immutables = liboscore::PrimitiveImmutables::derive(
                 hkdf,

--- a/src/lib/coapcore/src/seccontext.rs
+++ b/src/lib/coapcore/src/seccontext.rs
@@ -693,7 +693,7 @@ impl<
             .map_err(|e| {
                 error!("Sending out error:");
                 error!("{}", Debug2Format(&e));
-                e.position()
+                e.position
                     // FIXME: Could also come from processing inner
                     .map(CoAPError::bad_request_with_rbep)
                     .unwrap_or(CoAPError::bad_request())


### PR DESCRIPTION
# Description

The ACE EDHOC profile is a useful addition to coapcore as it allows having EDHOC (and thus forward secrecy) with ACE tokens.

<del>This first iteration of it uses signed CWTs instead of symmetrically encrypted CWTs – these may not be the logical first step building things up (as they are mainly useful thinking of group audiences), but it is what I can test first.</del>

[edit:] It supports both signed and encrypted CWTs. (Things Just Worked once the other case was added 🥰).

## Issues/PRs references

This builds on #690.

* This d_epends on https://github.com/twittner/minicbor/pull/9 -- consequently it adds a patch.crates-io. Let's see how responsive upstream is; the alternative is a rather awkward manual parsing of the map.
* Practical use d_epends on https://github.com/openwsn-berkeley/lakers/pull/331 (the old `quadruple_sizes` leads to kilobytes of stack usage); they might release based on that soon (either in the 0.7 series, or as a 0.8 with some breaking changes they already accumulated on main, but for which I already have the optional adjustment at hand).

[edit:] CI checks misinterpret what this means (see https://github.com/ariel-os/ariel-os/pull/691 for remedy); we can (and this branch does) work from branches, but it would be nice to get those merged at some point.

## Open Questions

* <del>As part of the patch series I'll need to overhaul the ScopeGenerator a bit, because when accepting a signed token, one has to check the audience (which is pretty much a no-op on symmetrically encrypted tokens, as their key can only be used by the AS for a single RS).</del>
  * ScopeGenerator was removed; the decrypt/verify functions now do a bit more than I'd ideally want to have in a single function, but document why that is, and a better version of ScopeGenerator (then probably: "opaque data carried between this and that method") can be reintroduced when it is better understood in the general case.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.