### PR TITLE
refactor: move the conflict with threading into `executor-single-thread`

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -677,8 +677,6 @@ modules:
           - -Clink-arg=-Tstorage.x
 
   - name: sw/threading
-    conflicts:
-      - executor-single-thread
     selects:
       - ?multi-core
     env:
@@ -849,6 +847,8 @@ modules:
       - esp
     provides_unique:
       - executor
+    conflicts:
+      - sw/threading
     env:
       global:
         FEATURES:


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Make the conflict a property of `executor-single-thread` instead of `sw/threading`.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
