### PR TITLE
feat(coap): laze based configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "ariel-os-random",
  "cbor-macro",
  "cboritem",
+ "cfg-if",
  "coap-handler",
  "coap-handler-implementations",
  "coapcore",

--- a/examples/coap-server/laze.yml
+++ b/examples/coap-server/laze.yml
@@ -6,7 +6,7 @@ apps:
           - CONFIG_ISR_STACKSIZE=32768
     selects:
       - coap-server
-      - coap-server-config-demokeys
+      - ?coap-server-config-demokeys
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi

--- a/examples/coap-server/laze.yml
+++ b/examples/coap-server/laze.yml
@@ -6,6 +6,7 @@ apps:
           - CONFIG_ISR_STACKSIZE=32768
     selects:
       - coap-server
+      - coap-server-config-demokeys
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -807,6 +807,9 @@ modules:
     # will have their own entry point when they exist.
     depends:
       - coap
+      # This does *not* depend on (or select) coap-server-config yet, because
+      # doing so would cause a config to be auto-selected, and there's none
+      # that can currently be recommended without explicit configuration.
     env:
       global:
         FEATURES:
@@ -819,6 +822,7 @@ modules:
       accept opportunistic EDHOC.
     depends:
       - coap
+    provides_unique: [coap-server-config]
     env:
       global:
         FEATURES:
@@ -830,6 +834,7 @@ modules:
       This configuration may change over time, in lockstep with the examples' setup.
     depends:
       - coap
+    provides_unique: [coap-server-config]
     env:
       global:
         FEATURES:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -812,6 +812,29 @@ modules:
         FEATURES:
           - ariel-os/coap-server
 
+  - name: coap-server-config-unprotected
+    help: Configure the CoAP server to accept any request without authorization checks.
+
+      The device will have no cryptographic identity for CoAP, and not even
+      accept opportunistic EDHOC.
+    depends:
+      - coap
+    env:
+      global:
+        FEATURES:
+          - ariel-os/coap-server-config-unprotected
+
+  - name: coap-server-config-demokeys
+    help: Configure the CoAP server as expected by simple examples that expect a fixed server key.
+
+      This configuration may change over time, in lockstep with the examples' setup.
+    depends:
+      - coap
+    env:
+      global:
+        FEATURES:
+          - ariel-os/coap-server-config-demokeys
+
   - name: coap-client
     help: Support for CoAP client functionality.
     depends:

--- a/src/ariel-os-coap/Cargo.toml
+++ b/src/ariel-os-coap/Cargo.toml
@@ -32,6 +32,8 @@ ariel-os-random = { workspace = true, features = ["csprng"] }
 ariel-os-macros = { path = "../ariel-os-macros" }
 static_cell = "2.1.0"
 
+cfg-if = { workspace = true }
+
 # FIXME: Should go out eventually
 hexlit = "0.5.5"
 cbor-macro = "0.1.0"
@@ -53,6 +55,9 @@ workspace = true
 # called "manual-server-start"; the name is chosen to align with
 # laze's name for this (where coap-server makes more sense).
 coap-server = []
+
+coap-server-config-unprotected = []
+coap-server-config-demokeys = []
 
 ## Enables an arbitrary set of features in dependencies where dependencies fail
 ## if no features are configured at all.

