### PR TITLE
docs(support-matrix): print the technical name of boards and chips

### DIFF
--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -1,5 +1,5 @@
 <!-- This table is auto-generated. Do not edit manually. -->
-<table>
+<table class="support-matrix">
   <thead>
     <tr>
       <th>Chip</th>
@@ -165,6 +165,11 @@
   </tbody>
 </table>
 <style>
+.support-matrix {
+    position: relative;
+    left: 50%;
+    transform: translate(-50%, 0);
+}
 .support-cell {
   text-align: center;
 }

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -2,13 +2,15 @@
 <table class="support-matrix">
   <thead>
     <tr>
-      <th>Chip</th>
-      <th>Testing Board</th>
+      <th colspan="2">Chip</th>
+      <th colspan="2">Testing Board</th>
       <th colspan="10">Functionality</th>
     </tr>
     <tr>
-      <th></th>
-      <th></th>
+      <th>Manufacturer Name</th>
+      <th>Ariel OS Name</th>
+      <th>Manufacturer Name</th>
+      <th>Ariel OS Name</th>
       <th>GPIO</th>
       <th>Debug Output</th>
       <th>I2C Controller Mode</th>
@@ -24,7 +26,9 @@
   <tbody>
     <tr>
       <td>nRF52833</td>
+      <td><code>nrf52833</code></td>
       <td><a href="https://web.archive.org/web/20250109121140/https://microbit.org/new-microbit/">BBC micro:bit V2</a></td>
+      <td><code>bbc-microbit-v2</code></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -38,7 +42,9 @@
     </tr>
     <tr>
       <td>ESP32-C6</td>
+      <td><code>esp32c6</code></td>
       <td><a href="https://web.archive.org/web/20250122153727/https://www.espressif.com/en/dev-board/esp32-c6-devkitc-1-en">Espressif ESP32-C6-DevKitC-1</a></td>
+      <td><code>espressif-esp32-c6-devkitc-1</code></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -52,7 +58,9 @@
     </tr>
     <tr>
       <td>ESP32-S3</td>
+      <td><code>esp32s3</code></td>
       <td><a href="https://web.archive.org/web/20250122153707/https://www.espressif.com/en/dev-board/esp32-s3-devkitc-1-en">Espressif ESP32-S3-DevKitC-1</a></td>
+      <td><code>espressif-esp32-s3-devkitc-1</code></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
@@ -66,7 +74,9 @@
     </tr>
     <tr>
       <td>nRF52840</td>
+      <td><code>nrf52840</code></td>
       <td><a href="https://web.archive.org/web/20250112154748/https://www.nordicsemi.com/Products/Development-hardware/nrf52840-dk">nRF52840-DK</a></td>
+      <td><code>nrf52840dk</code></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -79,8 +89,10 @@
       <td class="support-cell" title="supported">✅</td>
     </tr>
     <tr>
-      <td>nRF53xx</td>
+      <td>nRF5340</td>
+      <td><code>nrf5340</code></td>
       <td><a href="https://web.archive.org/web/20250115224621/https://www.nordicsemi.com/Products/Development-hardware/nrf5340-dk">nRF5340-DK</a></td>
+      <td><code>nrf5340dk</code></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -94,7 +106,9 @@
     </tr>
     <tr>
       <td>RP2040</td>
+      <td><code>rp2040</code></td>
       <td><a href="https://web.archive.org/web/20250101022830/https://www.raspberrypi.com/products/raspberry-pi-pico/">Raspberry Pi Pico</a></td>
+      <td><code>rpi-pico</code></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -108,7 +122,9 @@
     </tr>
     <tr>
       <td>RP2040</td>
+      <td><code>rp2040</code></td>
       <td><a href="https://web.archive.org/web/20250101022830/https://www.raspberrypi.com/products/raspberry-pi-pico/">Raspberry Pi Pico W</a></td>
+      <td><code>rpi-pico-w</code></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -122,7 +138,9 @@
     </tr>
     <tr>
       <td>STM32F401RETX</td>
+      <td><code>stm32f401retx</code></td>
       <td><a href="https://web.archive.org/web/20250115005425/https://www.st.com/en/evaluation-tools/nucleo-f401re.html">ST NUCLEO-F401RE</a></td>
+      <td><code>st-nucleo-f401re</code></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
@@ -136,7 +154,9 @@
     </tr>
     <tr>
       <td>STM32F755ZITX</td>
