### PR TITLE
feat: improve network configuration

### DIFF
--- a/book/src/networking.md
+++ b/book/src/networking.md
@@ -33,9 +33,16 @@ CONFIG_WIFI_NETWORK=<ssid> CONFIG_WIFI_PASSWORD=<pwd> laze build ...
 ### Network Configuration
 
 DHCPv4 is used by default for network configuration, including for IP address allocation.
+This is enabled by the `network-config-dhcp` [laze module](./build_system.md#laze-modules), selected by default.
 
-The [`#[ariel_os::config]` attribute macro][config-attr-macro-rustdoc] is currently used to provide manual network configuration for the device.
-When the `override-network-config` Cargo feature is enabled, DHCP is disabled and the provided configuration is used instead.
+In order to provide a static configuration, select the `network-config-static` [laze module](./build_system.md#laze-modules), which will take precedence.
+The configuration can be customized with the following environment variables:
+
+| Variable                                 | Default      |
+| --                                       | --           |
+| `CONFIG_NET_IPV4_STATIC_ADDRESS`         | `10.42.0.61` |
+| `CONFIG_NET_IPV4_STATIC_CIDR_PREFIX_LEN` | `24`         |
+| `CONFIG_NET_IPV4_STATIC_GATEWAY_ADDRESS` | `10.42.0.1`  |
 
 > Non-static IPv6 address allocation will be supported in the future.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,9 +26,9 @@ This directory contains example applications that showcase how to use Ariel OS.
 
 ## Networking
 
-Some examples demonstrate networking capabilities. By default, they will listen on a static
-IPv4 address: `10.42.0.61`.
-To make the device use a DHCP client for address allocation instead of the static address,
-disable the `override-network-config` feature in the example's `Cargo.toml`.
+Some examples demonstrate networking capabilities. By default, they will try to
+get an IP address via DHCPv4.
 
-See the [networking documentation](https://ariel-os.github.io/ariel-os/dev/docs/book/networking.html) to learn how to set up networking.
+See the [networking documentation][book-networking] to learn how to set up networking.
+
+[book-networking]: https://ariel-os.github.io/ariel-os/dev/docs/book/networking.html

--- a/examples/coap-client/Cargo.toml
+++ b/examples/coap-client/Cargo.toml
@@ -9,10 +9,7 @@ workspace = true
 
 [dependencies]
 heapless = { workspace = true }
-ariel-os = { path = "../../src/ariel-os", features = [
-  "override-network-config",
-  "coap",
-] }
+ariel-os = { path = "../../src/ariel-os", features = ["coap"] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 embedded-nal-coap = { workspace = true }
 coap-request = "0.2.0-alpha.2"

--- a/examples/coap-client/src/main.rs
+++ b/examples/coap-client/src/main.rs
@@ -3,18 +3,7 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 
-use ariel_os::{debug::log::info, reexports::embassy_net};
-
-#[ariel_os::config(network)]
-const NETWORK_CONFIG: embassy_net::Config = {
-    use embassy_net::{self, Ipv4Address};
-
-    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
-        dns_servers: heapless::Vec::new(),
-        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
-    })
-};
+use ariel_os::debug::log::info;
 
 /// Run a CoAP stack without serving any actual resources.
 #[ariel_os::task(autostart)]

--- a/examples/coap-server/Cargo.toml
+++ b/examples/coap-server/Cargo.toml
@@ -10,10 +10,7 @@ workspace = true
 [dependencies]
 embassy-sync = { workspace = true }
 heapless = { workspace = true }
-ariel-os = { path = "../../src/ariel-os", features = [
-  "override-network-config",
-  "coap",
-] }
+ariel-os = { path = "../../src/ariel-os", features = ["coap"] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 coap-message = "0.3.2"
 coap-message-demos = { version = "0.4.0", default-features = false }

--- a/examples/coap-server/src/main.rs
+++ b/examples/coap-server/src/main.rs
@@ -3,19 +3,6 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 
-use ariel_os::reexports::embassy_net;
-
-#[ariel_os::config(network)]
-const NETWORK_CONFIG: embassy_net::Config = {
-    use embassy_net::{self, Ipv4Address};
-
-    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
-        dns_servers: heapless::Vec::new(),
-        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
-    })
-};
-
 #[ariel_os::task(autostart)]
 async fn coap_run() {
     use coap_handler_implementations::{

--- a/examples/http-client/Cargo.toml
+++ b/examples/http-client/Cargo.toml
@@ -12,7 +12,6 @@ ariel-os = { path = "../../src/ariel-os", features = [
   "csprng",
   "dns",
   "mdns",
-  "override-network-config",
   "tcp",
   "time",
 ] }

--- a/examples/http-client/src/main.rs
+++ b/examples/http-client/src/main.rs
@@ -38,17 +38,6 @@ const ENDPOINT_URL: &str = config::str_from_env_or!(
     "endpoint to send the GET request to",
 );
 
-#[ariel_os::config(network)]
-const NETWORK_CONFIG: embassy_net::Config = {
-    use embassy_net::Ipv4Address;
-
-    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
-        dns_servers: heapless::Vec::new(),
-        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
-    })
-};
-
 #[ariel_os::task(autostart)]
 async fn main() {
     let stack = net::network_stack().await.unwrap();

--- a/examples/http-server/Cargo.toml
+++ b/examples/http-server/Cargo.toml
@@ -8,9 +8,7 @@ publish = false
 workspace = true
 
 [dependencies]
-ariel-os = { path = "../../src/ariel-os", features = [
-  "override-network-config",
-] }
+ariel-os = { path = "../../src/ariel-os" }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 embassy-sync = { workspace = true }
 heapless = { workspace = true }

--- a/examples/http-server/src/main.rs
+++ b/examples/http-server/src/main.rs
@@ -7,7 +7,7 @@
 mod pins;
 mod routes;
 
-use ariel_os::{asynch::Spawner, cell::StaticCell, net, reexports::embassy_net, time::Duration};
+use ariel_os::{asynch::Spawner, cell::StaticCell, net, time::Duration};
 
 #[cfg(feature = "button-reading")]
 use embassy_sync::once_lock::OnceLock;
@@ -19,17 +19,6 @@ const SERVER_CONFIG: picoserve::Config<Duration> = picoserve::Config::new(picose
     read_request: Some(Duration::from_secs(1)),
     write: Some(Duration::from_secs(1)),
 });
-
-#[ariel_os::config(network)]
-const NETWORK_CONFIG: embassy_net::Config = {
-    use embassy_net::{self, Ipv4Address};
-
-    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
-        dns_servers: heapless::Vec::new(),
-        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
-    })
-};
 
 static APP: StaticCell<picoserve::Router<routes::AppRouter>> = StaticCell::new();
 

