### PR TITLE
chore(deps): bump to sequential-storage 4.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
  "st-nucleo-f401re",
  "st-nucleo-h755zi-q",
  "st-nucleo-wb55",
-"st-nucleo-wba55",
+ "st-nucleo-wba55",
 ]
 
 [[package]]
@@ -4550,9 +4550,9 @@ checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "sequential-storage"
-version = "3.0.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b80693b2169b3fe0f9c68d5fae804490cc437113c0526dbabb75c01e758db597"
+checksum = "8d8e933f534642c25b7341338c10e2250187c8cd198c3957ef6894265eefda86"
 dependencies = [
  "arrayvec",
  "embedded-storage-async",

--- a/src/ariel-os-storage/Cargo.toml
+++ b/src/ariel-os-storage/Cargo.toml
@@ -17,7 +17,7 @@ ariel-os-hal = { workspace = true, features = ["storage"] }
 arrayvec = { version = "0.7.4", default-features = false }
 embedded-storage-async = { workspace = true }
 postcard = { version = "1.0.8", features = ["postcard-derive"] }
-sequential-storage = { version = "3.0.1", features = ["arrayvec"] }
+sequential-storage = { version = "4.0.1", features = ["arrayvec"] }
 serde = { workspace = true, default-features = false }
 
 [target.'cfg(context = "rp")'.dependencies]


### PR DESCRIPTION
# Description

This bumps sequential storage to 4.0.1.

Did a quick test on nrf52840dk. Shouldn't cause any issues.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
