### PR TITLE
chore: specify versions in each crates instead of inheriting for now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ default-members = ["examples/hello-world"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/ariel-os/ariel-os"

--- a/src/ariel-os-bench/Cargo.toml
+++ b/src/ariel-os-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-bench"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-boards/Cargo.toml
+++ b/src/ariel-os-boards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-boards"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/nrf52840dk/Cargo.toml
+++ b/src/ariel-os-boards/nrf52840dk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52840dk"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/nrf52dk/Cargo.toml
+++ b/src/ariel-os-boards/nrf52dk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52dk"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-boards/nrf5340dk/Cargo.toml
+++ b/src/ariel-os-boards/nrf5340dk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf5340dk"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-buildinfo/Cargo.toml
+++ b/src/ariel-os-buildinfo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-buildinfo"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-coap/Cargo.toml
+++ b/src/ariel-os-coap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-coap"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-debug-log/Cargo.toml
+++ b/src/ariel-os-debug-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-debug-log"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-debug/Cargo.toml
+++ b/src/ariel-os-debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-debug"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-embassy-common/Cargo.toml
+++ b/src/ariel-os-embassy-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-embassy-common"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-esp"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-identity/Cargo.toml
+++ b/src/ariel-os-identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-identity"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-macros/Cargo.toml
+++ b/src/ariel-os-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-macros"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-nrf"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-random/Cargo.toml
+++ b/src/ariel-os-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-random"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-rp"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-runqueue/Cargo.toml
+++ b/src/ariel-os-runqueue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-runqueue"
-version = "0.1.2"
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 description = "Ariel OS runqueue implementation"

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-stm32"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-utils/Cargo.toml
+++ b/src/ariel-os-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-utils"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os"
-version.workspace = true
+version = "0.1.0"
 license.workspace = true
 edition.workspace = true
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
We've discussed that this was the better course of action for now, as at least some crates may need to be versioned separately. It would always be possible to enable inheritance again for some of the crates later if needed. 

This sets the version number in every crate to `0.1.0`.

The version numbers of the crates in `src/lib` seem ok:

- `coapcore` is [published on crates.io](https://crates.io/crates/coapcore) with version number `0.0.0`
- `rbi` is [published on crates.io](https://crates.io/crates/rbi) with version number `0.1.1`
- `ringbuffer` is unpublished but already has the default number we are using (`0.1.0`)

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #726.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