+      <td><code>stm32h755zitx</code></td>
       <td><a href="https://web.archive.org/web/20240524105149/https://www.st.com/en/evaluation-tools/nucleo-h755zi-q.html">ST NUCLEO-H755ZI-Q</a></td>
+      <td><code>st-nucleo-h755zi-q</code></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
@@ -150,7 +170,9 @@
     </tr>
     <tr>
       <td>STM32W55RGVX</td>
+      <td><code>stm32wb55rgvx</code></td>
       <td><a href="https://web.archive.org/web/20240803070523/https://www.st.com/en/evaluation-tools/nucleo-wb55rg.html">ST NUCLEO-WB55RG</a></td>
+      <td><code>st-nucleo-wb55</code></td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>

--- a/doc/gen_support_matrix_html.rs
+++ b/doc/gen_support_matrix_html.rs
@@ -19,7 +19,7 @@ use miette::Diagnostic;
 
 const TABLE_TEMPLATE: &str =
 r##"<!-- This table is auto-generated. Do not edit manually. -->
-<table>
+<table class="support-matrix">
   <thead>
     <tr>
       <th>Chip</th>
@@ -47,6 +47,11 @@ r##"<!-- This table is auto-generated. Do not edit manually. -->
   </tbody>
 </table>
 <style>
+.support-matrix {
+    position: relative;
+    left: 50%;
+    transform: translate(-50%, 0);
+}
 .support-cell {
   text-align: center;
 }

--- a/doc/gen_support_matrix_html.rs
+++ b/doc/gen_support_matrix_html.rs
@@ -22,13 +22,15 @@ r##"<!-- This table is auto-generated. Do not edit manually. -->
 <table class="support-matrix">
   <thead>
     <tr>
-      <th>Chip</th>
-      <th>Testing Board</th>
+      <th colspan="2">Chip</th>
+      <th colspan="2">Testing Board</th>
       <th colspan="{{ matrix.functionalities|length }}">Functionality</th>
     </tr>
     <tr>
-      <th></th>
-      <th></th>
+      <th>Manufacturer Name</th>
+      <th>Ariel OS Name</th>
+      <th>Manufacturer Name</th>
+      <th>Ariel OS Name</th>
       {%- for functionality in matrix.functionalities %}
       <th>{{ functionality.title }}</th>
       {%- endfor %}
@@ -38,7 +40,9 @@ r##"<!-- This table is auto-generated. Do not edit manually. -->
     {%- for board in boards %}
     <tr>
       <td>{{ board.chip }}</td>
+      <td><code>{{ board.chip_technical_name }}</code></td>
       <td><a href="{{ board.url }}">{{ board.name }}</a></td>
+      <td><code>{{ board.technical_name }}</code></td>
       {%- for functionality in board.functionalities %}
       <td class="support-cell" title="{{ functionality.description }}">{{ functionality.icon }}</td>
       {%- endfor %}