--- a/examples/tcp-echo/Cargo.toml
+++ b/examples/tcp-echo/Cargo.toml
@@ -10,9 +10,5 @@ workspace = true
 [dependencies]
 embedded-io-async = "0.6.1"
 heapless = { workspace = true }
-ariel-os = { path = "../../src/ariel-os", features = [
-  "override-network-config",
-  "tcp",
-  "time",
-] }
+ariel-os = { path = "../../src/ariel-os", features = ["tcp", "time"] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }

--- a/examples/tcp-echo/src/main.rs
+++ b/examples/tcp-echo/src/main.rs
@@ -7,17 +7,6 @@ use ariel_os::{debug::log::*, net, reexports::embassy_net, time::Duration};
 use embassy_net::tcp::TcpSocket;
 use embedded_io_async::Write;
 
-#[ariel_os::config(network)]
-const NETWORK_CONFIG: embassy_net::Config = {
-    use embassy_net::{self, Ipv4Address};
-
-    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
-        dns_servers: heapless::Vec::new(),
-        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
-    })
-};
-
 #[ariel_os::task(autostart)]
 async fn tcp_echo() {
     let stack = net::network_stack().await.unwrap();

--- a/examples/udp-echo/Cargo.toml
+++ b/examples/udp-echo/Cargo.toml
@@ -9,8 +9,5 @@ workspace = true
 
 [dependencies]
 heapless = { workspace = true }
-ariel-os = { path = "../../src/ariel-os", features = [
-  "override-network-config",
-  "udp",
-] }
+ariel-os = { path = "../../src/ariel-os", features = ["udp"] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }

--- a/examples/udp-echo/src/main.rs
+++ b/examples/udp-echo/src/main.rs
@@ -6,17 +6,6 @@
 use ariel_os::{debug::log::*, net, reexports::embassy_net};
 use embassy_net::udp::{PacketMetadata, UdpSocket};
 
-#[ariel_os::config(network)]
-const NETWORK_CONFIG: embassy_net::Config = {
-    use embassy_net::{self, Ipv4Address};
-
-    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
-        dns_servers: heapless::Vec::new(),
-        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
-    })
-};
-
 #[ariel_os::task(autostart)]
 async fn udp_echo() {
     let stack = net::network_stack().await.unwrap();

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -637,6 +637,32 @@ modules:
   - name: network
     selects:
       - network_device
+      - network-config-default
+
+  - name: network-config-default
+    help: use default network configuration method
+    selects:
+      - ?network-config-dhcp
+      - ?network-config-static
+      - network-config
+
+  - name: network-config-dhcp
+    help: use DHCPv4 for network configuration
+    selects:
+      - network
+    provides_unique:
+      - network-config
+
+  - name: network-config-static
+    help: use static IP network configuration
+    selects:
+      - network
+    provides_unique:
+      - network-config
+    env:
+      global:
+        FEATURES:
+          - ariel-os/network-config-static
 
   - name: sw/storage
     context:

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -97,8 +97,8 @@ wifi-cyw43 = ["ariel-os-hal/wifi-cyw43", "net", "wifi"]
 wifi-esp = ["ariel-os-hal/wifi-esp", "net", "wifi"]
 
 threading = ["dep:ariel-os-threads"]
-network-config-static = ["override-network-config"]
-override-network-config = []
+network-config-static = ["network-config-override"]
+network-config-override = []
 override-usb-config = []
 
 executor-single-thread = [

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -97,6 +97,7 @@ wifi-cyw43 = ["ariel-os-hal/wifi-cyw43", "net", "wifi"]
 wifi-esp = ["ariel-os-hal/wifi-esp", "net", "wifi"]
 
 threading = ["dep:ariel-os-threads"]
+network-config-static = ["override-network-config"]
 override-network-config = []
 override-usb-config = []
 

--- a/src/ariel-os-embassy/src/net.rs
+++ b/src/ariel-os-embassy/src/net.rs
@@ -35,11 +35,11 @@ pub(crate) async fn net_task(mut runner: Runner<'static, NetworkDevice>) -> ! {
 
 #[allow(dead_code, reason = "false positive during builds outside of laze")]
 pub(crate) fn config() -> embassy_net::Config {
-    #[cfg(not(feature = "override-network-config"))]
+    #[cfg(not(feature = "network-config-override"))]
     {
         embassy_net::Config::dhcpv4(Default::default())
     }
-    #[cfg(feature = "override-network-config")]
+    #[cfg(feature = "network-config-override")]
     {
         extern "Rust" {
             fn __ariel_os_network_config() -> embassy_net::Config;

--- a/src/ariel-os-embassy/src/net.rs
+++ b/src/ariel-os-embassy/src/net.rs
@@ -121,3 +121,33 @@ impl embassy_net::driver::RxToken for DummyDriver {
         match self.0 {}
     }
 }
+
+#[cfg(feature = "network-config-static")]
+#[no_mangle]
+fn __ariel_os_network_config() -> embassy_net::Config {
+    use ariel_os_utils::{ipv4_addr_from_env_or, u8_from_env_or};
+
+    let ipaddr = ipv4_addr_from_env_or!(
+        "CONFIG_NET_IPV4_STATIC_ADDRESS",
+        "10.42.0.61",
+        "static IPv4 address",
+    );
+
+    let gw_addr = ipv4_addr_from_env_or!(
+        "CONFIG_NET_IPV4_STATIC_GATEWAY_ADDRESS",
+        "10.42.0.1",
+        "static IPv4 gateway address",
+    );
+
+    let prefix_len = u8_from_env_or!(
+        "CONFIG_NET_IPV4_STATIC_CIDR_PREFIX_LEN",
+        24,
+        "static IPv4 CIDR prefix length"
+    );
+
+    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
+        address: embassy_net::Ipv4Cidr::new(ipaddr, prefix_len),
+        dns_servers: heapless::Vec::new(),
+        gateway: Some(gw_addr),
+    })
+}

--- a/src/ariel-os-macros/Cargo.toml
+++ b/src/ariel-os-macros/Cargo.toml
@@ -25,7 +25,7 @@ ariel-os = { workspace = true, features = [
   "threading",
   "no-boards",
   "usb-ethernet",
-  "override-network-config",
+  "network-config-override",
 ] }
 trybuild = "1.0.89"
 

--- a/src/ariel-os-macros/src/config.rs
+++ b/src/ariel-os-macros/src/config.rs
@@ -11,7 +11,7 @@
 ///
 /// | Driver    | Expected type                  | Cargo feature to enable   |
 /// | --------- | ------------------------------ | ------------------------- |
-/// | `network` | `embassy_net::Config`          | `override-network-config` |
+/// | `network` | `embassy_net::Config`          | `network-config-override` |
 /// | `usb`     | `embassy_usb::Config`          | `override-usb-config`     |
 ///
 /// # Note

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -48,7 +48,7 @@ csprng = ["ariel-os-random/csprng"]
 ## Enables seeding the random number generator from hardware.
 hwrng = ["ariel-os-embassy/hwrng"]
 
-#! ## Network protocols
+#! ## Network protocols and configuration
 ## Enables support for TCP.
 tcp = ["ariel-os-embassy/tcp"]
 ## Enables support for UDP.
@@ -59,6 +59,8 @@ dns = ["ariel-os-embassy/dns"]
 mdns = ["ariel-os-embassy/mdns"]
 ## Enables support for [CoAP](https://ariel-os.github.io/ariel-os/dev/docs/book/tooling/coap.html).
 coap = ["dep:ariel-os-coap", "random"]
+## Selects static IP configuration.
+network-config-static = ["ariel-os-embassy/network-config-static"]
 
 #! ## Serial communication
 ## Enables I2C support.

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -78,7 +78,7 @@ usb-hid = ["ariel-os-embassy/usb-hid"]
 #! The features below need to be enabled so that the provided custom
 #! configuration is taken into account.
 ## Enables custom network configuration.
-override-network-config = ["ariel-os-embassy/override-network-config"]
+network-config-override = ["ariel-os-embassy/network-config-override"]
 ## Enables custom USB configuration.
 override-usb-config = ["ariel-os-embassy/override-usb-config"]
 

--- a/tests/coap-blinky/Cargo.toml
+++ b/tests/coap-blinky/Cargo.toml
@@ -8,11 +8,7 @@ publish = false
 workspace = true
 
 [dependencies]
-ariel-os = { path = "../../src/ariel-os", features = [
-  "override-network-config",
-  "coap",
-  "udp",
-] }
+ariel-os = { path = "../../src/ariel-os", features = ["coap", "udp"] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 coap-handler-implementations = "0.5.0"
 

--- a/tests/coap-blinky/src/main.rs
+++ b/tests/coap-blinky/src/main.rs
@@ -6,21 +6,7 @@
 #[path = "../../../examples/blinky/src/pins.rs"]
 mod pins;
 
-use ariel_os::{
-    gpio::{Level, Output},
-    reexports::embassy_net,
-};
-
-#[ariel_os::config(network)]
-const NETWORK_CONFIG: embassy_net::Config = {
-    use embassy_net::{self, Ipv4Address};
-
-    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
-        dns_servers: heapless::Vec::new(),
-        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
-    })
-};
+use ariel_os::gpio::{Level, Output};
 
 #[ariel_os::task(autostart, peripherals)]
 async fn coap_run(peripherals: pins::LedPeripherals) {

--- a/tests/coap/Cargo.toml
+++ b/tests/coap/Cargo.toml
@@ -10,11 +10,7 @@ workspace = true
 [dependencies]
 embassy-sync = { workspace = true }
 heapless = { workspace = true }
-ariel-os = { path = "../../src/ariel-os", features = [
-  "override-network-config",
-  "coap",
-  "udp",
-] }
+ariel-os = { path = "../../src/ariel-os", features = ["coap", "udp"] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 embassy-futures = "0.1.1"
 embedded-nal-coap = { workspace = true }

--- a/tests/coap/src/main.rs
+++ b/tests/coap/src/main.rs
@@ -3,19 +3,6 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 
-use ariel_os::reexports::embassy_net;
-
-#[ariel_os::config(network)]
-const NETWORK_CONFIG: embassy_net::Config = {
-    use embassy_net::{self, Ipv4Address};
-
-    embassy_net::Config::ipv4_static(embassy_net::StaticConfigV4 {
-        address: embassy_net::Ipv4Cidr::new(Ipv4Address::new(10, 42, 0, 61), 24),
-        dns_servers: heapless::Vec::new(),
-        gateway: Some(Ipv4Address::new(10, 42, 0, 1)),
-    })
-};
-
 #[ariel_os::task(autostart)]
 async fn coap_run() {
     use coap_handler_implementations::HandlerBuilder;


### PR DESCRIPTION
# Description

This PR:

- makes DHCP the current default
- enables choosing the previous static configuration via laze module `network-config-static`

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Part of #502.

## Open Questions

- [x] how to override the IP's used (e.g., via env?)

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
