### PR TITLE
feat(esp): solve esp XOR wifi for xtensa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ name = "ariel-os-embassy-common"
 version = "0.1.0"
 dependencies = [
  "ariel-os-buildinfo",
+ "ariel-os-utils",
  "const-sha1",
  "defmt",
  "embassy-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ esp-hal = { version = "0.23.1", default-features = false, features = [
 esp-hal-embassy = { version = "0.6.0", default-features = false }
 esp-println = { version = "0.13.0" }
 esp-wifi = { version = "0.12.0", default-features = false }
+esp-wifi-sys = { version = "0.7.1", default-features = false }
 
 esp-storage = { version = "0.4.0" }
 xtensa-lx-rt = { version = "0.18.0", default-features = false }
@@ -121,6 +122,7 @@ ariel-os-rt = { path = "src/ariel-os-rt" }
 ariel-os-runqueue = { path = "src/ariel-os-runqueue" }
 ariel-os-stm32 = { path = "src/ariel-os-stm32" }
 ariel-os-storage = { path = "src/ariel-os-storage" }
+ariel-os-threads = { path = "src/ariel-os-threads" }
 ariel-os-utils = { path = "src/ariel-os-utils", default-features = false }
 
 const_panic = { version = "0.2.8", default-features = false }

--- a/ariel-os-cargo.toml
+++ b/ariel-os-cargo.toml
@@ -26,13 +26,13 @@ embassy-rp = { git = "https://github.com/ariel-os/embassy", branch = "embassy-rp
 embassy-stm32 = { git = "https://github.com/ariel-os/embassy", branch = "embassy-stm32-v0.2.0+ariel-os" }
 
 # ariel-os esp-hal fork
-esp-alloc = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os" }
-esp-hal = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os" }
-esp-hal-embassy = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os" }
-esp-println = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os" }
-esp-wifi = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os" }
-esp-storage = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os" }
-xtensa-lx-rt = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os" }
+esp-alloc = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os-threads" }
+esp-hal = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os-threads" }
+esp-hal-embassy = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os-threads" }
+esp-println = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os-threads" }
+esp-wifi = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os-threads" }
+esp-storage = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os-threads" }
+xtensa-lx-rt = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os-threads" }
 
 # patched to use portable-atomics <https://github.com/seanmonstar/try-lock/pull/11>
 try-lock = { git = "https://github.com/seanmonstar/try-lock", rev = "a1aadfac9840fe23672159c12af7272e44bc684c" }

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -138,10 +138,7 @@ chips:
       spi_main: needs_testing
       logging: supported
       storage: not_currently_supported
-      wifi:
-        status: supported_with_caveats
-        comments:
-          - not currently compatible with threading
+      wifi: supported
 
   stm32f401retx:
     name: STM32F401RETX

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -917,6 +917,9 @@ modules:
       # - esp32s2
 
   - name: wifi-esp
+    depends: # using depends so the following syntax works
+      - riscv:
+          - wifi-esp-xor-threads
     context:
       - esp
     provides_unique:
@@ -925,6 +928,12 @@ modules:
       global:
         FEATURES:
           - ariel-os/wifi-esp
+
+  - name: wifi-esp-xor-threads
+    help: Helper module to conditionally make esp-wifi conflict with threads on esp32 riscv
+    depends: # using depends so the following syntax works
+      - sw/threading:
+          - wifi-with-threads-currently-broken-on-esp-riscv
 
   - name: executor-thread
     help: use embassy executor within ariel-os-threads thread

--- a/src/ariel-os-embassy-common/Cargo.toml
+++ b/src/ariel-os-embassy-common/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 ariel-os-buildinfo = { workspace = true }
+ariel-os-utils = { workspace = true }
 defmt = { workspace = true, optional = true }
 fugit = { workspace = true, optional = true }
 embassy-futures = { workspace = true }
@@ -29,5 +30,7 @@ i2c = ["dep:fugit"]
 spi = ["dep:fugit"]
 
 defmt = ["dep:defmt", "fugit?/defmt"]
+
+executor-thread = []
 
 _test = ["i2c", "spi", "external-interrupts"]

--- a/src/ariel-os-embassy-common/src/executor_thread.rs
+++ b/src/ariel-os-embassy-common/src/executor_thread.rs
@@ -1,0 +1,15 @@
+//! Executor thread configuration.
+
+/// Stack size used by the main executor thread.
+pub const STACKSIZE: usize = ariel_os_utils::usize_from_env_or!(
+    "CONFIG_EXECUTOR_THREAD_STACKSIZE",
+    16384,
+    "executor thread stack size"
+);
+
+/// Priority used by the main executor thread.
+pub const PRIORITY: u8 = ariel_os_utils::u8_from_env_or!(
+    "CONFIG_EXECUTOR_THREAD_PRIORITY",
+    8,
+    "executor thread priority"
+);

--- a/src/ariel-os-embassy-common/src/lib.rs
+++ b/src/ariel-os-embassy-common/src/lib.rs
@@ -10,6 +10,9 @@ pub mod gpio;
 #[cfg(context = "cortex-m")]
 pub mod executor_swi;
 
+#[cfg(feature = "executor-thread")]
+pub mod executor_thread;
+
 #[cfg(feature = "i2c")]
 pub mod i2c;
 

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -101,7 +101,7 @@ wifi = []
 wifi-cyw43 = ["ariel-os-hal/wifi-cyw43", "net", "wifi"]
 wifi-esp = ["ariel-os-hal/wifi-esp", "net", "wifi"]
 
-threading = ["dep:ariel-os-threads"]
+threading = ["dep:ariel-os-threads", "ariel-os-hal/threading"]
 network-config-static = ["network-config-override"]
 network-config-override = []
 override-usb-config = []

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -111,7 +111,7 @@ executor-single-thread = [
   "ariel-os-rt/executor-single-thread",
 ]
 executor-interrupt = ["ariel-os-hal/executor-interrupt"]
-executor-thread = ["threading"]
+executor-thread = ["threading", "ariel-os-embassy-common/executor-thread"]
 executor-none = []
 
 defmt = [

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -10,6 +10,9 @@ pub mod gpio;
 
 pub use ariel_os_hal as hal;
 
+#[cfg(feature = "executor-thread")]
+use ariel_os_embassy_common::executor_thread;
+
 #[cfg(feature = "i2c")]
 pub mod i2c;
 
@@ -145,21 +148,6 @@ fn init() -> ! {
     EXECUTOR
         .init_with(|| hal::Executor::new())
         .run(|spawner| spawner.must_spawn(init_task(p)))
-}
-
-#[cfg(feature = "executor-thread")]
-mod executor_thread {
-    pub(crate) const STACKSIZE: usize = ariel_os_utils::usize_from_env_or!(
-        "CONFIG_EXECUTOR_THREAD_STACKSIZE",
-        16384,
-        "executor thread stack size"
-    );
-
-    pub(crate) const PRIORITY: u8 = ariel_os_utils::u8_from_env_or!(
-        "CONFIG_EXECUTOR_THREAD_PRIORITY",
-        8,
-        "executor thread priority"
-    );
 }
 
 #[cfg(feature = "executor-thread")]

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -17,12 +17,15 @@ embassy-time = { workspace = true, optional = true }
 embedded-hal = { workspace = true }
 embedded-hal-async = { workspace = true }
 esp-alloc = { workspace = true, default-features = false, optional = true }
-esp-hal = { workspace = true, default-features = false, features = ["optfield"] }
+esp-hal = { workspace = true, default-features = false, features = [
+  "optfield",
+] }
 esp-hal-embassy = { workspace = true, default-features = false }
 esp-wifi = { workspace = true, default-features = false, features = [
   "esp-alloc",
   "wifi",
 ], optional = true }
+esp-wifi-sys = { workspace = true, optional = true }
 fugit = { workspace = true, optional = true }
 once_cell = { workspace = true }
 paste = { workspace = true }
@@ -30,6 +33,7 @@ ariel-os-rt = { workspace = true, features = ["alloc"] }
 ariel-os-debug = { workspace = true }
 ariel-os-embassy-common = { workspace = true }
 ariel-os-random = { workspace = true, optional = true }
+ariel-os-threads = { workspace = true, optional = true }
 ariel-os-utils = { workspace = true }
 static_cell = { workspace = true }
 
@@ -46,6 +50,7 @@ esp-hal-embassy = { workspace = true, default-features = false, features = [
 esp-wifi = { workspace = true, default-features = false, features = [
   "esp32",
 ], optional = true }
+esp-wifi-sys = { workspace = true, optional = true, features = ["esp32"] }
 
 [target.'cfg(context = "esp32c3")'.dependencies]
 esp-hal = { workspace = true, features = ["esp32c3"] }
@@ -55,6 +60,7 @@ esp-hal-embassy = { workspace = true, default-features = false, features = [
 esp-wifi = { workspace = true, default-features = false, features = [
   "esp32c3",
 ], optional = true }
+esp-wifi-sys = { workspace = true, optional = true, features = ["esp32c3"] }
 
 [target.'cfg(context = "esp32c6")'.dependencies]
 esp-hal = { workspace = true, features = ["esp32c6"] }
@@ -64,6 +70,7 @@ esp-hal-embassy = { workspace = true, default-features = false, features = [
 esp-wifi = { workspace = true, default-features = false, features = [
   "esp32c6",
 ], optional = true }
+esp-wifi-sys = { workspace = true, optional = true, features = ["esp32c6"] }
 
 [target.'cfg(context = "esp32s3")'.dependencies]
 esp-hal = { workspace = true, features = ["esp32s3"] }
@@ -73,6 +80,7 @@ esp-hal-embassy = { workspace = true, default-features = false, features = [
 esp-wifi = { workspace = true, default-features = false, features = [
   "esp32s3",
 ], optional = true }
+esp-wifi-sys = { workspace = true, optional = true, features = ["esp32s3"] }
 
 [features]
 ## Enables GPIO interrupt support.
@@ -86,6 +94,13 @@ i2c = ["dep:fugit", "ariel-os-embassy-common/i2c"]
 
 ## Enables SPI support.
 spi = ["dep:embassy-embedded-hal", "dep:fugit", "ariel-os-embassy-common/spi"]
+
+## Enables threading support.
+threading = [
+  "esp-wifi?/preempt-extern",
+  "dep:ariel-os-threads",
+  "dep:esp-wifi-sys",
+]
 
 ## Enables defmt support.
 defmt = ["dep:defmt", "esp-hal/defmt", "esp-wifi?/defmt", "fugit?/defmt"]

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -17,7 +17,7 @@ embassy-time = { workspace = true, optional = true }
 embedded-hal = { workspace = true }
 embedded-hal-async = { workspace = true }
 esp-alloc = { workspace = true, default-features = false, optional = true }
-esp-hal = { workspace = true, default-features = false }
+esp-hal = { workspace = true, default-features = false, features = ["optfield"] }
 esp-hal-embassy = { workspace = true, default-features = false }
 esp-wifi = { workspace = true, default-features = false, features = [
   "esp-alloc",

--- a/src/ariel-os-esp/src/lib.rs
+++ b/src/ariel-os-esp/src/lib.rs
@@ -6,6 +6,9 @@
 #![feature(type_alias_impl_trait)]
 #![deny(missing_docs)]
 
+#[cfg(all(feature = "threading", feature = "wifi"))]
+mod preempt;
+
 pub mod gpio;
 
 #[cfg(feature = "hwrng")]

--- a/src/ariel-os-esp/src/preempt.rs
+++ b/src/ariel-os-esp/src/preempt.rs
@@ -1,0 +1,84 @@
+/// This module provides the hooks for `esp-wifi` to schedule its threads
+/// with the Ariel OS scheduler.
+use core::ffi::c_void;
+
+use ariel_os_debug::log::{debug, trace};
+use ariel_os_threads::{create_raw, current_tid, yield_same, THREAD_COUNT};
+use esp_wifi::{preempt::Scheduler, TimeBase};
+use esp_wifi_sys::include::malloc;
+
+static THREAD_SEMAPHORES: [usize; THREAD_COUNT] = [0; THREAD_COUNT];
+
+struct ArielScheduler {}
+
+impl Scheduler for ArielScheduler {
+    fn setup(&self, _timer: TimeBase) {
+        trace!("{}:{} setup()", file!(), line!());
+    }
+
+    fn disable(&self) {
+        trace!("{}:{} disable()", file!(), line!());
+    }
+
+    fn yield_task(&self) {
+        yield_same();
+    }
+
+    fn current_task(&self) -> *mut c_void {
+        // NOTE(no-panic): this is always called from within a thread, so the `unwrap()` doesn't
+        // panic.
+        usize::from(current_tid().unwrap()) as *mut c_void
+    }
+
+    fn task_create(
+        &self,
+        task: extern "C" fn(*mut c_void),
+        param: *mut c_void,
+        task_stack_size: usize,
+    ) -> *mut c_void {
+        trace!("{}:{} task_create()", file!(), line!());
+        // SAFETY: might return NULL, we assert it didn't below.
+        let stack = unsafe { malloc(task_stack_size as u32) };
+        assert!(!stack.is_null());
+
+        // SAFETY: We checked that `stack` has been allocated (is not NULL). `malloc` also aligns
+        // properly.
+        let stack_slice: &'static mut [u8] =
+            unsafe { core::slice::from_raw_parts_mut(stack as *mut u8, task_stack_size as usize) };
+
+        let prio = ariel_os_embassy_common::executor_thread::PRIORITY;
+        let core_affinity = None;
+
+        // SAFETY: Upholding `create_raw()` invariants: We know what we are doing.
+        let tid = unsafe {
+            create_raw(
+                task as usize,
+                param as usize,
+                stack_slice,
+                prio,
+                core_affinity,
+            )
+        };
+        usize::from(tid) as *const usize as *mut c_void
+    }
+
+    fn schedule_task_deletion(&self, _task_handle: *mut c_void) {
+        // TODO: not called from `esp-wifi` until the stack is de-initialized,
+        // which Ariel currently doesn't do. This is safe but leaks the stack.
+        debug!(
+            "{}:{} schedule_task_deletion(): leaking stack",
+            file!(),
+            line!()
+        );
+    }
+
+    fn current_task_thread_semaphore(&self) -> *mut c_void {
+        trace!("{}:{} current_task_thread_semaphore()", file!(), line!());
+        // NOTE(no-panic): this is always called from within a thread, so the `unwrap()` doesn't
+        // panic.
+        let tid = usize::from(current_tid().unwrap());
+        &THREAD_SEMAPHORES[tid] as *const usize as *mut c_void
+    }
+}
+
+esp_wifi::scheduler_impl!(static SCHEDULER: ArielScheduler = ArielScheduler{});

--- a/src/ariel-os-hal/Cargo.toml
+++ b/src/ariel-os-hal/Cargo.toml
@@ -76,6 +76,13 @@ storage = [
   "ariel-os-stm32/storage",
 ]
 
+threading = [
+  "ariel-os-esp/threading",
+  #"ariel-os-nrf/threading",
+  #"ariel-os-rp/threading",
+  #"ariel-os-stm32/threading",
+]
+
 wifi-cyw43 = ["ariel-os-rp/wifi-cyw43"]
 wifi-esp = ["ariel-os-esp/wifi-esp"]
 


### PR DESCRIPTION
# Description

This PR hooks up the Ariel scheduler to esp-wifi, enabling use of threading together with WiFi on esp.

Unfortunately there's still an issue on riscv, but this works fine on xtensa.

This piggy-backs an update to our esp fork to use `optfield` for `OptionalPeripherals` like our embassy fork has been doing for a while.

## Issues/PRs references

Alternative to #300.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
