### PR TITLE
feat(coap): model in laze and autostart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-runqueue"
-version = "0.1.2"
+version = "0.1.0"
 dependencies = [
  "defmt",
  "hax-lib",
@@ -904,27 +904,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "coap"
-version = "0.0.0"
-dependencies = [
- "ariel-os",
- "ariel-os-boards",
- "ariel-os-coap",
- "coap-handler",
- "coap-handler-implementations",
- "coap-message",
- "coap-message-demos",
- "coap-request",
- "coap-request-implementations",
- "coap-scroll-ring-server",
- "embassy-futures",
- "embassy-sync 0.6.2",
- "embedded-nal-coap",
- "heapless 0.8.0",
- "scroll-ring",
-]
-
-[[package]]
 name = "coap-blinky"
 version = "0.0.0"
 dependencies = [
@@ -933,19 +912,6 @@ dependencies = [
  "coap-handler-implementations",
  "heapless 0.8.0",
  "riot-coap-handler-demos",
-]
-
-[[package]]
-name = "coap-client"
-version = "0.0.0"
-dependencies = [
- "ariel-os",
- "ariel-os-boards",
- "coap-handler-implementations",
- "coap-request",
- "coap-request-implementations",
- "embedded-nal-coap",
- "heapless 0.8.0",
 ]
 
 [[package]]
@@ -1068,20 +1034,6 @@ dependencies = [
  "coap-message-utils",
  "coap-numbers",
  "scroll-ring",
-]
-
-[[package]]
-name = "coap-server"
-version = "0.0.0"
-dependencies = [
- "ariel-os",
- "ariel-os-boards",
- "coap-handler",
- "coap-handler-implementations",
- "coap-message",
- "coap-message-demos",
- "embassy-sync 0.6.2",
- "heapless 0.8.0",
 ]
 
 [[package]]
@@ -2476,6 +2428,33 @@ version = "0.1.0"
 dependencies = [
  "ariel-os-debug",
  "ariel-os-rt",
+]
+
+[[package]]
+name = "example-coap-client"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+ "coap-handler-implementations",
+ "coap-request",
+ "coap-request-implementations",
+ "embedded-nal-coap",
+ "heapless 0.8.0",
+]
+
+[[package]]
+name = "example-coap-server"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+ "coap-handler",
+ "coap-handler-implementations",
+ "coap-message",
+ "coap-message-demos",
+ "embassy-sync 0.6.2",
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -5051,6 +5030,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-coap"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+ "ariel-os-coap",
+ "coap-handler",
+ "coap-handler-implementations",
+ "coap-message",
+ "coap-message-demos",
+ "coap-request",
+ "coap-request-implementations",
+ "coap-scroll-ring-server",
+ "embassy-futures",
+ "embassy-sync 0.6.2",
+ "embedded-nal-coap",
+ "heapless 0.8.0",
+ "scroll-ring",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,7 @@ version = "0.1.0"
 dependencies = [
  "ariel-os-debug",
  "ariel-os-embassy",
+ "ariel-os-macros",
  "ariel-os-random",
  "cbor-macro",
  "cboritem",

--- a/examples/coap-client/Cargo.toml
+++ b/examples/coap-client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "coap-client"
+name = "example-coap-client"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/coap-client/Cargo.toml
+++ b/examples/coap-client/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 
 [dependencies]
 heapless = { workspace = true }
-ariel-os = { path = "../../src/ariel-os", features = ["coap"] }
+ariel-os = { path = "../../src/ariel-os" }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 embedded-nal-coap = { workspace = true }
 coap-request = "0.2.0-alpha.2"

--- a/examples/coap-client/laze.yml
+++ b/examples/coap-client/laze.yml
@@ -1,5 +1,5 @@
 apps:
-  - name: coap-client
+  - name: example-coap-client
     env:
       global:
         CARGO_ENV:

--- a/examples/coap-client/laze.yml
+++ b/examples/coap-client/laze.yml
@@ -5,8 +5,7 @@ apps:
         CARGO_ENV:
           - CONFIG_ISR_STACKSIZE=32768
     selects:
-      - network
-      - random
+      - coap-client
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi

--- a/examples/coap-client/src/main.rs
+++ b/examples/coap-client/src/main.rs
@@ -5,15 +5,6 @@
 
 use ariel_os::debug::log::info;
 
-/// Run a CoAP stack without serving any actual resources.
-#[ariel_os::task(autostart)]
-async fn coap_run() {
-    use coap_handler_implementations::new_dispatcher;
-
-    let handler = new_dispatcher();
-    ariel_os::coap::coap_run(handler).await;
-}
-
 #[ariel_os::task(autostart)]
 async fn run_client_operations() {
     use coap_request::Stack;

--- a/examples/coap-server/Cargo.toml
+++ b/examples/coap-server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "coap-server"
+name = "example-coap-server"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/coap-server/Cargo.toml
+++ b/examples/coap-server/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 [dependencies]
 embassy-sync = { workspace = true }
 heapless = { workspace = true }
-ariel-os = { path = "../../src/ariel-os", features = ["coap"] }
+ariel-os = { path = "../../src/ariel-os" }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 coap-message = "0.3.2"
 coap-message-demos = { version = "0.4.0", default-features = false }

--- a/examples/coap-server/laze.yml
+++ b/examples/coap-server/laze.yml
@@ -1,5 +1,5 @@
 apps:
-  - name: coap-server
+  - name: example-coap-server
     env:
       global:
         CARGO_ENV:

--- a/examples/coap-server/laze.yml
+++ b/examples/coap-server/laze.yml
@@ -5,8 +5,7 @@ apps:
         CARGO_ENV:
           - CONFIG_ISR_STACKSIZE=32768
     selects:
-      - network
-      - random
+      - coap-server
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -760,6 +760,33 @@ modules:
         FEATURES:
           - ariel-os/hwrng
 
+  - name: coap
+    help: Basic support for the CoAP protocol.
+
+      On its own, this does nothing but load code; this should be auto-selected
+      by coap-client and/or coap-server as per the needs of other modules and
+      the application.
+    depends:
+      - random
+      - network
+
+  - name: coap-server
+    help: Support for applications to set up CoAP server handlers.
+
+      When an application selects this, it needs to run `ariel_os::coap_run()`
+      in a task; otherwise, other components (eg. system components that also
+      run on the CoAP server, or the CoAP client that depends on the server
+      loop to run) get stalled.
+    # Modules that want to inject a CoAP server will *not* depend on this, and
+    # will have their own entry point when they exist.
+    depends:
+      - coap
+
+  - name: coap-client
+    help: Support for CoAP client functionality.
+    depends:
+      - coap
+
   - name: random
     help: A system-wide RNG is available (through the ariel_os::random module).
 

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -785,6 +785,10 @@ modules:
     # will have their own entry point when they exist.
     depends:
       - coap
+    env:
+      global:
+        FEATURES:
+          - ariel-os/coap-server
 
   - name: coap-client
     help: Support for CoAP client functionality.

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -769,6 +769,10 @@ modules:
     depends:
       - random
       - network
+    env:
+      global:
+        FEATURES:
+          - ariel-os/coap
 
   - name: coap-server
     help: Support for applications to set up CoAP server handlers.

--- a/src/ariel-os-coap/Cargo.toml
+++ b/src/ariel-os-coap/Cargo.toml
@@ -29,6 +29,7 @@ lakers = { version = "0.7.2", default-features = false }
 ariel-os-debug.workspace = true
 ariel-os-embassy = { workspace = true, features = ["net"] }
 ariel-os-random = { workspace = true, features = ["csprng"] }
+ariel-os-macros = { path = "../ariel-os-macros" }
 static_cell = "2.1.0"
 
 # FIXME: Should go out eventually
@@ -43,9 +44,19 @@ embedded-io-async = "0.6.1"
 workspace = true
 
 [features]
+# Enables the coap_run function through which a server is passed in. The
+# crate setting this must call `ariel_os{_,::}coap::coap_run()`; if not set,
+# that function is run with a default minimal server automatically (as is
+# required by the implementation to have client functionality).
+#
+# At the feature level, this is a bit of a misnomer, could also be
+# called "manual-server-start"; the name is chosen to align with
+# laze's name for this (where coap-server makes more sense).
+coap-server = []
+
 ## Enables an arbitrary set of features in dependencies where dependencies fail
 ## if no features are configured at all.
-doc = ["embassy-net/proto-ipv6", "embassy-net/medium-ip"]
+doc = ["embassy-net/proto-ipv6", "embassy-net/medium-ip", "coap-server"]
 
 ## Enables defmt logging of coapcore
 defmt = ["coapcore/defmt"]

--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -83,6 +83,13 @@ async fn coap_run_impl(handler: impl coap_handler::Handler + coap_handler::Repor
 
     let stack = ariel_os_embassy::net::network_stack().await.unwrap();
 
+    // There's no strong need to wait this early (it matters that we wait before populating
+    // CLIENT), but this is a convenient place in the code (we have a `stack` now, to populate
+    // CLIENT after the server, we'd have to poll the server and `wait_config_up` in parallel), and
+    // it's not like we'd expect requests to come in before everything is up. (Not even a loopback
+    // request, because we shouldn't hand out a client early).
+    stack.wait_config_up().await;
+
     // FIXME trim to CoAP requirements
     let mut rx_meta = [PacketMetadata::EMPTY; 16];
     let mut rx_buffer = [0; 4096];

--- a/src/ariel-os-embassy/src/sendcell.rs
+++ b/src/ariel-os-embassy/src/sendcell.rs
@@ -24,7 +24,7 @@ unsafe impl<T> Send for SendCell<T> {}
 /// handle for the current [`Spawner`] themselves. They internally call the non-async versions. Use
 /// the sync versions if a [`Spawner`] object is available or the async versions cannot be used,
 /// e.g., in closures. Otherwise, the async versions are also fine.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SendCell<T> {
     executor_id: usize,
     inner: T,

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -59,6 +59,13 @@ dns = ["ariel-os-embassy/dns"]
 mdns = ["ariel-os-embassy/mdns"]
 ## Enables support for [CoAP](https://ariel-os.github.io/ariel-os/dev/docs/book/tooling/coap.html).
 coap = ["dep:ariel-os-coap", "random"]
+## Support for applications to set up CoAP server handlers.
+##
+## When an application selects this, it needs to run `ariel_os::coap_run()`
+## in a task; otherwise, other components (eg. system components that also
+## run on the CoAP server, or the CoAP client that depends on the server
+## loop to run) get stalled.
+coap-server = ["coap", "ariel-os-coap/coap-server"]
 ## Selects static IP configuration.
 network-config-static = ["ariel-os-embassy/network-config-static"]
 

--- a/tests/coap-blinky/Cargo.toml
+++ b/tests/coap-blinky/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 workspace = true
 
 [dependencies]
-ariel-os = { path = "../../src/ariel-os", features = ["coap", "udp"] }
+ariel-os = { path = "../../src/ariel-os" }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 coap-handler-implementations = "0.5.0"
 

--- a/tests/coap-blinky/laze.yml
+++ b/tests/coap-blinky/laze.yml
@@ -5,8 +5,7 @@ apps:
         CARGO_ENV:
           - CONFIG_ISR_STACKSIZE=32768
     selects:
-      - network
-      - random
+      - coap-server
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi

--- a/tests/coap/Cargo.toml
+++ b/tests/coap/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "coap"
+name = "test-coap"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/tests/coap/Cargo.toml
+++ b/tests/coap/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 [dependencies]
 embassy-sync = { workspace = true }
 heapless = { workspace = true }
-ariel-os = { path = "../../src/ariel-os", features = ["coap", "udp"] }
+ariel-os = { path = "../../src/ariel-os" }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 embassy-futures = "0.1.1"
 embedded-nal-coap = { workspace = true }

--- a/tests/coap/laze.yml
+++ b/tests/coap/laze.yml
@@ -5,8 +5,8 @@ apps:
         CARGO_ENV:
           - CONFIG_ISR_STACKSIZE=32768
     selects:
-      - network
-      - random
+      - coap-server
+      - coap-client
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi

--- a/tests/coap/laze.yml
+++ b/tests/coap/laze.yml
@@ -1,5 +1,5 @@
 apps:
-  - name: coap
+  - name: test-coap
     env:
       global:
         CARGO_ENV:


### PR DESCRIPTION
# Description

This is a first step for modelling ariel-os's `coap` feature in laze. Reasons:

* Examples currently need to manually select random and network (yuck)
* We'll want to do more later (eg. run an CoAP "main loop" automatically if client and not server is selected, making the coap-client easier)

## Open Questions

* Will I go beyond what is in the first few commits in this PR, or in a separate one? (Next steps are auto-starting the server and setting server policy and even identity through this.)

  * A: Yes to auto-starting the server (because that corresponds to the initial comments around the laze entries), no to more (because some of that may need discussion).

    **Remaining things to do**: model server policy (even if it's just a "pick the demo stuff"), provide public function that people should build their request handler on (even if it's just never_found() right now).

## Issue relations

Closes: https://github.com/ariel-os/ariel-os/issues/674

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
