### PR TITLE
coap: prepare for DHCP

### DIFF
--- a/examples/coap-client/src/main.rs
+++ b/examples/coap-client/src/main.rs
@@ -31,8 +31,9 @@ async fn run_client_operations() {
 
     let client = ariel_os::coap::coap_client().await;
 
-    // Corresponding to the fixed network setup, we select a fixed server address.
-    let addr = "10.42.0.1:5683";
+    // Corresponding to the fixed network setup, we select a fixed server address; this may need to
+    // be updated on hosts that are configured differently.
+    let addr = "10.42.0.1:5683"; // IPv4 🔔
     let demoserver = addr.parse().unwrap();
 
     info!("Sending POST to {}...", demoserver);

--- a/examples/coap-server/client.diag
+++ b/examples/coap-server/client.diag
@@ -1,5 +1,5 @@
 {
-  "coap://10.42.0.61/*": {
+  "coap://*": {
     "edhoc-oscore": {
       "suite": 2,
       "method": 3,

--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -79,9 +79,7 @@ pub async fn coap_run(handler: impl coap_handler::Handler + coap_handler::Report
 
     info!("Starting up CoAP server");
 
-    // Can't that even bind to the Any address??
-    // let local_any = "0.0.0.0:5683".parse().unwrap(); // shame
-    let local_any = "10.42.0.61:5683".parse().unwrap(); // shame
+    let local_any = "0.0.0.0:5683".parse().unwrap(); // shame
     let mut unconnected = udp_nal::UnconnectedUdp::bind_multiple(socket, local_any)
         .await
         .unwrap();

--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -79,7 +79,7 @@ pub async fn coap_run(handler: impl coap_handler::Handler + coap_handler::Report
 
     info!("Starting up CoAP server");
 
-    let local_any = "0.0.0.0:5683".parse().unwrap(); // shame
+    let local_any = "[::]:5683".parse().unwrap();
     let mut unconnected = udp_nal::UnconnectedUdp::bind_multiple(socket, local_any)
         .await
         .unwrap();

--- a/src/ariel-os-coap/src/udp_nal/mod.rs
+++ b/src/ariel-os-coap/src/udp_nal/mod.rs
@@ -66,7 +66,13 @@ impl<'a> ConnectedUdp<'a> {
         local: SocketAddr,
         remote: SocketAddr,
     ) -> Result<Self, Error> {
-        socket.bind(sockaddr_nal2smol(local)?)?;
+        // Workaround for https://github.com/smoltcp-rs/smoltcp/issues/1037
+        let bind_to = sockaddr_nal2smol(local)?;
+        if bind_to.addr.is_unspecified() {
+            socket.bind(bind_to.port)?;
+        } else {
+            socket.bind(bind_to)?;
+        }
 
         Ok(ConnectedUdp {
             remote: sockaddr_nal2smol(remote)?,
@@ -111,7 +117,13 @@ impl<'a> UnconnectedUdp<'a> {
         mut socket: udp::UdpSocket<'a>,
         local: SocketAddr,
     ) -> Result<Self, Error> {
-        socket.bind(sockaddr_nal2smol(local)?)?;
+        // Workaround for https://github.com/smoltcp-rs/smoltcp/issues/1037
+        let bind_to = sockaddr_nal2smol(local)?;
+        if bind_to.addr.is_unspecified() {
+            socket.bind(bind_to.port)?;
+        } else {
+            socket.bind(bind_to)?;
+        }
 
         Ok(UnconnectedUdp { socket })
     }

--- a/tests/coap/client.diag
+++ b/tests/coap/client.diag
@@ -1,5 +1,5 @@
 {
-  "coap://10.42.0.61/*": {
+  "coap://*": {
     "edhoc-oscore": {
       "suite": 2,
       "method": 3,

--- a/tests/coap/src/main.rs
+++ b/tests/coap/src/main.rs
@@ -56,8 +56,9 @@ async fn coap_run() {
 async fn run_client_operations(mut stdout: impl core::fmt::Write) {
     let client = ariel_os::coap::coap_client().await;
 
-    // shame
-    let addr = "10.42.0.1:1234";
+    // Corresponding to the fixed network setup, we select a fixed server address; this may need to
+    // be updated on hosts that are configured differently.
+    let addr = "10.42.0.1:1234"; // IPv4 🔔
     let demoserver = addr.parse().unwrap();
 
     use coap_request::Stack;


### PR DESCRIPTION
# Description

There were two places where we had IP addresses hardcoded:

* in the ariel-os-coap server (due to https://github.com/smoltcp-rs/smoltcp/issues/1037 for which there is now a workaround)
* in the credentials files (but wildcards work there as well)

## Issues/PRs references

Blocks: https://github.com/ariel-os/ariel-os/pull/715 (subtly: that PR would go through, but the examples described in the README would not work any more)

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

  Note that no changes to the docs are required at this time; #715 will update READMEs en masse.