### PR TITLE
chore(deps): use upstream `const-str` as the new version was released

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,8 +1141,9 @@ checksum = "0d8a42181e0652c2997ae4d217f25b63c5337a52fd2279736e97b832fa0a3cff"
 
 [[package]]
 name = "const-str"
-version = "0.5.7"
-source = "git+https://github.com/Nugine/const-str?rev=91d01909fd83939008bee8d0287c935dbac48f7f#91d01909fd83939008bee8d0287c935dbac48f7f"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671927c085eb5827d30b95df08f6c6a2301eafe2274c368bb2c16f42e03547eb"
 
 [[package]]
 name = "const_panic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ ariel-os-storage = { path = "src/ariel-os-storage" }
 ariel-os-utils = { path = "src/ariel-os-utils", default-features = false }
 
 const_panic = { version = "0.2.8", default-features = false }
-const-str = { git = "https://github.com/Nugine/const-str", rev = "91d01909fd83939008bee8d0287c935dbac48f7f" }
+const-str = "0.6.0"
 defmt = { version = "0.3.7" }
 document-features = "0.2.8"
 fugit = { version = "0.3.7", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -56,7 +56,6 @@ allow-git = [
   "https://gitlab.com/oscore/liboscore",
   "https://github.com/seanmonstar/try-lock",
   "https://gitlab.com/etonomy/riot-module-examples",
-  "https://github.com/Nugine/const-str",
   # while https://github.com/twittner/minicbor/pull/9 is open
   "https://github.com/chrysn-pull-requests/minicbor",
 ]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
#718 required patching the upstream crate, which was swiftly accepted so we used the upstream repo directly. The new version of that crate has now been released and this uses the <crates.io> version instead.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Follows #718.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
