### PR TITLE
fix(alloc): reduce esp default heap size

### DIFF
--- a/src/ariel-os-alloc/src/lib.rs
+++ b/src/ariel-os-alloc/src/lib.rs
@@ -75,7 +75,8 @@ mod alloc {
         use ariel_os_debug::log::debug;
 
         // TODO: figure out amount of leftover memory
-        const HEAP_SIZE: usize = 128 * 1024;
+        // 112k currently works on all our supported boards.
+        const HEAP_SIZE: usize = 112 * 1024;
 
         debug!("ariel-os-alloc: initializing heap with {} bytes", HEAP_SIZE);
 


### PR DESCRIPTION
# Description

Previous default was a little large for the plain esp32: [nightly build fail](https://github.com/ariel-os/ariel-os/actions/runs/13255340409).

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
