### PR TITLE
coap: fixes for tests and examples

### DIFF
--- a/examples/coap-client/laze.yml
+++ b/examples/coap-client/laze.yml
@@ -3,7 +3,7 @@ apps:
     env:
       global:
         CARGO_ENV:
-          - CONFIG_ISR_STACKSIZE=16384
+          - CONFIG_ISR_STACKSIZE=32768
     selects:
       - network
       - random

--- a/examples/coap-server/README.md
+++ b/examples/coap-server/README.md
@@ -19,14 +19,14 @@ making the former configurable and the latter dynamic is work in progress.
   to list the resources of the device:
 
   ```sh
-  $ pipx install 'aiocoap[all]'
+  $ pipx install 'aiocoap[oscore,prettyprint]'
   $ aiocoap-client coap://10.42.0.61/.well-known/core --credentials client.diag
   # application/link-format content was re-formatted
   </hello>
   ```
 
   If you prefer not to install the CoAP client, you can
-  replace any call to `aiocoap-client` with `pipx run --spec 'aiocoap[all]' aiocoap-client` instead.
+  replace any call to `aiocoap-client` with `pipx run --spec 'aiocoap[oscore,prettyprint]' aiocoap-client` instead.
 
   The output tells you there is a `/hello` resource, so read that next:
 

--- a/examples/coap-server/laze.yml
+++ b/examples/coap-server/laze.yml
@@ -3,7 +3,7 @@ apps:
     env:
       global:
         CARGO_ENV:
-          - CONFIG_ISR_STACKSIZE=16384
+          - CONFIG_ISR_STACKSIZE=32768
     selects:
       - network
       - random

--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -36,8 +36,13 @@ mod demo_setup {
         hex!("72cc4761dbd4c78f758931aa589d348d1ef874a7e303ede2f140dcf3e6aa4aac");
 
     /// Scope usable by any client inside any demo device.
-    pub(super) const UNAUTHENTICATED_SCOPE: cboritem::CborItem =
-        cbor!([["/.well-known/core", 1], ["/poem", 1]]);
+    pub(super) const UNAUTHENTICATED_SCOPE: cboritem::CborItem = cbor!([
+            ["/.well-known/core", 1],
+            ["/poem", 1],
+            ["/hello", 1],
+            / any operation /
+            ["/led", 63]
+    ]);
 
     /// Scope usable by the the administrator of the demo device.
     pub(super) const ADMIN_SCOPE: cboritem::CborItem = cbor!([

--- a/tests/coap-blinky/README.md
+++ b/tests/coap-blinky/README.md
@@ -8,7 +8,7 @@ This application makes the GPIO pin from the blinky example accessible over the 
 
 * Run on any board with networking, eg. `laze build -b particle-xenon run`.
 * [Set up networking](../README.md).
-* Run `pipx run --spec 'aiocoap[all]' aiocoap-client coap://10.42.0.61/led -m PUT --content-format application/cbor --payload true`
+* Run `pipx run --spec 'aiocoap[prettyprint]' aiocoap-client coap://10.42.0.61/led -m PUT --content-format application/cbor --payload true`
   or `false`.
 
 ## Roadmap

--- a/tests/coap-blinky/laze.yml
+++ b/tests/coap-blinky/laze.yml
@@ -3,7 +3,7 @@ apps:
     env:
       global:
         CARGO_ENV:
-          - CONFIG_ISR_STACKSIZE=16384
+          - CONFIG_ISR_STACKSIZE=32768
     selects:
       - network
       - random

--- a/tests/coap/README.md
+++ b/tests/coap/README.md
@@ -8,6 +8,8 @@ This application is a work in progress demo of running CoAP with OSCORE/EDHOC se
 
 * Run on any board with networking, eg. `laze build -b particle-xenon run`.
 * [Set up networking](../README.md).
+* Run `chmod go-rwX client.cosekey`.
+  This file contains the key we authenticate with, and aiocoap gets jumpy around world readable key material.
 * Run `pipx run coap-console coap://10.42.0.61 --credentials client.diag`,
   which establishes a secure CoAP connection using EDHOC and OSCORE,
   and shows the log of the device.

--- a/tests/coap/README.md
+++ b/tests/coap/README.md
@@ -11,7 +11,7 @@ This application is a work in progress demo of running CoAP with OSCORE/EDHOC se
 * Run `pipx run coap-console coap://10.42.0.61 --credentials client.diag`,
   which establishes a secure CoAP connection using EDHOC and OSCORE,
   and shows the log of the device.
-* Run `pipx run --spec 'aiocoap[all]' aiocoap-client coap://10.42.0.61/.well-known/core --credentials client.diag`
+* Run `pipx run --spec 'aiocoap[oscore,prettyprint]' aiocoap-client coap://10.42.0.61/.well-known/core --credentials client.diag`
   to show what else the device can do.
   If you kept the log running, you will see that every new command runs through EDHOC once:
   aiocoap does not currently attempt to persist EDHOC derived OSCORE contexts across runs.

--- a/tests/coap/laze.yml
+++ b/tests/coap/laze.yml
@@ -3,7 +3,7 @@ apps:
     env:
       global:
         CARGO_ENV:
-          - CONFIG_ISR_STACKSIZE=16384
+          - CONFIG_ISR_STACKSIZE=32768
     selects:
       - network
       - random


### PR DESCRIPTION
# Description

This closes 3 issues which @ROMemories and I found during testing:

* don't install aiocoap with all features (avoid requiring setuptools; all other dependencies have binary wheels for the platforms)
* increase stack size (got stack overflow, granted not in the default setup, but it's hard to debug, so why take risks)
* put blinky's LED on unauthenticated list (README uses it unauthenticated; proper fix that does away with many of the demo settings is in the works)

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
