### PR TITLE
Typo fix for STM32 WB55 and H7 in Doc, Rust book, and HAL comment

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -52,4 +52,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.pr.outputs.pr }}
           message: |
-            🚀 PR preview deployed to <https://${{ github.repository_owner }}-docs-preview-pr${{ steps.pr.outputs.pr }}.surge.sh>
+            🚀 Documentation preview deployed to <https://${{ github.repository_owner }}-docs-preview-pr${{ steps.pr.outputs.pr }}.surge.sh/dev/docs/api/ariel_os/>
+            📔 Book preview deployed to <https://${{ github.repository_owner }}-docs-preview-pr${{ steps.pr.outputs.pr }}.surge.sh/dev/docs/book/>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,8 +1637,8 @@ dependencies = [
 
 [[package]]
 name = "embassy-rp"
-version = "0.3.0"
-source = "git+https://github.com/ariel-os/embassy?branch=embassy-rp-v0.3.0%2Bariel-os#029f8ab7c2b99ae0db55a4290b492b357344f5dc"
+version = "0.3.1"
+source = "git+https://github.com/ariel-os/embassy?branch=embassy-rp-v0.3.1%2Bariel-os#ed3bfe9bbffc6daec3acce3beae77a5eec34afad"
 dependencies = [
  "atomic-polyfill",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "heapless 0.8.0",
  "linkme",
  "once_cell",
+ "portable-atomic",
  "rand_core",
  "static_cell",
  "usbd-hid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,6 @@ dependencies = [
  "ariel-os-hal",
  "arrayvec",
  "cfg-if",
- "embassy-embedded-hal",
  "embassy-sync 0.6.2",
  "embassy-time",
  "embedded-storage-async",

--- a/ariel-os-cargo.toml
+++ b/ariel-os-cargo.toml
@@ -22,7 +22,7 @@ embassy-executor = { git = "https://github.com/ariel-os/embassy", branch = "emba
 embassy-hal-internal = { git = "https://github.com/ariel-os/embassy", branch = "embassy-hal-internal-v0.2.0+ariel-os" }
 embassy-nrf = { git = "https://github.com/ariel-os/embassy", branch = "embassy-nrf-v0.3.1+ariel-os" }
 embassy-net = { git = "https://github.com/ariel-os/embassy", branch = "embassy-net-v0.6.0+ariel-os" }
-embassy-rp = { git = "https://github.com/ariel-os/embassy", branch = "embassy-rp-v0.3.0+ariel-os" }
+embassy-rp = { git = "https://github.com/ariel-os/embassy", branch = "embassy-rp-v0.3.1+ariel-os" }
 embassy-stm32 = { git = "https://github.com/ariel-os/embassy", branch = "embassy-stm32-v0.2.0+ariel-os" }
 
 # ariel-os esp-hal fork

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -169,7 +169,7 @@
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
     </tr>
     <tr>
-      <td>STM32W55RGVX</td>
+      <td>STM32WB55RGVX</td>
       <td><code>stm32wb55rgvx</code></td>
       <td><a href="https://web.archive.org/web/20240803070523/https://www.st.com/en/evaluation-tools/nucleo-wb55rg.html">ST NUCLEO-WB55RG</a></td>
       <td><code>st-nucleo-wb55</code></td>

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -153,7 +153,7 @@
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
     </tr>
     <tr>
-      <td>STM32F755ZITX</td>
+      <td>STM32H755ZITX</td>
       <td><code>stm32h755zitx</code></td>
       <td><a href="https://web.archive.org/web/20240524105149/https://www.st.com/en/evaluation-tools/nucleo-h755zi-q.html">ST NUCLEO-H755ZI-Q</a></td>
       <td><code>st-nucleo-h755zi-q</code></td>

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -159,7 +159,7 @@ chips:
       wifi: not_available
 
   stm32wb55rgvx:
-    name: STM32W55RGVX
+    name: STM32WB55RGVX
     support:
       gpio: supported
       debug_output: supported

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -147,7 +147,7 @@ chips:
       wifi: not_available
 
   stm32h755zitx:
-    name: STM32F755ZITX
+    name: STM32H755ZITX
     support:
       gpio: supported
       debug_output: supported

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -777,7 +777,7 @@ modules:
   - name: coap-server
     help: Support for applications to set up CoAP server handlers.
 
-      When an application selects this, it needs to run `ariel_os::coap_run()`
+      When an application selects this, it needs to run `ariel_os::coap::coap_run()`
       in a task; otherwise, other components (eg. system components that also
       run on the CoAP server, or the CoAP client that depends on the server
       loop to run) get stalled.

--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -62,7 +62,14 @@ mod demo_setup {
 
 /// Runs a CoAP server with the given handler on the system's CoAP transports.
 ///
-/// As the CoAP stack gets ready, it also unblocks [`coap_client`].
+/// # Note
+///
+/// The application needs to run this in a task; otherwise, other components (e.g., system
+/// components that also run on the CoAP server, or the CoAP client that depends on the server
+/// loop to run) get stalled.
+///
+/// As the CoAP stack gets ready (which may take some time if the network is not ready yet), it also
+/// unblocks [`coap_client()`].
 ///
 /// # Panics
 ///
@@ -168,7 +175,7 @@ async fn coap_run_impl(handler: impl coap_handler::Handler + coap_handler::Repor
 
 /// Returns a CoAP client requester.
 ///
-/// This asynchronously blocks until [`coap_run`] has been called (which happens at startup
+/// This asynchronously blocks until [`coap_run()`] has been called (which happens at startup
 /// when the corresponding feature `coap-server` is not active), and the CoAP stack is operational.
 ///
 /// # Panics

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 const_panic.workspace = true
 critical-section.workspace = true
 linkme.workspace = true
+portable-atomic.workspace = true
 rand_core = { workspace = true, optional = true }
 static_cell.workspace = true
 cfg-if.workspace = true

--- a/src/ariel-os-embassy/src/delegate.rs
+++ b/src/ariel-os-embassy/src/delegate.rs
@@ -1,11 +1,12 @@
-//! Delegate or lend an object to another task
+//! Delegate or lend an object to another task.
 
 use embassy_executor::Spawner;
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
+use portable_atomic::{AtomicBool, Ordering};
 
 use crate::sendcell::SendCell;
 
-/// [`Delegate`] or lend an object to another task.
+/// [`Delegate`]s or lends an object to another task.
 ///
 /// This struct can be used to lend a `&mut T` to another task on the same executor.
 /// The other task can then call a closure on it. After that, the `&mut T` is returned
@@ -14,14 +15,17 @@ use crate::sendcell::SendCell;
 /// Under the hood, [`Delegate`] leverages [`SendCell`] to ensure the delegated
 /// object stays on the same executor.
 ///
-/// Example:
-/// ```Rust
+/// # Example
+///
+/// ```
+/// # use ariel_os_embassy::delegate::Delegate;
 /// static SOME_VALUE: Delegate<u32> = Delegate::new();
 ///
 /// // in some task
 /// async fn foo() {
 ///   let mut my_val = 0u32;
-///   SOME_VALUE.lend(&mut my_val).await;
+///   // SAFETY: `lend` is only called once.
+///   unsafe { SOME_VALUE.lend(&mut my_val).await; }
 ///   assert_eq!(my_val, 1);
 /// }
 ///
@@ -30,18 +34,16 @@ use crate::sendcell::SendCell;
 ///   SOME_VALUE.with(|val| *val = 1).await;
 /// }
 /// ```
-///
-/// TODO: this is a PoC implementation.
-/// - takes 24b for each delegate (on arm), which seems too much.
-/// - doesn't protect at all against calling [`lend()`](Delegate::lend) or
-///   [`with()`](Delegate::with) multiple times
-///   each, breaking safety assumptions. So while the API seems OK, the implementation
-///   needs work.
+// TODO: this is a PoC implementation.
+// - Takes 28 B for each delegate (on arm), which seems too much.
 #[derive(Default)]
 pub struct Delegate<T> {
     send: Signal<CriticalSectionRawMutex, SendCell<*mut T>>,
     reply: Signal<CriticalSectionRawMutex, ()>,
+    was_exercised: AtomicBool,
 }
+
+impl<T> !Send for Delegate<T> {}
 
 impl<T> Delegate<T> {
     /// Creates a new [`Delegate`].
@@ -49,13 +51,18 @@ impl<T> Delegate<T> {
         Self {
             send: Signal::new(),
             reply: Signal::new(),
+            was_exercised: AtomicBool::new(false),
         }
     }
 
     /// Lends an object.
     ///
-    /// This blocks until another task called [`with()`](Delegate::with).
-    pub async fn lend<'a, 'b: 'a>(&'a self, something: &'b mut T) {
+    /// This blocks until [`Delegate::with()`] is called on the instance.
+    ///
+    /// # Safety
+    ///
+    /// This must only be called *once* per [`Delegate`] instance.
+    pub async unsafe fn lend<'a, 'b: 'a>(&'a self, something: &'b mut T) {
         let spawner = Spawner::for_current_executor().await;
         self.send
             .signal(SendCell::new(something as *mut T, spawner));
@@ -63,10 +70,17 @@ impl<T> Delegate<T> {
         self.reply.wait().await
     }
 
-    /// Calls a closure on a lended object.
+    /// Calls a closure on a lent object.
     ///
-    /// This blocks until another task called [`lend(something)`](Delegate::lend).
+    /// This blocks until [`Delegate::lend()`] is called on the instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called multiple times on the same [`Delegate`] instance.
     pub async fn with<U>(&self, func: impl FnOnce(&mut T) -> U) -> U {
+        // Enforce that the value be only populated once, panic otherwise.
+        assert!(!self.was_exercised.swap(true, Ordering::AcqRel));
+
         let data = self.send.wait().await;
         let spawner = Spawner::for_current_executor().await;
         // SAFETY:
@@ -78,7 +92,6 @@ impl<T> Delegate<T> {
         //   => the mutable reference is never used more than once
         // - the lifetime bound on `lend` enforces that the raw pointer outlives this `Delegate`
         //   instance
-        // TODO: it is actually possible to call `with()` twice, which breaks assumptions.
         let result = func(unsafe { data.get(spawner).unwrap().as_mut().unwrap() });
         self.reply.signal(());
         result

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 #![feature(doc_auto_cfg)]
+#![feature(negative_impls)]
 
 pub mod gpio;
 
@@ -277,7 +278,10 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     #[cfg(feature = "usb")]
     {
         for hook in usb::USB_BUILDER_HOOKS {
-            hook.lend(&mut usb_builder).await;
+            // SAFETY: `lend()` is only called once per hook instance, as required.
+            unsafe {
+                hook.lend(&mut usb_builder).await;
+            }
         }
         let usb = usb_builder.build();
         spawner.spawn(usb::usb_task(usb)).unwrap();

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 [dependencies]
 cfg-if = { workspace = true }
 defmt = { workspace = true, optional = true }
-embassy-embedded-hal = { workspace = true }
+embassy-embedded-hal = { workspace = true, optional = true }
 embassy-executor = { workspace = true, default-features = false }
 embassy-time = { workspace = true, optional = true }
 embedded-hal = { workspace = true }
@@ -84,7 +84,7 @@ hwrng = ["dep:ariel-os-random"]
 i2c = ["dep:fugit", "ariel-os-embassy-common/i2c"]
 
 ## Enables SPI support.
-spi = ["dep:fugit", "ariel-os-embassy-common/spi"]
+spi = ["dep:embassy-embedded-hal", "dep:fugit", "ariel-os-embassy-common/spi"]
 
 ## Enables defmt support.
 defmt = ["dep:defmt", "esp-hal/defmt", "esp-wifi?/defmt", "fugit?/defmt"]

--- a/src/ariel-os-hal/src/lib.rs
+++ b/src/ariel-os-hal/src/lib.rs
@@ -7,7 +7,7 @@
 //! | Espressif            | ESP32       | ESP32-C6          | [`ariel-os-esp::*`](../../ariel_os_esp/index.html)     |
 //! | Nordic Semiconductor | nRF         | nRF52840          | [`ariel-os-nrf::*`](../../ariel_os_nrf/index.html)     |
 //! | Raspberry Pi         | RP          | RP2040            | [`ariel-os-rp::*`](../../ariel_os_rp/index.html)       |
-//! | STMicroelectronics   | STM32       | STM32W55RGVX      | [`ariel-os-stm32::*`](../../ariel_os_stm32/index.html) |
+//! | STMicroelectronics   | STM32       | STM32WB55RGVX     | [`ariel-os-stm32::*`](../../ariel_os_stm32/index.html) |
 //!
 //! Documentation is only rendered for the MCUs listed in the table above, but [many others are
 //! supported](https://ariel-os.github.io/ariel-os/dev/docs/book/hardware_functionality_support.html).

--- a/src/ariel-os-random/src/lib.rs
+++ b/src/ariel-os-random/src/lib.rs
@@ -133,6 +133,7 @@ mod csprng {
 ///
 /// - Panics if the underlying RNG returns an error.
 /// - Panics if this function is called multiple times.
+#[doc(hidden)]
 pub fn construct_rng(hwrng: impl RngCore) {
     RNG.init(RefCell::new(
         SelectedRng::from_rng(hwrng).expect("Hardware RNG failed to provide entropy"),

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 [dependencies]
 cfg-if = { workspace = true }
 defmt = { workspace = true, optional = true }
-embassy-embedded-hal = { workspace = true }
+embassy-embedded-hal = { workspace = true, optional = true }
 embassy-net-driver-channel = { workspace = true, optional = true }
 embassy-rp = { workspace = true, default-features = false, features = [
   "optfield",
@@ -53,7 +53,7 @@ hwrng = ["dep:ariel-os-random"]
 i2c = ["ariel-os-embassy-common/i2c"]
 
 ## Enables SPI support.
-spi = ["ariel-os-embassy-common/spi"]
+spi = ["dep:embassy-embedded-hal", "ariel-os-embassy-common/spi"]
 
 ## Enables storage support.
 storage = []

--- a/src/ariel-os-rp/src/i2c/controller/mod.rs
+++ b/src/ariel-os-rp/src/i2c/controller/mod.rs
@@ -187,6 +187,7 @@ fn from_error(err: embassy_rp::i2c::Error) -> ariel_os_embassy_common::i2c::cont
         InvalidReadBufferLength => Error::Other,
         InvalidWriteBufferLength => Error::Other,
         AddressOutOfRange(_) => Error::Other,
+        #[allow(deprecated)]
         AddressReserved(_) => Error::Other,
     }
 }

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 [dependencies]
 cfg-if = { workspace = true }
 defmt = { workspace = true, optional = true }
-embassy-embedded-hal = { workspace = true }
+embassy-embedded-hal = { workspace = true, optional = true }
 embassy-executor = { workspace = true, default-features = false, features = [
   "arch-cortex-m",
 ] }
@@ -44,10 +44,14 @@ stm32-rng = []
 
 ## Enables I2C support.
 # Time-related features are required for timeout support.
-i2c = ["ariel-os-embassy-common/i2c", "embassy-stm32/time"]
+i2c = [
+  "dep:embassy-embedded-hal",
+  "ariel-os-embassy-common/i2c",
+  "embassy-stm32/time",
+]
 
 ## Enables SPI support.
-spi = ["ariel-os-embassy-common/spi"]
+spi = ["dep:embassy-embedded-hal", "ariel-os-embassy-common/spi"]
 
 ## Enables USB support.
 usb = []

--- a/src/ariel-os-storage/Cargo.toml
+++ b/src/ariel-os-storage/Cargo.toml
@@ -10,7 +10,6 @@ workspace = true
 
 [dependencies]
 cfg-if = { workspace = true }
-embassy-embedded-hal = { workspace = true }
 embassy-sync = { workspace = true }
 once_cell = { workspace = true }
 ariel-os-debug = { workspace = true }

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -59,12 +59,8 @@ dns = ["ariel-os-embassy/dns"]
 mdns = ["ariel-os-embassy/mdns"]
 ## Enables support for [CoAP](https://ariel-os.github.io/ariel-os/dev/docs/book/tooling/coap.html).
 coap = ["dep:ariel-os-coap", "random"]
-## Support for applications to set up CoAP server handlers.
-##
-## When an application selects this, it needs to run `ariel_os::coap_run()`
-## in a task; otherwise, other components (eg. system components that also
-## run on the CoAP server, or the CoAP client that depends on the server
-## loop to run) get stalled.
+## Enables applications to set up CoAP server handlers.
+## See [`coap::coap_run()`].
 coap-server = ["coap", "ariel-os-coap/coap-server"]
 ## Selects static IP configuration.
 network-config-static = ["ariel-os-embassy/network-config-static"]


### PR DESCRIPTION
# Description
Typo fix for STM32WB55 and STM32H7 in the documentation, Rust book and one comment in the hal lib.
Previously : STM32W55..., STM32F7...
Now : STM32WB55..., STM32H7...


## Issues/PRs references
These are typo fix, not code related.
There is no PR related to these commits.


## Open Questions
I plan to add other STM32 support, such as WBA55 for which I ran some examples on a board (hello world, blinky, etc).
Should I open an issue to track this activity or can I commit directly through PR ?


## Change checklist
Please refer to the above description as there is not so many changes.
