### PR TITLE
feat(alloc): initial `embedded-alloc` integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,6 +126,7 @@ jobs:
                 usb-ethernet,
                 "
             -p ariel-os
+            -p ariel-os-alloc
             -p ariel-os-boards
             -p ariel-os-chips
             -p ariel-os-coap

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ariel-os-alloc"
+version = "0.1.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+ "ariel-os-debug",
+ "embedded-alloc",
+ "embedded-test",
+ "esp-alloc",
+]
+
+[[package]]
 name = "ariel-os-bench"
 version = "0.1.0"
 dependencies = [
@@ -256,6 +268,7 @@ dependencies = [
  "ariel-os-debug",
  "ariel-os-embassy-common",
  "ariel-os-random",
+ "ariel-os-rt",
  "ariel-os-utils",
  "cfg-if",
  "defmt",
@@ -370,6 +383,7 @@ dependencies = [
 name = "ariel-os-rt"
 version = "0.1.0"
 dependencies = [
+ "ariel-os-alloc",
  "ariel-os-debug",
  "ariel-os-threads",
  "ariel-os-utils",
@@ -536,6 +550,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1080,6 +1100,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "const-default"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "const-oid"
@@ -1824,6 +1850,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-alloc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f2de9133f68db0d4627ad69db767726c99ff8585272716708227008d3f1bddd"
+dependencies = [
+ "const-default",
+ "critical-section",
+ "rlsf",
+]
+
+[[package]]
 name = "embedded-can"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +2467,14 @@ version = "0.1.0"
 dependencies = [
  "ariel-os-debug",
  "ariel-os-rt",
+]
+
+[[package]]
+name = "example-alloc"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
 ]
 
 [[package]]
@@ -4267,7 +4312,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb1be74cb817fa6dbda417110f575d9b9ad5488817f1eb65f2f6468fe6d5d663"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "buffered-io",
  "embedded-io 0.6.1",
  "embedded-io-async",
@@ -4378,6 +4423,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "rlsf"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222fb240c3286247ecdee6fa5341e7cdad0ffdf8e7e401d9937f2d58482a20bf"
+dependencies = [
+ "cfg-if",
+ "const-default",
+ "libc",
+ "svgbobdoc",
 ]
 
 [[package]]
@@ -4941,6 +4998,19 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgbobdoc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c04b93fc15d79b39c63218f15e3fdffaa4c227830686e3b7c5f41244eb3e50"
+dependencies = [
+ "base64 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-width",
+]
 
 [[package]]
 name = "switch-hal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "src/lib/ringbuffer",
   "src/lib/coapcore",
   "src/ariel-os",
+  "src/ariel-os-alloc",
   "src/ariel-os-bench",
   "src/ariel-os-boards",
   "src/ariel-os-boards/nrf52",
@@ -101,6 +102,7 @@ xtensa-lx-rt = { version = "0.18.0", default-features = false }
 linkme = { version = "0.3.21", features = ["used_linker"] }
 
 ariel-os = { path = "src/ariel-os", default-features = false }
+ariel-os-alloc = { path = "src/ariel-os-alloc", default-features = false }
 ariel-os-bench = { path = "src/ariel-os-bench", default-features = false }
 ariel-os-boards = { path = "src/ariel-os-boards", default-features = false }
 ariel-os-buildinfo = { path = "src/ariel-os-buildinfo", default-features = false }

--- a/examples/alloc/Cargo.toml
+++ b/examples/alloc/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example-alloc"
+license.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+ariel-os = { path = "../../src/ariel-os" }
+ariel-os-boards = { path = "../../src/ariel-os-boards" }

--- a/examples/alloc/README.md
+++ b/examples/alloc/README.md
@@ -1,0 +1,12 @@
+# example-alloc
+
+## About
+
+This application shows how to enable and use an allocator and the use of the
+`alloc` crate.
+
+## How to run
+
+In this directory, run
+
+    laze build -b nrf52840dk run

--- a/examples/alloc/laze.yml
+++ b/examples/alloc/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: example-alloc
+    selects:
+      - alloc

--- a/examples/alloc/src/main.rs
+++ b/examples/alloc/src/main.rs
@@ -1,0 +1,25 @@
+#![no_main]
+#![no_std]
+#![feature(impl_trait_in_assoc_type)]
+#![feature(used_with_arg)]
+
+extern crate alloc;
+
+use ariel_os::debug::{exit, log::*, ExitCode};
+
+#[ariel_os::task(autostart)]
+async fn main() {
+    info!("Hello from `alloc` example! ");
+
+    use alloc::vec::Vec;
+
+    let i = 1;
+
+    info!("creating vector and pushing {}:", i);
+    let mut some_vec = Vec::new();
+    some_vec.push(i);
+
+    info!("some_vec[0]={}", some_vec[0]);
+
+    exit(ExitCode::SUCCESS);
+}

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -4,6 +4,7 @@ defaults:
       - ariel-os
 
 subdirs:
+  - alloc
   - benchmark
   - blinky
   - coap-client

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -378,6 +378,7 @@ modules:
           - -Clink-arg=${LINK_ARG_PREFIX}--no-eh-frame-hdr
           - -Clink-arg=-Tlinkme.x
           - -Clink-arg=-Tlink.x
+          - -Clink-arg=-Teheap.x
           - -Clink-arg=-Tdevice.x
           - -Clink-arg=-Tisr_stack.x
           - --cfg context=\"cortex-m\"
@@ -450,6 +451,14 @@ modules:
       global:
         RUSTFLAGS:
           - "-Clink-arg=-Tlink-rp.x"
+
+  ## System functionality modules
+  - name: alloc
+    context: ariel-os
+    env:
+      global:
+        FEATURES:
+          - ariel-os/alloc
 
   - name: debug-console
     context: ariel-os

--- a/src/ariel-os-alloc/Cargo.toml
+++ b/src/ariel-os-alloc/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "ariel-os-alloc"
+version = "0.1.0"
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+harness = false
+
+[dependencies]
+ariel-os-debug = { workspace = true }
+
+[target.'cfg(context = "cortex-m")'.dependencies]
+embedded-alloc = { version = "0.6.0", default-features = false, features = [
+  "tlsf",
+] }
+
+[target.'cfg(context = "esp")'.dependencies]
+esp-alloc = { workspace = true, default-features = false }
+
+[target.'cfg(context = "ariel-os")'.dev-dependencies]
+ariel-os = { path = "../../src/ariel-os", features = ["alloc"] }
+ariel-os-boards = { path = "../../src/ariel-os-boards" }
+
+embedded-test = { workspace = true }
+
+[features]
+_test = []

--- a/src/ariel-os-alloc/laze.yml
+++ b/src/ariel-os-alloc/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: crates/ariel-os-alloc
+    selects:
+      - embedded-test-only

--- a/src/ariel-os-alloc/src/lib.rs
+++ b/src/ariel-os-alloc/src/lib.rs
@@ -1,0 +1,113 @@
+//! This crate glues a suitable allocator into Ariel OS.
+
+#![no_std]
+#![deny(missing_docs)]
+#![deny(clippy::pedantic)]
+// required for tests:
+#![cfg_attr(test, no_main)]
+#![cfg_attr(test, feature(impl_trait_in_assoc_type))]
+#![cfg_attr(test, feature(used_with_arg))]
+
+// With embedded-test enabled, this crate gets built *twice*, once regularly
+// as the system alloc it is supposed to be, and once as test application.
+// In the latter case, `cfg(test)` is set.
+// So we *only* set up the global stuff if *not* testing in order to avoid clashes.
+#[cfg(not(test))]
+pub use alloc::init;
+
+#[cfg(not(test))]
+mod alloc {
+    /// Initializes the heap.
+    ///
+    /// This is called by `ariel-os-rt` early during system initialization.
+    ///
+    /// # Safety
+    ///
+    /// Call only once!
+    pub unsafe fn init() {
+        unsafe {
+            #[cfg(context = "cortex-m")]
+            init_embedded_alloc();
+            #[cfg(context = "esp")]
+            init_esp_alloc();
+            #[cfg(not(any(context = "cortex-m", context = "esp")))]
+            init_none();
+        }
+    }
+
+    /// Initializes an `embedded_alloc` heap.
+    ///
+    /// # Safety
+    ///
+    /// Call only once!
+    #[cfg(context = "cortex-m")]
+    unsafe fn init_embedded_alloc() {
+        use ariel_os_debug::log::debug;
+
+        use embedded_alloc::TlsfHeap as Heap;
+
+        #[global_allocator]
+        static HEAP: Heap = const { Heap::empty() };
+
+        extern "C" {
+            static __sheap: u32;
+            static __eheap: u32;
+        }
+
+        let start = &raw const __sheap as usize;
+        let size = &raw const __eheap as usize - start;
+
+        debug!(
+            "ariel-os-alloc: initializing heap with {} bytes at 0x{:x}",
+            size, start
+        );
+
+        unsafe { HEAP.init(start, size) }
+    }
+
+    /// Initializes an `esp_alloc` heap.
+    ///
+    /// # Safety
+    ///
+    /// Call only once!
+    #[cfg(context = "esp")]
+    unsafe fn init_esp_alloc() {
+        use ariel_os_debug::log::debug;
+
+        // TODO: figure out amount of leftover memory
+        const HEAP_SIZE: usize = 128 * 1024;
+
+        debug!("ariel-os-alloc: initializing heap with {} bytes", HEAP_SIZE);
+
+        esp_alloc::heap_allocator!(HEAP_SIZE);
+    }
+
+    /// Initializes **no** heap.
+    ///
+    /// Used as catch-all for tooling.
+    ///
+    /// # Safety
+    ///
+    /// Not actually unsafe but we don't want the caller to get in trouble.
+    #[cfg(not(any(context = "esp", context = "cortex-m")))]
+    unsafe fn init_none() {
+        // compile-fail unless building docs etc.
+        #[cfg(context = "ariel-os")]
+        compile_error!("ariel-os-alloc: unsupported architecture!");
+    }
+}
+
+#[cfg(test)]
+#[embedded_test::tests]
+mod tests {
+    #[test]
+    async fn basic() {
+        extern crate alloc;
+        use alloc::vec::Vec;
+        let i = 0xdeadbeefu32;
+
+        let mut some_vec = Vec::new();
+        some_vec.push(i);
+        assert!(some_vec[0] == i);
+    }
+}

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -26,6 +26,7 @@ esp-wifi = { workspace = true, default-features = false, features = [
 fugit = { workspace = true, optional = true }
 once_cell = { workspace = true }
 paste = { workspace = true }
+ariel-os-rt = { workspace = true, features = ["alloc"] }
 ariel-os-debug = { workspace = true }
 ariel-os-embassy-common = { workspace = true }
 ariel-os-random = { workspace = true, optional = true }

--- a/src/ariel-os-esp/src/lib.rs
+++ b/src/ariel-os-esp/src/lib.rs
@@ -128,9 +128,6 @@ pub fn init() -> OptionalPeripherals {
     {
         use esp_hal::timer::timg::TimerGroup;
 
-        use esp_alloc as _;
-        esp_alloc::heap_allocator!(72 * 1024);
-
         ariel_os_debug::log::debug!("ariel-os-embassy::hal::esp::init(): wifi");
 
         let timer = TimerGroup::new(peripherals.TIMG0.take().unwrap()).timer0;

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 [dependencies]
 cfg-if.workspace = true
 linkme.workspace = true
+ariel-os-alloc = { workspace = true, optional = true }
 ariel-os-debug.workspace = true
 ariel-os-threads = { path = "../ariel-os-threads", optional = true }
 ariel-os-utils = { workspace = true }
@@ -33,6 +34,7 @@ cortex-m = { workspace = true, features = ["critical-section-single-core"] }
 cortex-m = { workspace = true, features = ["critical-section-single-core"] }
 
 [features]
+alloc = ["dep:ariel-os-alloc"]
 threading = ["dep:ariel-os-threads"]
 
 debug-console = ["ariel-os-debug/debug-console"]

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -9,5 +9,9 @@ fn main() {
     std::fs::copy("linkme.x", out.join("linkme.x")).unwrap();
     std::fs::copy("eheap.x", out.join("eheap.x")).unwrap();
 
+    println!("cargo:rerun-if-changed=isr_stack.x");
+    println!("cargo:rerun-if-changed=linkme.x");
+    println!("cargo:rerun-if-changed=eheap.x");
+
     println!("cargo:rustc-link-search={}", out.display());
 }

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -7,6 +7,7 @@ fn main() {
 
     std::fs::copy("isr_stack.ld.in", out.join("isr_stack.x")).unwrap();
     std::fs::copy("linkme.x", out.join("linkme.x")).unwrap();
+    std::fs::copy("eheap.x", out.join("eheap.x")).unwrap();
 
     println!("cargo:rustc-link-search={}", out.display());
 }

--- a/src/ariel-os-rt/eheap.x
+++ b/src/ariel-os-rt/eheap.x
@@ -1,0 +1,4 @@
+/* In Ariel OS on Cortex-M, the main (ISR) stack is explicitly taken at the beginning of the RAM.
+ * That means, all memory from `__sheap` to the end of RAM should be available for the heap.*/
+PROVIDE(_ram_end = ORIGIN(RAM) + LENGTH(RAM));
+PROVIDE(__eheap = _ram_end);

--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -73,6 +73,12 @@ fn startup() -> ! {
 
     debug!("ariel_os_rt::startup()");
 
+    #[cfg(feature = "alloc")]
+    // SAFETY: *this* is the only place alloc should be initialized.
+    unsafe {
+        ariel_os_alloc::init()
+    };
+
     #[cfg(test)]
     debug!("ariel_os_rt::startup() cfg(test)");
 

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -29,6 +29,8 @@ static_cell = { workspace = true }
 default = ["ariel-os-rt/_panic-handler"]
 
 #! ## System functionality
+## Enables a global system allocator.
+alloc = ["ariel-os-rt/alloc"]
 ## Enables GPIO interrupt support.
 external-interrupts = ["ariel-os-embassy/external-interrupts"]
 ## Enables storage support.

--- a/src/laze.yml
+++ b/src/laze.yml
@@ -1,5 +1,6 @@
 subdirs:
   - ariel-os
+  - ariel-os-alloc
   - ariel-os-debug-log
   - ariel-os-embassy
   - ariel-os-embassy-common


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This PR integrates `embedded-alloc` on Cortex-M, and exposes `esp-alloc` on esp, allowing use of the `alloc` crate in applications.

~~draft b/c I want to see what CI says, not using all available memory but only a fixed-size buffer.~~

This is using `rtlf` through the `embedded-alloc` crate, so with some default configuration of an TLSF allocator (on Cortex-M).
We might want to directly use rtlf to get more control over the TLSF settings. Or allow the linked-list allocator.

On esp, we could also use the TLSF allocator (replacing `esp-alloc`, which does use the linked-list one). Not sure if esp doesn't require special placement in RAM for some things (esp-wifi buffers for DMA or similar), though.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

- [x] use all unallocated memory => it does now on Cortex-M. using a fixed size on esp, need to figure out where the default stack(s) are there.
<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