--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -34,13 +34,13 @@ mod demo_setup {
     use hexlit::hex;
 
     /// Credential presented by any demo device.
-    pub(super) const DEVICE_CREDENTIAL: &[u8] = &hex!("A2026008A101A5010202410A2001215820BBC34960526EA4D32E940CAD2A234148DDC21791A12AFBCBAC93622046DD44F02258204519E257236B2A0CE2023F0931F1F386CA7AFDA64FCDE0108C224C51EABF6072");
+    const DEVICE_CREDENTIAL: &[u8] = &hex!("A2026008A101A5010202410A2001215820BBC34960526EA4D32E940CAD2A234148DDC21791A12AFBCBAC93622046DD44F02258204519E257236B2A0CE2023F0931F1F386CA7AFDA64FCDE0108C224C51EABF6072");
     /// Private key for `DEVICE_CREDENTIAL`.
-    pub(super) const DEVICE_KEY: [u8; 32] =
+    const DEVICE_KEY: [u8; 32] =
         hex!("72cc4761dbd4c78f758931aa589d348d1ef874a7e303ede2f140dcf3e6aa4aac");
 
     /// Scope usable by any client inside any demo device.
-    pub(super) const UNAUTHENTICATED_SCOPE: cboritem::CborItem = cbor!([
+    const UNAUTHENTICATED_SCOPE: cboritem::CborItem = cbor!([
             ["/.well-known/core", 1],
             ["/poem", 1],
             ["/hello", 1],
@@ -49,7 +49,7 @@ mod demo_setup {
     ]);
 
     /// Scope usable by the the administrator of the demo device.
-    pub(super) const ADMIN_SCOPE: cboritem::CborItem = cbor!([
+    const ADMIN_SCOPE: cboritem::CborItem = cbor!([
             ["/stdout", 17 / GET and FETCH /],
             ["/.well-known/core", 1],
             ["/poem", 1]
@@ -57,7 +57,28 @@ mod demo_setup {
     /// Credential by which the administrator of any demo device is recognized.
     ///
     /// The corresponding private key is shipped in `tests/coap/client.cosekey`.
-    pub(super) const ADMIN_CREDENTIAL: &[u8] = &hex!("A2027734322D35302D33312D46462D45462D33372D33322D333908A101A5010202412B2001215820AC75E9ECE3E50BFC8ED60399889522405C47BF16DF96660A41298CB4307F7EB62258206E5DE611388A4B8A8211334AC7D37ECB52A387D257E6DB3C2A93DF21FF3AFFC8");
+    const ADMIN_CREDENTIAL: &[u8] = &hex!("A2027734322D35302D33312D46462D45462D33372D33322D333908A101A5010202412B2001215820AC75E9ECE3E50BFC8ED60399889522405C47BF16DF96660A41298CB4307F7EB62258206E5DE611388A4B8A8211334AC7D37ECB52A387D257E6DB3C2A93DF21FF3AFFC8");
+
+    /// Assembles this module's components into a server security configuration.
+    pub(super) fn build_demo_ssc() -> coapcore::seccfg::ConfigBuilder {
+        let own_key = DEVICE_KEY;
+        let own_credential = lakers::Credential::parse_ccs(DEVICE_CREDENTIAL)
+            .expect("Credential should be processable");
+
+        let unauthenticated_scope = coapcore::scope::AifValue::parse(&UNAUTHENTICATED_SCOPE)
+            .expect("hard-coded scope fits this type")
+            .into();
+        let admin_key = lakers::Credential::parse_ccs(ADMIN_CREDENTIAL)
+            .expect("hard-coded credential fits this type");
+        let admin_scope = coapcore::scope::AifValue::parse(&ADMIN_SCOPE)
+            .expect("hard-coded scope fits this type")
+            .into();
+
+        coapcore::seccfg::ConfigBuilder::new()
+            .allow_unauthenticated(unauthenticated_scope)
+            .with_own_edhoc_credential(own_credential, own_key)
+            .with_known_edhoc_credential(admin_key, admin_scope)
+    }
 }
 
 /// Runs a CoAP server with the given handler on the system's CoAP transports.
@@ -121,29 +142,14 @@ async fn coap_run_impl(handler: impl coap_handler::Handler + coap_handler::Repor
         .await
         .unwrap();
 
-    let own_key = demo_setup::DEVICE_KEY;
-    let own_credential = lakers::Credential::parse_ccs(demo_setup::DEVICE_CREDENTIAL)
-        .expect("Credential should be processable");
-
-    let unauthenticated_scope =
-        coapcore::scope::AifValue::parse(&demo_setup::UNAUTHENTICATED_SCOPE)
-            .expect("hard-coded scope fits this type")
-            .into();
-    let admin_key = lakers::Credential::parse_ccs(demo_setup::ADMIN_CREDENTIAL)
-        .expect("hard-coded credential fits this type");
-    let admin_scope = coapcore::scope::AifValue::parse(&demo_setup::ADMIN_SCOPE)
-        .expect("hard-coded scope fits this type")
-        .into();
+    let security_config = demo_setup::build_demo_ssc();
 
     // FIXME: Should we allow users to override that? After all, this is just convenience and may
     // be limiting in special applications.
     let handler = handler.with_wkc();
     let mut handler = coapcore::OscoreEdhocHandler::new(
         handler,
-        coapcore::seccfg::ConfigBuilder::new()
-            .allow_unauthenticated(unauthenticated_scope)
-            .with_own_edhoc_credential(own_credential, own_key)
-            .with_known_edhoc_credential(admin_key, admin_scope),
+        security_config,
         || lakers_crypto_rustcrypto::Crypto::new(ariel_os_random::crypto_rng()),
         ariel_os_random::crypto_rng(),
         coapcore::time::TimeUnknown,

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -64,6 +64,13 @@ coap = ["dep:ariel-os-coap", "random"]
 ## Enables applications to set up CoAP server handlers.
 ## See [`coap::coap_run()`].
 coap-server = ["coap", "ariel-os-coap/coap-server"]
+# Plain forwarded features that are not documented as features but just as laze
+# modules, because while those here work without any extra help from laze, most
+# later ones will likely need some build system help.
+coap-server-config-demokeys = ["ariel-os-coap/coap-server-config-demokeys"]
+coap-server-config-unprotected = [
+  "ariel-os-coap/coap-server-config-unprotected",
+]
 ## Selects static IP configuration.
 network-config-static = ["ariel-os-embassy/network-config-static"]
 

--- a/src/lib/coapcore/src/seccfg.rs
+++ b/src/lib/coapcore/src/seccfg.rs
@@ -29,6 +29,12 @@ pub trait ServerSecurityConfig: crate::Sealed {
     /// paths.
     const PARSES_TOKENS: bool;
 
+    /// True if the type will at any time need to process requests to /.well-known/edhoc
+    ///
+    /// This is used by the handler implementation to shortcut through some message processing
+    /// paths.
+    const HAS_EDHOC: bool;
+
     /// The way scopes issued with this system as audience by this AS are expressed here.
     type GeneralClaims: GeneralClaims;
 
@@ -150,17 +156,19 @@ impl crate::Sealed for DenyAll {}
 
 impl ServerSecurityConfig for DenyAll {
     const PARSES_TOKENS: bool = false;
+    const HAS_EDHOC: bool = false;
 
     type GeneralClaims = core::convert::Infallible;
 }
 
-/// An SSC representing unconditionally allowed access, including unencrypted.
+/// An SSC representing unconditionally allowed access without the option for opportunistic EDHOC.
 pub struct AllowAll;
 
 impl crate::Sealed for AllowAll {}
 
 impl ServerSecurityConfig for AllowAll {
     const PARSES_TOKENS: bool = false;
+    const HAS_EDHOC: bool = false;
 
     type GeneralClaims = Unlimited<crate::scope::AllowAll>;
 
@@ -196,6 +204,7 @@ impl crate::Sealed for ConfigBuilder {}
 impl ServerSecurityConfig for ConfigBuilder {
     // We can't know at build time, assume yes
     const PARSES_TOKENS: bool = true;
+    const HAS_EDHOC: bool = true;
 
     type GeneralClaims = ConfigBuilderClaims;
 

--- a/tests/coap-blinky/laze.yml
+++ b/tests/coap-blinky/laze.yml
@@ -6,7 +6,7 @@ apps:
           - CONFIG_ISR_STACKSIZE=32768
     selects:
       - coap-server
-      - coap-server-config-demokeys
+      - ?coap-server-config-demokeys
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi

--- a/tests/coap-blinky/laze.yml
+++ b/tests/coap-blinky/laze.yml
@@ -6,6 +6,7 @@ apps:
           - CONFIG_ISR_STACKSIZE=32768
     selects:
       - coap-server
+      - coap-server-config-demokeys
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi

--- a/tests/coap/README.md
+++ b/tests/coap/README.md
@@ -21,6 +21,12 @@ This application is a work in progress demo of running CoAP with OSCORE/EDHOC se
   up to the maximum number of security contexts that are stored (currently 4).
 * There is also `./fauxhoc.py`, which did EDHOC manually before it was integrated in aiocoap.
 
+### Variation
+
+* CoAP in NoSec mode: Building a smaller binary at the cost of confidentiality and integrity protection.
+    * In `laze.yml`, replace `coap-server-config-demokeys` with `coap-server-config-unprotected`.
+    * All resources are now only accessible without `--credentials`. (The "fauxhoc" script does not work in that mode).
+
 ## Roadmap
 
 Eventually, all of this should be covered by 20-line examples.

--- a/tests/coap/README.md
+++ b/tests/coap/README.md
@@ -24,7 +24,7 @@ This application is a work in progress demo of running CoAP with OSCORE/EDHOC se
 ### Variation
 
 * CoAP in NoSec mode: Building a smaller binary at the cost of confidentiality and integrity protection.
-    * In `laze.yml`, replace `coap-server-config-demokeys` with `coap-server-config-unprotected`.
+    * Add `-s coap-server-config-unprotected` to the laze invocation; this replaces the demokeys setup.
     * All resources are now only accessible without `--credentials`. (The "fauxhoc" script does not work in that mode).
 
 ## Roadmap

--- a/tests/coap/laze.yml
+++ b/tests/coap/laze.yml
@@ -6,6 +6,7 @@ apps:
           - CONFIG_ISR_STACKSIZE=32768
     selects:
       - coap-server
+      - coap-server-config-demokeys
       - coap-client
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418

--- a/tests/coap/laze.yml
+++ b/tests/coap/laze.yml
@@ -6,7 +6,7 @@ apps:
           - CONFIG_ISR_STACKSIZE=32768
     selects:
       - coap-server
-      - coap-server-config-demokeys
+      - ?coap-server-config-demokeys
       - coap-client
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418


### PR DESCRIPTION
# Description

Right now, all our examples use the demo keys, and we can't provision own keys, and can't run completely nosec.

This introduces laze (really cargo) features in which ariel-os-coap decides how to set up security, with the examples' config remaining "pick the demo keys" (but this time, explicitly).

With some coapcore internal changes (well they change its API, but not in a way ariel-os-coap notices), the nosec mode builds with considerably less flash usage.

Next steps from here are introducing more building blocks (like "flash my moral equivalent of ~/.ssh/id_ecdh.pub as the root key instead of a key file we ship" or "there is provisioning like in #453 so take those keys"), and those can extend both the -demokeys and can become part of a -default setup, but I'd take those gradually from here.

## Issues

Depends on #805 (so please ignore that first commit)

## Open Questions

* <del>I've seen a stack overflow again; I don't think this PR increases it, but nonetheless running some more tests.</del>

## Reviewing hints

* "consolidate demo setup" is best viewed with --ignore-all-space
* "feat(coapcore): do not link OSCORE and EDHOC unless usable ": chatting with tanriol at #rust:matrix.org has led me on a path for doing this better (uninhabited types to make some internal state machines vanish completely in the nosec mode), but that's a next step.

## Change checklist

- [ ] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
