### PR TITLE
feat(stm32): add partial support for persistent storage

### DIFF
--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -166,7 +166,7 @@
       <td class="support-cell" title="not available on this piece of hardware">–</td>
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+      <td class="support-cell" title="supported with some caveats">☑️</td>
     </tr>
     <tr>
       <td>STM32W55RGVX</td>
@@ -182,7 +182,7 @@
       <td class="support-cell" title="not available on this piece of hardware">–</td>
       <td class="support-cell" title="supported">✅</td>
       <td class="support-cell" title="supported">✅</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+      <td class="support-cell" title="supported with some caveats">☑️</td>
     </tr>
   </tbody>
 </table>

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -143,7 +143,10 @@ chips:
       i2c_controller: not_currently_supported
       spi_main: not_currently_supported
       logging: supported
-      storage: not_currently_supported
+      storage:
+        status: not_currently_supported
+        comments:
+          - unsupported heterogeneous flash organization
       wifi: not_available
 
   stm32h755zitx:
@@ -155,7 +158,10 @@ chips:
       i2c_controller: supported
       spi_main: supported
       logging: supported
-      storage: not_currently_supported
+      storage:
+        status: supported_with_caveats
+        comments:
+          - removing items not supported
       wifi: not_available
 
   stm32wb55rgvx:
@@ -167,7 +173,10 @@ chips:
       i2c_controller: supported
       spi_main: supported
       logging: supported
-      storage: not_currently_supported
+      storage:
+        status: supported_with_caveats
+        comments:
+          - removing items not supported
       wifi: not_available
 
 # Encodes support status for each board.

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -669,6 +669,8 @@ modules:
       - rp2040
       - nrf52840
       - nrf5340
+      - stm32h755zitx
+      - stm32wb55rgvx
     env:
       global:
         FEATURES:

