### PR TITLE
ci(lint): add basic checking of internal links in PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -322,3 +322,24 @@ jobs:
 
       - name: typos
         uses: crate-ci/typos@v1.22.0
+
+      - name: Install mdbook and mdbook utils
+        uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook, mdbook-cmdrun
+
+      - name: Check for unexpected cmdrun uses
+        run: |
+            cd book
+            ./cmdrun-check.sh
+
+      - name: Build the book
+        run: |
+          cd book
+          mdbook build
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --offline --require-https --no-progress --include-fragments --include-verbatim -v '*.md' book/book
+          fail: true


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This is a first step in automatically checking our links in PRs. The goal of this is *not* to check for external 404s in a scheduled manner, only to check internal, relative links—*including fragments/anchors*—especially in the book, in each PR.

The goal is to give us assurance that our internal links are not broken and that we don't have to hold ourselves back from cross-linking as much as we want so as to make the docs as clear and useful as possible (from fear of typos or of our links becoming outdated).

[lychee](https://github.com/lycheeverse/lychee) has been chosen as the link checker because:

- It seems feature-full enough that we should be able to configure it to make it work in our complex multi-output PRs/future workflows.
- It's popular (2.4 k GH stars at the time of writing).
- It has an official GitHub Action.
- It's written in Rust.

## Future work

This is only a first step and we may later want to:

- Check links from the rustdoc docs
- Check external links in PRs to avoid typos
- Check external links with a scheduled workflow to notify about outdated links

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #834.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
