### PR TITLE
ci(rustdoc): build documentation for coapcore

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -62,6 +62,7 @@ jobs:
           cargo doc \
               --no-deps \
               -p ariel-os \
+              -p coapcore \
               --features "
                   bench,
                   coap,
@@ -85,6 +86,7 @@ jobs:
                   udp,
                   usb,
                   usb-hid,
+                  coapcore/_nightly_docs
                   "
           RUSTDOCFLAGS='-D warnings --cfg context="esp32c6"' cargo doc \
               --target=riscv32imac-unknown-none-elf \


### PR DESCRIPTION
# Description

With #743, coapcore documentation became unavailable. While not part of the API which ariel-os exposes a public, this is a public API of an in-tree crate.

This restores the regression of "this API should be documented somewhere" in one of two possible ways: by building it as part of our docs.

The alternative is to build it separately and host it … somewhere else around here.

## Issues/PRs references

Regression introduced in #743.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
