### PR TITLE
feat(riscv): support configuring isr stacksize on riscv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "esp-hal",
  "linkme",
  "portable-atomic",
+ "rustflags",
 ]
 
 [[package]]
@@ -4511,6 +4512,12 @@ checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver 1.0.25",
 ]
+
+[[package]]
+name = "rustflags"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7fc92159fb50a431c5da366f7627751fe7263cf867f8a30f27fa6063ba02ac0"
 
 [[package]]
 name = "rustix"

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -457,6 +457,7 @@ modules:
       global:
         RUSTFLAGS:
           - --cfg context=\"riscv\"
+          - -Clink-arg=-Tisr_stack.x
 
   - name: rp-link-arg
     help: helper module that ensures link-rp.x is added behind cortex-m ld scripts

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -15,6 +15,9 @@ ariel-os-debug.workspace = true
 ariel-os-threads = { path = "../ariel-os-threads", optional = true }
 ariel-os-utils = { workspace = true }
 
+[build-dependencies]
+rustflags = "0.1"
+
 [target.'cfg(context = "cortex-m")'.dependencies]
 cortex-m = { workspace = true }
 cortex-m-rt = { workspace = true }

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -1,15 +1,49 @@
+use rustflags::Flag;
 use std::env;
 use std::path::PathBuf;
 
 fn main() {
+    let flags = rustflags::from_env();
+    let contexts = flags
+        .filter_map(|flag| match flag {
+            Flag::Cfg {
+                name,
+                value: Some(v),
+            } if name == "context" => Some(v),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    let context = |name: &str| contexts.contains(&name.to_string());
+
+    let context_any = |list: &'static [&'static str]| list.iter().find(|entry| context(entry));
+
     // Put the linker scripts somewhere the linker can find them
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
-    std::fs::copy("isr_stack.ld.in", out.join("isr_stack.x")).unwrap();
+    if let Some(context) = context_any(&["cortex-m", "riscv"]) {
+        let insert_before = match *context {
+            "riscv" => ".trap",
+            "cortex-m" => ".data",
+            _ => unreachable!(),
+        };
+
+        let region = match *context {
+            "riscv" => "RWDATA",
+            "cortex-m" => "RAM",
+            _ => unreachable!(),
+        };
+
+        let mut isr_stack_template = std::fs::read_to_string("isr_stack.ld.in").unwrap();
+        isr_stack_template = isr_stack_template.replace("${INSERT_BEFORE}", insert_before);
+        isr_stack_template = isr_stack_template.replace("${STACK_REGION}", region);
+        std::fs::write(out.join("isr_stack.x"), &isr_stack_template).unwrap();
+        println!("cargo:rerun-if-changed=isr_stack.x");
+    }
+
     std::fs::copy("linkme.x", out.join("linkme.x")).unwrap();
     std::fs::copy("eheap.x", out.join("eheap.x")).unwrap();
 
-    println!("cargo:rerun-if-changed=isr_stack.x");
     println!("cargo:rerun-if-changed=linkme.x");
     println!("cargo:rerun-if-changed=eheap.x");
 

--- a/src/ariel-os-rt/isr_stack.ld.in
+++ b/src/ariel-os-rt/isr_stack.ld.in
@@ -2,13 +2,19 @@ SECTIONS
 {
     .isr_stack (NOLOAD) : ALIGN(8)
     {
-        _stack_bottom = .;
+        _stack_bottom_tmp = .;
         KEEP (*(.isr_stack))
         . = ALIGN(8);
-        _stack_start = .;
-    } > RAM
+        _stack_start_tmp = .;
+    } > ${STACK_REGION}
 }
 
-INSERT BEFORE .data;
+INSERT BEFORE ${INSERT_BEFORE};
+
+/* using `_tmp` helpers so this overrides other linker script variables */
+_stack_end = _stack_bottom_tmp;
+_stack_bottom = _stack_bottom_tmp;
+_stack_start = _stack_start_tmp;
 
 ASSERT(_stack_start != _stack_bottom, "ERROR(ariel-os-rt): isr stack too small");
+ASSERT(_stack_start == _stack_start_tmp, "ERROR(ariel-os-rt): _stack_start not used!");

--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -39,12 +39,18 @@ cfg_if::cfg_if! {
     }
 }
 
-const ISR_STACKSIZE: usize =
-    ariel_os_utils::usize_from_env_or!("CONFIG_ISR_STACKSIZE", 8192, "ISR stack size (in bytes)");
+#[cfg(any(context = "cortex-m", context = "riscv"))]
+mod isr_stack {
+    const ISR_STACKSIZE: usize = ariel_os_utils::usize_from_env_or!(
+        "CONFIG_ISR_STACKSIZE",
+        8192,
+        "ISR stack size (in bytes)"
+    );
 
-#[link_section = ".isr_stack"]
-#[used(linker)]
-static ISR_STACK: [u8; ISR_STACKSIZE] = [0u8; ISR_STACKSIZE];
+    #[link_section = ".isr_stack"]
+    #[used(linker)]
+    static ISR_STACK: [u8; ISR_STACKSIZE] = [0u8; ISR_STACKSIZE];
+}
 
 #[cfg(feature = "_panic-handler")]
 #[panic_handler]


### PR DESCRIPTION
# Description

Previously, riscv (or the esp variants we're supporting) still used the end of memory as initial stack pointer. This PR brings them in line with Cortex-M, where the isr stack is placed at the beginning of RAM.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
