### PR TITLE
feat(coapcore): evaluate tokens' lifetime

### DIFF
--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -111,6 +111,7 @@ pub async fn coap_run(handler: impl coap_handler::Handler + coap_handler::Report
             .with_known_edhoc_credential(admin_key, admin_scope),
         || lakers_crypto_rustcrypto::Crypto::new(ariel_os_random::crypto_rng()),
         ariel_os_random::crypto_rng(),
+        coapcore::time::TimeUnknown,
     );
 
     info!("Server is ready.");

--- a/src/lib/coapcore/src/ace.rs
+++ b/src/lib/coapcore/src/ace.rs
@@ -14,7 +14,7 @@ use crate::helpers::COwn;
 use crate::time::TimeConstraint;
 
 /// Fixed length of the ACE OSCORE nonce issued by this module.
-pub const OWN_NONCE_LEN: usize = 8;
+pub(crate) const OWN_NONCE_LEN: usize = 8;
 
 /// Size allocated for the ACE OSCORE nonces chosen by the peers.
 const MAX_SUPPORTED_PEER_NONCE_LEN: usize = 16;
@@ -65,9 +65,9 @@ type UnprotectedAuthzInfoPost<'a> = AceCbor<'a>;
 pub struct HeaderMap<'a> {
     #[n(1)]
     // Might be extended as more exotic algorithms are supported
-    pub alg: Option<i32>,
+    pub(crate) alg: Option<i32>,
     #[cbor(b(5), with = "minicbor::bytes")]
-    pub iv: Option<&'a [u8]>,
+    pub(crate) iv: Option<&'a [u8]>,
 }
 
 impl HeaderMap<'_> {
@@ -95,20 +95,20 @@ impl HeaderMap<'_> {
 )]
 #[cbor(map)]
 #[non_exhaustive]
-pub struct CoseKey<'a> {
+pub(crate) struct CoseKey<'a> {
     #[n(1)]
-    pub kty: i32, // or tstr (unsupported here so far)
+    pub(crate) kty: i32, // or tstr (unsupported here so far)
     #[cbor(b(2), with = "minicbor::bytes")]
-    pub kid: Option<&'a [u8]>,
+    pub(crate) kid: Option<&'a [u8]>,
     #[n(3)]
-    pub alg: Option<i32>, // or tstr (unsupported here so far)
+    pub(crate) alg: Option<i32>, // or tstr (unsupported here so far)
 
     #[n(-1)]
-    pub crv: Option<i32>, // or tstr (unsupported here so far)
+    pub(crate) crv: Option<i32>, // or tstr (unsupported here so far)
     #[cbor(b(-2), with = "minicbor::bytes")]
-    pub x: Option<&'a [u8]>,
+    pub(crate) x: Option<&'a [u8]>,
     #[cbor(b(-3), with = "minicbor::bytes")]
-    pub y: Option<&'a [u8]>, // or bool (unsupported here so far)
+    pub(crate) y: Option<&'a [u8]>, // or bool (unsupported here so far)
 }
 
 /// A COSE_Encrypt0 structure as defined in [RFC8152](https://www.rfc-editor.org/rfc/rfc8152)
