### PR TITLE
fix(debug-console): enable the debug logging facade only with a console

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -22,7 +22,6 @@ contexts:
     selects:
       - executor-default
       - ?critical-section
-      - ?debug-logging-facade-default
       - ?lto
       - ?semihosting
     env:
@@ -475,6 +474,8 @@ modules:
 
   - name: debug-console
     context: ariel-os
+    selects:
+      - ?debug-logging-facade-default
     env:
       global:
         FEATURES:


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The debug logging facade should only be enabled when a debug console is there to print on.
Previously the following would fail to link:
```sh
laze -C examples/log/ build -d debug-console -b nrf52840dk size
```
and would require to explicitly disable `debug-logging-facade` as well:
```sh
laze -C examples/log/ build -d debug-console -d debug-logging-facade -b nrf52840dk size
```

With this PR `debug-logging-facade` is only enabled when `debug-console` is enabled instead of always, so the first command works as expected.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
