### PR TITLE
refactor(macros): enable internal autostart

### DIFF
--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -69,6 +69,10 @@ pub mod reexports {
     pub use usbd_hid;
     // Used by a macro we provide
     pub use embassy_executor;
+    // Used by macros for task autostarting.
+    // (In most applications, it'd suffice to have this in ariel-os, but not when an internal crate
+    // does an autostart)
+    pub use linkme;
 }
 
 #[cfg(feature = "net")]

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -26,8 +26,7 @@ mod wifi;
 
 use ariel_os_debug::log::debug;
 
-// re-exports
-pub use linkme::{self, distributed_slice};
+use linkme::distributed_slice;
 
 // All items of this module are re-exported at the root of `ariel_os`.
 pub mod api {

--- a/src/ariel-os-macros/src/task.rs
+++ b/src/ariel-os-macros/src/task.rs
@@ -80,7 +80,7 @@ pub fn task(args: TokenStream, item: TokenStream) -> TokenStream {
 
     // TODO: forbid generics on the function
 
-    let ariel_os_crate = utils::ariel_os_crate();
+    let ariel_os_crate = utils::ariel_os_crate_or_internal(Some("ariel-os-embassy"));
 
     let expanded = if attrs.autostart {
         let peripheral_param = if attrs.peripherals {
@@ -205,7 +205,7 @@ mod task {
         pub fn hook_definitions() -> [HookDefinition; 1] {
             use quote::quote;
 
-            let ariel_os_crate = crate::utils::ariel_os_crate();
+            let ariel_os_crate = crate::utils::ariel_os_crate_or_internal(Some("ariel-os-embassy"));
 
             // New hooks need to be defined here, in the order they are run during system
             // initialization

--- a/src/ariel-os-macros/src/utils.rs
+++ b/src/ariel-os-macros/src/utils.rs
@@ -10,8 +10,28 @@ const ARIEL_OS_CRATE_NAME: &str = "ariel-os";
 ///   this function is called.
 /// - Panics if `ariel-os` is used as a dependency of itself.
 pub fn ariel_os_crate() -> syn::Ident {
+    ariel_os_crate_or_internal(None)
+}
+
+/// Returns a [`struct@syn::Ident`] identifying the `ariel-os` dependency, or an (internal)
+/// fallback crate that provides the same relevant items.
+///
+/// # Panics
+///
+/// - Panics when neither crate can be found as a dependency of the crate in which
+///   this function is called.
+/// - Panics if either crate is used as a dependency of itself.
+pub fn ariel_os_crate_or_internal(internal: Option<&'static str>) -> syn::Ident {
     find_crate(ARIEL_OS_CRATE_NAME)
-        .unwrap_or_else(|| panic!("{ARIEL_OS_CRATE_NAME} should be present in `Cargo.toml`"))
+        .or_else(|| find_crate(internal?))
+        .unwrap_or_else(|| {
+            panic!(
+                "{ARIEL_OS_CRATE_NAME} should be present in `Cargo.toml`{}",
+                internal
+                    .map(|i| format!(" (internal crates may also use {i})"))
+                    .unwrap_or_default()
+            )
+        })
 }
 
 /// Returns a [`struct@syn::Ident`] identifying the `name` dependency (or `None`).

--- a/src/ariel-os/src/lib.rs
+++ b/src/ariel-os/src/lib.rs
@@ -62,6 +62,5 @@ pub mod config {
 pub mod reexports {
     pub use ariel_os_embassy::reexports::*;
     // These are used by proc-macros we provide
-    pub use linkme;
     pub use static_cell;
 }


### PR DESCRIPTION
# Description

Internal crates with rather lose coupling [may want to](https://github.com/ariel-os/ariel-os/pull/755) run autostart locally rather than hooking in a big task starting routine.

This PR enables that.

## Issues/PRs references

Commits are cherry-picked from https://github.com/ariel-os/ariel-os/pull/755, where there is a use case that tests them.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
