### PR TITLE
fix(coap): tune down UDP buffers

### DIFF
--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -99,11 +99,12 @@ async fn coap_run_impl(handler: impl coap_handler::Handler + coap_handler::Repor
     // request, because we shouldn't hand out a client early).
     stack.wait_config_up().await;
 
-    // FIXME trim to CoAP requirements
-    let mut rx_meta = [PacketMetadata::EMPTY; 16];
-    let mut rx_buffer = [0; 4096];
-    let mut tx_meta = [PacketMetadata::EMPTY; 16];
-    let mut tx_buffer = [0; 4096];
+    // FIXME trim to CoAP requirements (those values are just a likely good starting point for "we
+    // process any message immediately anyway")
+    let mut rx_meta = [PacketMetadata::EMPTY; 2];
+    let mut rx_buffer = [0; 1500];
+    let mut tx_meta = [PacketMetadata::EMPTY; 2];
+    let mut tx_buffer = [0; 1500];
 
     let socket = UdpSocket::new(
         stack,


### PR DESCRIPTION
# Description

During testing (and even on unmodified main before and after #752), I've run into stack overflows with the CoAP examples. I didn't explore deeper into whether it was a nightly update or some unrelated commit that broke things.

This commit just tunes down two huge buffers whose size was copy-pasted from embassy-net examples -- it's not final tuning, but they work.

Curiously, those wind up as part of the stack size (stack uses of `embassy_executor::raw::TaskStorage<F>::poll`), even though their lifetime spans an await points (and they should thus be part of the state enum). By reducing the buffer size by less than 3000 byte per direction, 4x that amount is freed from the stack.

## Issues/PRs references

Deeper investigation is ongoing in https://github.com/ariel-os/ariel-os/issues/804

## Testing

I've successfully run all CoAP tests on the particle-xenon board with `-D LOG=debug`.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.
