### PR TITLE
feat(rt): more flexible stacksize configuration

### DIFF
--- a/examples/coap-client/laze.yml
+++ b/examples/coap-client/laze.yml
@@ -2,7 +2,7 @@ apps:
   - name: example-coap-client
     env:
       global:
-        CARGO_ENV:
-          - CONFIG_ISR_STACKSIZE=32768
+        executor_stacksize_required:
+          - "32768"
     selects:
       - coap-client

--- a/examples/coap-server/laze.yml
+++ b/examples/coap-server/laze.yml
@@ -2,8 +2,8 @@ apps:
   - name: example-coap-server
     env:
       global:
-        CARGO_ENV:
-          - CONFIG_ISR_STACKSIZE=32768
+        executor_stacksize_required:
+          - "32768"
     selects:
       - coap-server
       - ?coap-server-config-demokeys

--- a/examples/http-client/laze.yml
+++ b/examples/http-client/laze.yml
@@ -2,8 +2,8 @@ apps:
   - name: http-client
     env:
       global:
-        CARGO_ENV:
-          - CONFIG_ISR_STACKSIZE=32768
+        executor_stacksize_required:
+          - "32768"
     selects:
       - network
       - random

--- a/examples/http-server/laze.yml
+++ b/examples/http-server/laze.yml
@@ -2,8 +2,8 @@ apps:
   - name: http-server
     env:
       global:
-        CARGO_ENV:
-          - CONFIG_ISR_STACKSIZE=16384
+        executor_stacksize_required:
+          - "16384"
     selects:
       - network
       - ?button-reading

--- a/examples/tcp-echo/laze.yml
+++ b/examples/tcp-echo/laze.yml
@@ -2,7 +2,7 @@ apps:
   - name: tcp-echo
     env:
       global:
-        CARGO_ENV:
-          - CONFIG_ISR_STACKSIZE=16384
+        executor_stacksize_required:
+          - "16384"
     selects:
       - network

--- a/examples/udp-echo/laze.yml
+++ b/examples/udp-echo/laze.yml
@@ -2,7 +2,7 @@ apps:
   - name: udp-echo
     env:
       global:
-        CARGO_ENV:
-          - CONFIG_ISR_STACKSIZE=16384
+        executor_stacksize_required:
+          - "16384"
     selects:
       - network

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -33,9 +33,10 @@ contexts:
       SCRIPTS: ${relroot}/scripts
       CARGO_ARGS:
         - --config ${root}/${relroot}/ariel-os-cargo.toml
-      # laze doesn't know the concept of "export" as make does, so each variable
-      # that needs to be passed via environment needs to be listed in that rule
-      # or task's command list.
+      # While laze allows "export:" in rules and tasks to export laze
+      # variables to a rule's recipe shell environment, this would require
+      # those to be listed for *all* rules and tasks where they are needed.
+      # So until laze allows "global shell exporting of variables",
       # "CARGO_ENV" is used for that.
       CARGO_ENV:
         - >-
@@ -46,6 +47,8 @@ contexts:
           ${CARGO_TARGET_PREFIX}_RUNNER=${CARGO_RUNNER}
           ${CARGO_TARGET_PREFIX}_RUSTFLAGS="${RUSTFLAGS}"
           CARGO_TARGET_DIR=${relroot}/${build-dir}/bin/${builder}/cargo
+          CONFIG_EXECUTOR_STACKSIZE=${CONFIG_EXECUTOR_STACKSIZE}
+          CONFIG_ISR_STACKSIZE=${CONFIG_ISR_STACKSIZE}
       BOARD: ${builder}
       PROFILE: release
       QEMU_SYSTEM_ARM: >-
@@ -57,6 +60,17 @@ contexts:
         -kernel
       PROBE_RS_PROTOCOL: swd
       CARGO_PRESHELL: []
