### PR TITLE
fix(boards): rename the ESP32 boards

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
         if: github.event_name != 'schedule'
         run: |
           source ~/source-this-first.sh
-          echo "LAZE_BUILDERS=ai-c3,espressif-esp32-c6-devkitc-1,espressif-esp32-s3-wroom-1,microbit-v2,nrf52840dk,nrf5340dk,rpi-pico,rpi-pico-w,st-nucleo-h755zi-q,st-nucleo-wb55" >> "$GITHUB_ENV"
+          echo "LAZE_BUILDERS=ai-c3,espressif-esp32-c6-devkitc-1,espressif-esp32-s3-devkitc-1,microbit-v2,nrf52840dk,nrf5340dk,rpi-pico,rpi-pico-w,st-nucleo-h755zi-q,st-nucleo-wb55" >> "$GITHUB_ENV"
 
       - name: "ariel-os compilation test"
         if: steps.result-cache.outputs.cache-hit != 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,8 +121,8 @@ dependencies = [
  "cfg-if",
  "dwm1001",
  "espressif-esp32-c6-devkitc-1",
- "espressif-esp32-s3-wroom-1",
- "espressif-esp32-wroom-32",
+ "espressif-esp32-devkitc",
+ "espressif-esp32-s3-devkitc-1",
  "linkme",
  "microbit",
  "microbit-v2",
@@ -2354,7 +2354,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "espressif-esp32-s3-wroom-1"
+name = "espressif-esp32-devkitc"
 version = "0.1.0"
 dependencies = [
  "ariel-os-debug",
@@ -2362,7 +2362,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "espressif-esp32-wroom-32"
+name = "espressif-esp32-s3-devkitc-1"
 version = "0.1.0"
 dependencies = [
  "ariel-os-debug",

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -52,7 +52,7 @@
     </tr>
     <tr>
       <td>ESP32-S3</td>
-      <td>Espressif ESP32-S3-WROOM-1</td>
+      <td>Espressif ESP32-S3-DevKitC-1</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -216,8 +216,8 @@ boards:
       user_usb: not_currently_supported
       ethernet_over_usb: not_currently_supported
 
-  espressif-esp32-s3-wroom-1:
-    name: Espressif ESP32-S3-WROOM-1
+  espressif-esp32-s3-devkitc-1:
+    name: Espressif ESP32-S3-DevKitC-1
     chip: esp32-s3
     support:
       user_usb: not_currently_supported

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -670,7 +670,7 @@ modules:
   - name: hw/usb-device-port
     help: provided if a device has a USB device port wired up
     context:
-      - espressif-esp32-s3-wroom-1
+      - espressif-esp32-s3-devkitc-1
       - nrf5340dk
       - nrf52840dk
       - rpi-pico
@@ -1000,13 +1000,13 @@ builders:
   - name: ai-c3
     parent: esp32c3
 
-  - name: espressif-esp32-wroom-32
+  - name: espressif-esp32-devkitc
     parent: esp32
 
   - name: espressif-esp32-c6-devkitc-1
     parent: esp32c6
 
-  - name: espressif-esp32-s3-wroom-1
+  - name: espressif-esp32-s3-devkitc-1
     parent: esp32s3
 
   - name: nrf5340dk

--- a/src/ariel-os-boards/Cargo.toml
+++ b/src/ariel-os-boards/Cargo.toml
@@ -15,8 +15,8 @@ ariel-os-rt = { path = "../ariel-os-rt" }
 
 ai-c3 = { optional = true, path = "ai-c3" }
 espressif-esp32-c6-devkitc-1 = { optional = true, path = "espressif-esp32-c6-devkitc-1" }
-espressif-esp32-s3-wroom-1 = { optional = true, path = "espressif-esp32-s3-wroom-1" }
-espressif-esp32-wroom-32 = { optional = true, path = "espressif-esp32-wroom-32" }
+espressif-esp32-s3-devkitc-1 = { optional = true, path = "espressif-esp32-s3-devkitc-1" }
+espressif-esp32-devkitc = { optional = true, path = "espressif-esp32-devkitc" }
 dwm1001 = { optional = true, path = "dwm1001" }
 microbit = { optional = true, path = "microbit" }
 microbit-v2 = { optional = true, path = "microbit-v2" }

--- a/src/ariel-os-boards/espressif-esp32-devkitc/Cargo.toml
+++ b/src/ariel-os-boards/espressif-esp32-devkitc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "espressif-esp32-wroom-32"
+name = "espressif-esp32-devkitc"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true

--- a/src/ariel-os-boards/espressif-esp32-devkitc/src/lib.rs
+++ b/src/ariel-os-boards/espressif-esp32-devkitc/src/lib.rs
@@ -3,5 +3,5 @@
 use ariel_os_debug::println;
 
 pub fn init() {
-    println!("espressif-esp32-wroom-32::init()");
+    println!("espressif-esp32-devkitc::init()");
 }

--- a/src/ariel-os-boards/espressif-esp32-s3-devkitc-1/Cargo.toml
+++ b/src/ariel-os-boards/espressif-esp32-s3-devkitc-1/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "espressif-esp32-s3-wroom-1"
+name = "espressif-esp32-s3-devkitc-1"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true

--- a/src/ariel-os-boards/espressif-esp32-s3-devkitc-1/src/lib.rs
+++ b/src/ariel-os-boards/espressif-esp32-s3-devkitc-1/src/lib.rs
@@ -3,5 +3,5 @@
 use ariel_os_debug::log::debug;
 
 pub fn init() {
-    debug!("espressif-esp32-s3-wroom-1::init()");
+    debug!("espressif-esp32-s3-devkitc-1::init()");
 }

--- a/src/ariel-os-boards/src/lib.rs
+++ b/src/ariel-os-boards/src/lib.rs
@@ -6,12 +6,12 @@ use cfg_if::cfg_if;
 cfg_if! {
     if #[cfg(feature = "ai-c3")] {
         pub use ai_c3 as board;
-    } else if #[cfg(feature = "espressif-esp32-wroom-32")] {
-        pub use espressif_esp32_wroom_32 as board;
+    } else if #[cfg(feature = "espressif-esp32-devkitc")] {
+        pub use espressif_esp32_devkitc as board;
     } else if #[cfg(feature = "espressif-esp32-c6-devkitc-1")] {
         pub use espressif_esp32_c6_devkitc_1 as board;
-    } else if #[cfg(feature = "espressif-esp32-s3-wroom-1")] {
-        pub use espressif_esp32_s3_wroom_1 as board;
+    } else if #[cfg(feature = "espressif-esp32-s3-devkitc-1")] {
+        pub use espressif_esp32_s3_devkitc_1 as board;
     } else if #[cfg(feature = "nrf52dk")] {
         pub use nrf52dk as board;
     } else if #[cfg(feature = "dwm1001")] {


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Some of them were using the *module* name instead of the board name.

There should be no remaining occurrences of "wroom" (case insensitive) in the repo, including in the file/directory names.

---

This is suboptimal as multiple module variants can exist per devkit board, but this is out of scope of this PR.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