--- a/src/ariel-os-hal/Cargo.toml
+++ b/src/ariel-os-hal/Cargo.toml
@@ -73,7 +73,7 @@ storage = [
   #"ariel-os-esp/storage",
   "ariel-os-nrf/storage",
   "ariel-os-rp/storage",
-  #"ariel-os-stm32/storage",
+  "ariel-os-stm32/storage",
 ]
 
 wifi-cyw43 = ["ariel-os-rp/wifi-cyw43"]

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -53,6 +53,9 @@ i2c = [
 ## Enables SPI support.
 spi = ["dep:embassy-embedded-hal", "ariel-os-embassy-common/spi"]
 
+## Enables storage support.
+storage = ["dep:embassy-embedded-hal"]
+
 ## Enables USB support.
 usb = []
 # These are chosen automatically by ariel-os-boards and select the correct stm32

--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -25,6 +25,10 @@ pub mod identity;
 #[cfg(feature = "spi")]
 pub mod spi;
 
+#[cfg(feature = "storage")]
+#[doc(hidden)]
+pub mod storage;
+
 use embassy_stm32::Config;
 
 #[doc(hidden)]

--- a/src/ariel-os-stm32/src/storage.rs
+++ b/src/ariel-os-stm32/src/storage.rs
@@ -1,0 +1,26 @@
+// TODO: we may later want to introduce a Cargo feature for async flash drivers, possibly enabled
+// by laze.
+
+use embassy_stm32::flash;
+
+#[cfg(context = "stm32f401retx")]
+embassy_stm32::bind_interrupts!(struct Irqs {
+    FLASH => flash::InterruptHandler;
+});
+
+#[cfg(context = "stm32f401retx")]
+pub type Flash = flash::Flash<'static>;
+#[cfg(any(context = "stm32h755zitx", context = "stm32wb55rgvx",))]
+pub type Flash =
+    embassy_embedded_hal::adapter::BlockingAsync<flash::Flash<'static, flash::Blocking>>;
+pub type FlashError = flash::Error;
+
+pub fn init(peripherals: &mut crate::OptionalPeripherals) -> Flash {
+    #[cfg(context = "stm32f401retx")]
+    let flash = flash::Flash::new(peripherals.FLASH.take().unwrap(), Irqs);
+    #[cfg(any(context = "stm32h755zitx", context = "stm32wb55rgvx",))]
+    let flash = embassy_embedded_hal::adapter::BlockingAsync::new(flash::Flash::new_blocking(
+        peripherals.FLASH.take().unwrap(),
+    ));
+    flash
+}

--- a/src/ariel-os-storage/build.rs
+++ b/src/ariel-os-storage/build.rs
@@ -1,24 +1,47 @@
 use std::{env, path::PathBuf};
 
-fn main() {
-    // TODO: These should be configurable. Like this, it works for MCUs with
-    // a flash page size <= 4KiB.
-    const FLASH_PAGE_SIZE: u32 = 0x1000;
-    const STORAGE_SIZE_TOTAL: u32 = 0x2000;
+const KIBIBYTES: u32 = 1024;
 
-    // need at least two flash pages
-    // TODO: uncomment once this is not always true
-    //assert!(STORAGE_SIZE_TOTAL / FLASH_PAGE_SIZE >= 2);
+fn main() {
+    // NOTE(hal): values of `flash_page_size` from the datasheets, confirmed by HAL's constants.
+    // Important: only homogeneous flash organizations are currently supported.
+    // Trying to restrict the storage size to the subset of homogeneous flash would not work as it
+    // could be pushed out of it by a large enough binary.
+    let (storage_size_total, flash_page_size) =
+        if is_in_current_contexts(&["nrf52", "nrf5340", "rp2040", "stm32wb55rgvx"]) {
+            (8 * KIBIBYTES, 4 * KIBIBYTES)
+        } else if is_in_current_contexts(&["stm32h755zitx"]) {
+            (256 * KIBIBYTES, 128 * KIBIBYTES)
+        } else if !is_in_current_contexts(&["ariel-os"]) {
+            // Dummy value for platform-independent tooling.
+            (8 * KIBIBYTES, 4 * KIBIBYTES)
+        } else {
+            panic!("MCU not supported");
+        };
+
+    // `sequential-storage` needs at least two flash pages.
+    assert!(storage_size_total / flash_page_size >= 2);
 
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
     let mut storage_template = std::fs::read_to_string("storage.ld.in").unwrap();
-    storage_template = storage_template.replace("${ALIGNMENT}", &format!("{FLASH_PAGE_SIZE}"));
-    storage_template = storage_template.replace("${SIZE}", &format!("{STORAGE_SIZE_TOTAL}"));
+    storage_template = storage_template.replace("${ALIGNMENT}", &format!("{flash_page_size}"));
+    storage_template = storage_template.replace("${SIZE}", &format!("{storage_size_total}"));
 
     std::fs::write(out.join("storage.x"), &storage_template).unwrap();
 
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_CONTEXT");
     println!("cargo:rerun-if-changed=storage.ld.in");
     println!("cargo:rustc-link-search={}", out.display());
+}
+
+/// Returns whether any of the current `cfg` contexts is one of the given contexts.
+fn is_in_current_contexts(contexts: &[&str]) -> bool {
+    let Ok(context_var) = std::env::var("CARGO_CFG_CONTEXT") else {
+        return false;
+    };
+
+    // Contexts cannot include commas.
+    context_var.split(',').any(|c| contexts.contains(&c))
 }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This adds partial support for flash-backed persistent storage to the currently supported STM32 MCUs, which only support blocking drivers. This makes `ariel_os::storage::remove()` unavailable on that MCU family, as flash drivers do not implement `MultiwriteNorFlash`. We may want to revisit how we handle this limitation.

This only supports homogeneous flash organization (therefore precluding support for STM32F401RE); support for heterogeneous organization can be addressed in the future.

## How to review this PR

- The `storage` example works as expected on STM32H755ZI, STM32WB55RG.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