+
+      # Stack size config
+      executor_stacksize_required:
+        # These defines the defaults. Other modules can append their needs,
+        # the maximum value will be chosen.
+        # Note: make sure to append to the list, not set single value!
+        - "8192"
+      isr_stacksize_required:
+        - "2048"
+      CONFIG_EXECUTOR_STACKSIZE: $(max (0, ${executor_stacksize_required}))
+      CONFIG_ISR_STACKSIZE: $(max (0, ${isr_stacksize_required}))
 
     var_options:
       # this turns ${FEATURES} from a list to "--features=feature1,feature2"
@@ -78,6 +92,12 @@ contexts:
       # this prefixes `--protocol=` to `PROBE_RS_PROTOCOL`
       PROBE_RS_PROTOCOL:
         start: --protocol=
+
+      # Executor / ISR stacksize helpers
+      executor_stacksize_required:
+        joiner: ", "
+      isr_stacksize_required:
+        joiner: ", "
 
     rules:
       - name: LINK
@@ -897,7 +917,8 @@ modules:
           - PEERS_YML=$$(realpath ${PEERS_YML})
 
   - name: coap-server-config-unprotected
-    help: Configure the CoAP server to accept any request without authorization checks.
+    help:
+      Configure the CoAP server to accept any request without authorization checks.
 
       The device will have no cryptographic identity for CoAP, and not even
       accept opportunistic EDHOC.
@@ -910,7 +931,8 @@ modules:
           - ariel-os/coap-server-config-unprotected
 
   - name: coap-server-config-demokeys
-    help: Configure the CoAP server as expected by simple examples that expect a fixed server key.
+    help:
+      Configure the CoAP server as expected by simple examples that expect a fixed server key.
 
       This configuration may change over time, in lockstep with the examples' setup.
     selects:

--- a/src/ariel-os-embassy-common/src/executor_thread.rs
+++ b/src/ariel-os-embassy-common/src/executor_thread.rs
@@ -2,7 +2,7 @@
 
 /// Stack size used by the main executor thread.
 pub const STACKSIZE: usize = ariel_os_utils::usize_from_env_or!(
-    "CONFIG_EXECUTOR_THREAD_STACKSIZE",
+    "CONFIG_EXECUTOR_STACKSIZE",
     16384,
     "executor thread stack size"
 );

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -155,7 +155,10 @@ fn init() -> ! {
 fn init() {
     use static_cell::StaticCell;
 
-    debug!("ariel-os-embassy::init(): using thread executor");
+    debug!(
+        "ariel-os-embassy::init(): using thread executor with thread stack size {}",
+        executor_thread::STACKSIZE
+    );
     let p = hal::init();
 
     static EXECUTOR: StaticCell<thread_executor::Executor> = StaticCell::new();

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -42,6 +42,7 @@ threading = ["dep:ariel-os-threads"]
 
 debug-console = ["ariel-os-debug/debug-console"]
 executor-single-thread = []
+executor-interrupt = []
 panic-printing = []
 _panic-handler = []
 single-core = ["cortex-m/critical-section-single-core"]

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -152,7 +152,10 @@ net = ["ariel-os-embassy/net"]
 # ## Executor type selection for the (autostarted) main executor
 # Exactly one of the features below must be enabled at once.
 # Enables the interrupt executor.
-executor-interrupt = ["ariel-os-embassy/executor-interrupt"]
+executor-interrupt = [
+  "ariel-os-embassy/executor-interrupt",
+  "ariel-os-rt/executor-interrupt",
+]
 # Enables the single thread-mode executor.
 executor-single-thread = ["ariel-os-embassy/executor-single-thread"]
 # Enables the ariel-os-threading thread executor.


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This is my try at making the executor stack size configuration a bit more flexible, and more to the point.
E.g., our examples increase the `CONFIG_ISR_STACKSIZE`, but probably mean to increase the executor stack size.

Marking as draft, IMO we need some way of actually measuring the stack size to work on this properly.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