@@ -212,7 +216,9 @@ fn render_html(matrix: &schema::Matrix) -> Result<String, Error> {
     #[derive(Debug, Serialize)]
     struct BoardSupport {
         chip: String,
+        chip_technical_name: String,
         url: String,
+        technical_name: String,
         name: String,
         functionalities: Vec<FunctionalitySupport>,
     }
@@ -225,7 +231,7 @@ fn render_html(matrix: &schema::Matrix) -> Result<String, Error> {
         // TODO: add the PR link
     }
 
-    let mut boards = matrix.boards.iter().map(|(_, board_info)| {
+    let mut boards = matrix.boards.iter().map(|(board_technical_name, board_info)| {
         let board_name = &board_info.name;
 
         let functionalities = matrix.functionalities
@@ -283,14 +289,15 @@ fn render_html(matrix: &schema::Matrix) -> Result<String, Error> {
 
         Ok(BoardSupport {
             chip: chip.name.to_owned(),
+            chip_technical_name: board_info.chip.to_owned(),
             url: board_info.url.to_owned(),
+            technical_name: board_technical_name.to_owned(),
             name: board_name.to_owned(),
             functionalities,
         })
     }).collect::<Result<Vec<_>, Error>>()?;
     // TODO: read the order from the YAML file instead?
     boards.sort_unstable_by_key(|b| b.name.to_lowercase());
-    dbg!(&boards);
 
     let mut env = Environment::new();
     env.add_template("matrix", TABLE_TEMPLATE).unwrap();

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -74,8 +74,8 @@ chips:
       storage: supported
       wifi: not_available
 
-  nrf53xx:
-    name: nRF53xx
+  nrf5340:
+    name: nRF5340
     support:
       gpio: supported
       debug_output: supported
@@ -98,7 +98,7 @@ chips:
       storage: supported
       wifi: not_available
 
-  esp32-c6:
+  esp32c6:
     name: ESP32-C6
     support:
       gpio: supported
@@ -113,7 +113,7 @@ chips:
         comments:
           - not currently compatible with threading
 
-  esp32-s3:
+  esp32s3:
     name: ESP32-S3
     support:
       gpio: supported
@@ -192,7 +192,7 @@ boards:
   nrf5340dk:
     name: nRF5340-DK
     url: https://web.archive.org/web/20250115224621/https://www.nordicsemi.com/Products/Development-hardware/nrf5340-dk
-    chip: nrf53xx
+    chip: nrf5340
     support:
       user_usb: supported
       ethernet_over_usb: supported
@@ -217,7 +217,7 @@ boards:
   espressif-esp32-c6-devkitc-1:
     name: Espressif ESP32-C6-DevKitC-1
     url: https://web.archive.org/web/20250122153727/https://www.espressif.com/en/dev-board/esp32-c6-devkitc-1-en
-    chip: esp32-c6
+    chip: esp32c6
     support:
       user_usb: not_currently_supported
       ethernet_over_usb: not_currently_supported
@@ -225,7 +225,7 @@ boards:
   espressif-esp32-s3-devkitc-1:
     name: Espressif ESP32-S3-DevKitC-1
     url: https://web.archive.org/web/20250122153707/https://www.espressif.com/en/dev-board/esp32-s3-devkitc-1-en
-    chip: esp32-s3
+    chip: esp32s3
     support:
       user_usb: not_currently_supported
       ethernet_over_usb: not_currently_supported

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -181,7 +181,7 @@ boards:
       user_usb: not_available
       ethernet_over_usb: not_available
 
-  nrf52840-dk:
+  nrf52840dk:
     name: nRF52840-DK
     url: https://web.archive.org/web/20250112154748/https://www.nordicsemi.com/Products/Development-hardware/nrf52840-dk
     chip: nrf52840
@@ -189,7 +189,7 @@ boards:
       user_usb: supported
       ethernet_over_usb: supported
 
-  nrf5340-dk:
+  nrf5340dk:
     name: nRF5340-DK
     url: https://web.archive.org/web/20250115224621/https://www.nordicsemi.com/Products/Development-hardware/nrf5340-dk
     chip: nrf53xx
@@ -197,7 +197,7 @@ boards:
       user_usb: supported
       ethernet_over_usb: supported
 
-  rp-pico:
+  rpi-pico:
     name: Raspberry Pi Pico
     url: https://web.archive.org/web/20250101022830/https://www.raspberrypi.com/products/raspberry-pi-pico/
     chip: rp2040
@@ -205,7 +205,7 @@ boards:
       user_usb: supported
       ethernet_over_usb: supported
 
-  rp-pico-w:
+  rpi-pico-w:
     name: Raspberry Pi Pico W
     url: https://web.archive.org/web/20250101022830/https://www.raspberrypi.com/products/raspberry-pi-pico/
     chip: rp2040
@@ -214,7 +214,7 @@ boards:
       wifi: supported
       ethernet_over_usb: supported
 
-  esp32-c6-devkitc-1:
+  espressif-esp32-c6-devkitc-1:
     name: Espressif ESP32-C6-DevKitC-1
     url: https://web.archive.org/web/20250122153727/https://www.espressif.com/en/dev-board/esp32-c6-devkitc-1-en
     chip: esp32-c6


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This adds two columns for the technical name of boards and chips. Maybe that makes the table a bit busy visually, but at least users can easily find the names they're looking for without having to look at Ariel OS's `laze-project.yml` as mentioned in the current Quick Start section, and we can revisit the visual design later when that table grows in size.

This also centers the support matrix, which looks better on wide-enough viewports.

## How to review this PR

Generate the book with:

```
(cd book && mdbook build . --open)
```

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
