### PR TITLE
feat: add STM32WBA55 Nucleo to blinky example

### DIFF
--- a/examples/blinky/laze.yml
+++ b/examples/blinky/laze.yml
@@ -11,3 +11,4 @@ apps:
       - st-nucleo-f401re
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
+      - st-nucleo-wba55

--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -29,3 +29,6 @@ ariel_os::hal::define_peripherals!(LedPeripherals { led: PB0 });
 
 #[cfg(context = "st-nucleo-wb55")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: PB5 });
+
+#[cfg(context = "st-nucleo-wba55")]
+ariel_os::hal::define_peripherals!(LedPeripherals { led: PB4 });


### PR DESCRIPTION
# Description
Add new feature : support of STM32WBA55 Nucleo board for blinky example.
Out of the 3 Leds available, the blinky example will use PB4, connected to Led 1 (Blue led).
It is the 2nd example supported, with the basic hello-world.

## Issues/PRs references
N/A.

## Open Questions
N/A.

## Change checklist
Tested on Nucleo WBA55CG board.