### PR TITLE
feat(net): use an RNG to seed the network stack, when already enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "heapless 0.8.0",
  "linkme",
  "once_cell",
+ "rand_core",
  "static_cell",
  "usbd-hid",
 ]

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 const_panic.workspace = true
 critical-section.workspace = true
 linkme.workspace = true
+rand_core = { workspace = true, optional = true }
 static_cell.workspace = true
 cfg-if.workspace = true
 
@@ -77,6 +78,8 @@ usb-hid = ["dep:usbd-hid", "embassy-usb?/usbd-hid", "usb"]
 # embassy-net requires embassy-time and support for timeouts in the executor
 net = ["dep:embassy-net", "time"]
 usb-ethernet = ["usb", "net"]
+
+random = ["dep:ariel-os-random", "dep:rand_core"]
 ## Use a hardware RNG to seed into the ariel-os-random system-wide RNG
 hwrng = ["ariel-os-hal/hwrng"]
 

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -313,12 +313,12 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
 
         let config = net::config();
 
-        // Generate random seed
-        // let mut rng = Rng::new(p.RNG, Irqs);
-        // let mut seed = [0; 8];
-        // rng.blocking_fill_bytes(&mut seed);
-        // let seed = u64::from_le_bytes(seed);
+        // This seed is mostly used by smoltcp and does not have to be cryptographically secure.
+        #[cfg(feature = "random")]
+        let seed = rand_core::RngCore::next_u64(&mut ariel_os_random::fast_rng());
+        #[cfg(not(feature = "random"))]
         let seed = 1234u64;
+        debug!("Network stack seed: {:#x}", seed);
 
         // Init network stack
         static RESOURCES: StaticCell<StackResources<MAX_CONCURRENT_SOCKETS>> = StaticCell::new();

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -42,7 +42,7 @@ threading = [
 ## Enables the internal executor's timer queue, required for timer support.
 time = ["ariel-os-embassy/time"]
 ## Enables the [`random`] module.
-random = ["ariel-os-random"]
+random = ["ariel-os-embassy/random", "ariel-os-random"]
 ## Enables a cryptographically secure random number generator in the [`random`] module.
 csprng = ["ariel-os-random/csprng"]
 ## Enables seeding the random number generator from hardware.


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The network stack was previously using a hard-coded seed.
This seed is used internally by `embassy_net` and by [smoltcp](https://docs.rs/smoltcp/latest/smoltcp/iface/struct.Config.html#structfield.random_seed) to avoid collisions between random network numbers (TCP ports/sequence numbers).

This only uses an RNG for seeding if support for one is already being compiled, and defaults to the hard-coded seed otherwise. We may revisit this in the future.

## How to test this PR

Use a network-enabled example (e.g., `tcp-echo`), and enable `debug`-level logging with `-DLOG=debug`. The seed used is printed (it is not a cryptography secret). Run the example without modifications, it should print the hard-coded seed:
```
DEBUG Network stack seed: 0x4d2
```

Then, enable the `random` laze module in that example, and run the example again; it should now print a random seed:

```
DEBUG Network stack seed: 0x[random value]
```

Run the example again to verify a different value is used this time.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