@@ -324,7 +324,7 @@ pub struct AceCborAuthzInfoResponse {
 }
 
 impl AceCborAuthzInfoResponse {
-    pub fn render<M: coap_message::MutableWritableMessage>(
+    pub(crate) fn render<M: coap_message::MutableWritableMessage>(
         &self,
         message: &mut M,
     ) -> Result<(), M::UnionError> {
@@ -375,7 +375,7 @@ impl AceCborAuthzInfoResponse {
 /// * Instead of the random nonce2, it would be preferable to pass in an RNG -- but some owners of
 ///   an RNG may have a hard time lending out an exclusive reference to it for the whole function
 ///   call duration.
-pub fn process_acecbor_authz_info<Scope>(
+pub(crate) fn process_acecbor_authz_info<Scope>(
     payload: &[u8],
     authorities: &impl crate::seccfg::ServerSecurityConfig<Scope = Scope>,
     nonce2: [u8; OWN_NONCE_LEN],
@@ -460,7 +460,7 @@ pub fn process_acecbor_authz_info<Scope>(
     Ok((response, derived, scope, time_constraint))
 }
 
-pub fn process_edhoc_token<Scope>(
+pub(crate) fn process_edhoc_token<Scope>(
     ead3: &[u8],
     authorities: &impl crate::seccfg::ServerSecurityConfig<Scope = Scope>,
 ) -> Result<(lakers::Credential, Scope, TimeConstraint), CredentialError> {

--- a/src/lib/coapcore/src/ace.rs
+++ b/src/lib/coapcore/src/ace.rs
@@ -383,9 +383,9 @@ pub fn process_acecbor_authz_info<Scope>(
 ) -> Result<
     (
         AceCborAuthzInfoResponse,
+        liboscore::PrimitiveContext,
         Scope,
         crate::time::TimeConstraint,
-        liboscore::PrimitiveContext,
     ),
     CredentialError,
 > {
@@ -457,7 +457,7 @@ pub fn process_acecbor_authz_info<Scope>(
         ace_server_recipientid,
     };
 
-    Ok((response, scope, time_constraint, derived))
+    Ok((response, derived, scope, time_constraint))
 }
 
 pub fn process_edhoc_token<Scope>(

--- a/src/lib/coapcore/src/generalclaims.rs
+++ b/src/lib/coapcore/src/generalclaims.rs
@@ -1,0 +1,71 @@
+//! Abstractions around the permissions of a particular security context.
+
+use crate::scope::Scope;
+
+/// Claims about a peer that are independent of the security mechanism.
+///
+/// A [`GeneralClaims`] instance represents processed properties of a particular security
+/// connection peer.
+///
+/// The data is similar to a CWT's claims, but does not include ACE profile specifics (eg. the
+/// confirmation data), may come from a source that does not even originally stem from ACE (eg.
+/// when a raw public key is known) and also contains data not typically expressed in a CWT (eg.
+/// whether these claims represent a more valuable connection for the purpose of discarding
+/// connections).
+pub trait GeneralClaims: core::fmt::Debug {
+    /// An internal representation of a scope (which may be parsed from a CWT).
+    ///
+    /// Being generic, this allow both to transport claims in their original form (copied into a
+    /// buffer and processed request by request) or to be preprocessed further (eg. converting
+    /// paths in an AIF into an enum that indicates a resource).
+    type Scope: Scope;
+
+    /// Accesses the scope of the claim.
+    ///
+    /// This is used to decide whether a particular request is allowed on a particular resource.
+    fn scope(&self) -> &Self::Scope;
+
+    /// Accesses the temporal validity of the claim.
+    ///
+    /// This is evaluated independently of the request's content, and may be evaluated without a
+    /// request when eviction of a security context is being considered.
+    fn time_constraint(&self) -> crate::time::TimeConstraint;
+
+    /// Access whether a security context is important.
+    ///
+    /// This is intentionally vague (importance of a security context can vary by application), but
+    /// useful for keeping administrative security contexts around even when attackers can create
+    /// many low-authorization contexts.
+    fn is_important(&self) -> bool {
+        false
+    }
+}
+
+impl GeneralClaims for core::convert::Infallible {
+    type Scope = core::convert::Infallible;
+
+    fn scope(&self) -> &Self::Scope {
+        self
+    }
+
+    fn time_constraint(&self) -> crate::time::TimeConstraint {
+        match *self {}
+    }
+}
+
+/// An implementation of [`GeneralClaims`] that puts no additional restrictions on the [`Scope`]
+/// `S` it contains.
+#[derive(Debug)]
+pub struct Unlimited<S: Scope>(pub S);
+
+impl<S: Scope> GeneralClaims for Unlimited<S> {
+    type Scope = S;
+
+    fn scope(&self) -> &Self::Scope {
+        &self.0
+    }
+
+    fn time_constraint(&self) -> crate::time::TimeConstraint {
+        crate::time::TimeConstraint::unbounded()
+    }
+}

--- a/src/lib/coapcore/src/helpers.rs
+++ b/src/lib/coapcore/src/helpers.rs
@@ -30,7 +30,7 @@ impl COwn {
     /// Find a value of self that is not found in the iterator.
     ///
     /// This asserts that the iterator is (known to be) short enough that this will always succeed.
-    pub fn not_in_iter(iterator: impl Iterator<Item = Self>) -> Self {
+    pub(crate) fn not_in_iter(iterator: impl Iterator<Item = Self>) -> Self {
         // In theory, this would allow the compiler to see that the unreachable below is indeed
         // unreachable
         assert!(
@@ -67,7 +67,7 @@ impl COwn {
     }
 
     /// Given an OSCORE Key ID (kid), find the corresponding context identifier value
-    pub fn from_kid(kid: &[u8]) -> Option<Self> {
+    pub(crate) fn from_kid(kid: &[u8]) -> Option<Self> {
         match kid {
             [first] if *first <= 0x17 || (*first >= 0x20 && *first <= 0x37) => Some(Self(*first)),
             _ => None,
@@ -82,7 +82,7 @@ impl COwn {
     /// because the type currently only generates, and because the [`lakers::ConnId`] (being an
     /// owned type) copies data into itself anyway, from where it can produce all forms; that type
     /// also has a [`lakers::ConnId::as_cbor`] accessor.
-    pub fn as_slice(&self) -> &[u8] {
+    pub(crate) fn as_slice(&self) -> &[u8] {
         core::slice::from_ref(&self.0)
     }
 }

--- a/src/lib/coapcore/src/lib.rs
+++ b/src/lib/coapcore/src/lib.rs
@@ -34,6 +34,8 @@ mod iana;
 
 mod helpers;
 
+pub mod time;
+
 mod ace;
 pub mod scope;
 pub mod seccfg;

--- a/src/lib/coapcore/src/lib.rs
+++ b/src/lib/coapcore/src/lib.rs
@@ -44,6 +44,7 @@ pub mod seccfg;
 //
 // This is pub only to make the doctests run (but the crate's pub-ness needs a major overhaul
 // anyway)
+#[doc(hidden)]
 pub mod oluru;
 mod seccontext;
 pub use seccontext::*;

--- a/src/lib/coapcore/src/lib.rs
+++ b/src/lib/coapcore/src/lib.rs
@@ -37,7 +37,9 @@ mod helpers;
 pub mod time;
 
 mod ace;
+mod generalclaims;
 pub mod scope;
+pub use generalclaims::GeneralClaims;
 pub mod seccfg;
 
 // Might warrant a standalone crate at some point

--- a/src/lib/coapcore/src/oluru.rs
+++ b/src/lib/coapcore/src/oluru.rs
@@ -165,6 +165,11 @@ impl<T: PriorityLevel, const N: usize, const L: usize> OrderedPool<T, N, L> {
     /// If the new element's priority is lower than the lowest in the queue, it is returned as an
     /// Err. Otherwise, the element is inserted, and any dropped lower priority element is
     /// returned in the Ok value.
+    // Dead code is only allowed and not expected because of interactions testing.
+    #[allow(
+        dead_code,
+        reason = "Need for this function is unclear, but it is covered in tests and docs, and may easily be needed again as coapcore is being refactored."
+    )]
     pub fn insert(&mut self, new: T) -> Result<Option<T>, T> {
         let new_index = self.entries.len();
         if new_index < N {
@@ -257,7 +262,7 @@ impl<T: PriorityLevel, const N: usize, const L: usize> OrderedPool<T, N, L> {
     }
 
     /// Returns an iterator visiting all items in arbitrary order.
-    pub fn iter(&self) -> impl Iterator<Item = &T> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &T> {
         self.entries.iter()
     }
 }

--- a/src/lib/coapcore/src/scope.rs
+++ b/src/lib/coapcore/src/scope.rs
@@ -6,12 +6,6 @@ use coap_message::{MessageOption, ReadableMessage};
 pub trait Scope: Sized + core::fmt::Debug {
     /// Returns true if a request may be performed by the bound security context.
     fn request_is_allowed<M: ReadableMessage>(&self, request: &M) -> bool;
-
-    /// Returns true if a bound security context should be preferably retained when hitting
-    /// resource limits.
-    fn is_admin(&self) -> bool {
-        false
-    }
 }
 
 impl Scope for core::convert::Infallible {
@@ -148,10 +142,6 @@ impl Scope for AifValue {
         // No matches found
         false
     }
-
-    fn is_admin(&self) -> bool {
-        self.0[0] >= 0x83
-    }
 }
 
 /// A scope that can use multiple backends, erasing its type.
@@ -175,14 +165,6 @@ impl Scope for UnionScope {
             UnionScope::AifValue(v) => v.request_is_allowed(request),
             UnionScope::AllowAll => AllowAll.request_is_allowed(request),
             UnionScope::DenyAll => DenyAll.request_is_allowed(request),
-        }
-    }
-
-    fn is_admin(&self) -> bool {
-        match self {
-            UnionScope::AifValue(v) => v.is_admin(),
-            UnionScope::AllowAll => AllowAll.is_admin(),
-            UnionScope::DenyAll => DenyAll.is_admin(),
         }
     }
 }

--- a/src/lib/coapcore/src/seccfg.rs
+++ b/src/lib/coapcore/src/seccfg.rs
@@ -7,7 +7,7 @@ use crate::ace::HeaderMap;
 use crate::error::{CredentialError, CredentialErrorDetail};
 use crate::time::TimeConstraint;
 
-pub const MAX_AUD_SIZE: usize = 8;
+pub(crate) const MAX_AUD_SIZE: usize = 8;
 
 /// Error type of [`ServerSecurityConfig::render_not_allowed`].
 ///

--- a/src/lib/coapcore/src/seccontext.rs
+++ b/src/lib/coapcore/src/seccontext.rs
@@ -742,7 +742,7 @@ impl<
         let mut nonce2 = [0; crate::ace::OWN_NONCE_LEN];
         self.rng.fill_bytes(&mut nonce2);
 
-        let (response, scope, time_constraint, oscore) =
+        let (response, oscore, scope, time_constraint) =
             crate::ace::process_acecbor_authz_info(payload, &self.authorities, nonce2, |nonce1| {
                 // This preferably (even exclusively) produces EDHOC-ideal recipient IDs, but as long
                 // as we're having more of those than slots, no point in not reusing the code.

--- a/src/lib/coapcore/src/time.rs
+++ b/src/lib/coapcore/src/time.rs
@@ -52,6 +52,7 @@ impl TimeProvider for TimeUnknown {
 }
 
 /// A processed set of token claims that limit it in time.
+#[derive(Copy, Clone, Debug)]
 pub struct TimeConstraint {
     // iat would not go in here (that's only to feed a `TimeProvider::past_trusted`; nbf would go
     // in here but we don't read that yet)

--- a/src/lib/coapcore/src/time.rs
+++ b/src/lib/coapcore/src/time.rs
@@ -59,8 +59,8 @@ pub struct TimeConstraint {
 }
 
 impl TimeConstraint {
-    /// Creates a [`TimeConstraints`] with no bounds; it is valid at any time.
-    pub(crate) fn unbounded() -> Self {
+    /// Creates a [`TimeConstraint`] with no bounds; it is valid at any time.
+    pub fn unbounded() -> Self {
         Self { exp: None }
     }
 

--- a/src/lib/coapcore/src/time.rs
+++ b/src/lib/coapcore/src/time.rs
@@ -1,0 +1,88 @@
+//! Traits and types around representing time, as used to consider token expiration.
+
+/// A clock by which time stamps on authorization credentials are compared.
+///
+/// It is yet unspecified whether timestamps are given in Unix time (UTC) or TAI.
+///
+/// # Evolution
+///
+/// Currently this is set up to provide interval and ray time. It may need more interfaces later in
+/// order to also accommodate usages where a `cnonce` is generated (which may then be used to
+/// either just validate a token's time constraints, or may be used together with an `iat` in the
+/// subsequent token to enhance the device's understanding of time).
+///
+/// Given that the 2038 problem can be mitigated also by using a different offset, we might
+/// consider switching to an internal u32 based type that expresses Unix time / TAI with an offset
+/// -- while the 130 years expressible with it are coming to an end, I'm relatively sure that we
+/// can get away with limiting the usable range to 130 years starting from when a concrete firmware
+/// is built.
+pub trait TimeProvider {
+    /// Confidence interval of the clock as lower and upper bound.
+    fn now(&mut self) -> (u64, Option<u64>);
+
+    /// Informs the clock that a credential has been ingested from a trusted AS that claims this
+    /// time to be in the past.
+    #[expect(
+        unused_variables,
+        reason = "Names are human visible part of API description"
+    )]
+    fn past_trusted(&mut self, timestamp: u64) {}
+}
+
+impl<T: TimeProvider> TimeProvider for &mut T {
+    fn now(&mut self) -> (u64, Option<u64>) {
+        (*self).now()
+    }
+
+    fn past_trusted(&mut self, timestamp: u64) {
+        (*self).past_trusted(timestamp)
+    }
+}
+
+/// A time provider that knows nothing.
+///
+/// It ignores any input, and always produces the maximum uncertainty.
+pub struct TimeUnknown;
+
+impl TimeProvider for TimeUnknown {
+    #[inline]
+    fn now(&mut self) -> (u64, Option<u64>) {
+        (0, None)
+    }
+}
+
+/// A processed set of token claims that limit it in time.
+pub struct TimeConstraint {
+    // iat would not go in here (that's only to feed a `TimeProvider::past_trusted`; nbf would go
+    // in here but we don't read that yet)
+    exp: Option<u64>,
+}
+
+impl TimeConstraint {
+    /// Creates a [`TimeConstraints`] with no bounds; it is valid at any time.
+    pub(crate) fn unbounded() -> Self {
+        Self { exp: None }
+    }
+
+    /// Extract time constraint from a claim.
+    ///
+    /// This is infallible as long as all relevant constraints on the value can be encoded in the
+    /// ace module; doing that is preferable because it eases error tracking.
+    pub fn from_claims_set(claims: &crate::ace::CwtClaimsSet<'_>) -> Self {
+        TimeConstraint {
+            exp: Some(claims.exp),
+        }
+    }
+
+    /// Evaluates the constraint against time provided by the time provider.
+    ///
+    /// Any uncertainty of the time provider is counted for the benefit of the client.
+    pub(crate) fn is_valid_with(&self, time_provider: &mut impl TimeProvider) -> bool {
+        let Some(exp) = self.exp else {
+            return true;
+        };
+        let (now_early, _now_late) = time_provider.now();
+
+        exp > now_early
+    }
+}


### PR DESCRIPTION
# Description

Issued ACE tokens often have limited lifetime; this adds the APIs to coapcore to evaluate that aspect.
As it required touching some signatures and pub'nesses, the PR also contains changes to reduce and harmonize the public surface before coapcore's API can stabilized for a 0.1 release.

## Issues/PRs references

Currently we don't have "wall time" in Ariel OS (but even if we had, we'd need it trusted).

For this first iteration, Ariel OS just uses the zero-sized "we don't know the time" configuration. Once we start using configuration storage more actively, we can progress from "we don't know anything" to "this can't be valid because we've seen a way newer token" on to [full raytime](https://datatracker.ietf.org/doc/draft-amsuess-t2trg-raytime/).

## Change checklist


- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
