### PR TITLE
Docs : fix typo for STM32 WB55 and H7 in Doc, Rust book, and HAL comment

### DIFF
--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -169,7 +169,7 @@
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
     </tr>
     <tr>
-      <td>STM32W55RGVX</td>
+      <td>STM32WB55RGVX</td>
       <td><code>stm32wb55rgvx</code></td>
       <td><a href="https://web.archive.org/web/20240803070523/https://www.st.com/en/evaluation-tools/nucleo-wb55rg.html">ST NUCLEO-WB55RG</a></td>
       <td><code>st-nucleo-wb55</code></td>

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -153,7 +153,7 @@
       <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
     </tr>
     <tr>
-      <td>STM32F755ZITX</td>
+      <td>STM32H755ZITX</td>
       <td><code>stm32h755zitx</code></td>
       <td><a href="https://web.archive.org/web/20240524105149/https://www.st.com/en/evaluation-tools/nucleo-h755zi-q.html">ST NUCLEO-H755ZI-Q</a></td>
       <td><code>st-nucleo-h755zi-q</code></td>

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -159,7 +159,7 @@ chips:
       wifi: not_available
 
   stm32wb55rgvx:
-    name: STM32W55RGVX
+    name: STM32WB55RGVX
     support:
       gpio: supported
       debug_output: supported

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -147,7 +147,7 @@ chips:
       wifi: not_available
 
   stm32h755zitx:
-    name: STM32F755ZITX
+    name: STM32H755ZITX
     support:
       gpio: supported
       debug_output: supported

--- a/src/ariel-os-hal/src/lib.rs
+++ b/src/ariel-os-hal/src/lib.rs
@@ -7,7 +7,7 @@
 //! | Espressif            | ESP32       | ESP32-C6          | [`ariel-os-esp::*`](../../ariel_os_esp/index.html)     |
 //! | Nordic Semiconductor | nRF         | nRF52840          | [`ariel-os-nrf::*`](../../ariel_os_nrf/index.html)     |
 //! | Raspberry Pi         | RP          | RP2040            | [`ariel-os-rp::*`](../../ariel_os_rp/index.html)       |
-//! | STMicroelectronics   | STM32       | STM32W55RGVX      | [`ariel-os-stm32::*`](../../ariel_os_stm32/index.html) |
+//! | STMicroelectronics   | STM32       | STM32WB55RGVX     | [`ariel-os-stm32::*`](../../ariel_os_stm32/index.html) |
 //!
 //! Documentation is only rendered for the MCUs listed in the table above, but [many others are
 //! supported](https://ariel-os.github.io/ariel-os/dev/docs/book/hardware_functionality_support.html).


### PR DESCRIPTION
# Description
Typo fix for STM32WB55 and STM32H7 in the documentation, Rust book and one comment in the hal lib.
Previously : STM32W55..., STM32F7...
Now : STM32WB55..., STM32H7...


## Issues/PRs references
These are typo fix related to the docs only.
There is no PR related to these commits.


## Open Questions
I plan to add other STM32 support, such as WBA55 for which I ran some examples on a board (hello world, blinky, etc).
Should I open an issue to track this activity or can I commit directly through PR ?


## Change checklist
Please refer to the above description as there is not so many changes.