### PR TITLE
feat(esp32): add untested support for I2C controller and SPI main

### DIFF
--- a/src/ariel-os-esp/src/i2c/controller/mod.rs
+++ b/src/ariel-os-esp/src/i2c/controller/mod.rs
@@ -171,6 +171,8 @@ fn from_error(err: esp_hal::i2c::master::Error) -> ariel_os_embassy_common::i2c:
 }
 
 // Define a driver per peripheral
+#[cfg(context = "esp32")]
+define_i2c_drivers!(I2C0, I2C1);
 #[cfg(context = "esp32c3")]
 define_i2c_drivers!(I2C0);
 #[cfg(context = "esp32c6")]

--- a/src/ariel-os-esp/src/i2c/mod.rs
+++ b/src/ariel-os-esp/src/i2c/mod.rs
@@ -7,7 +7,10 @@ pub mod controller;
 pub fn init(peripherals: &mut crate::OptionalPeripherals) {
     // Take all I2C peripherals and do nothing with them.
     cfg_if::cfg_if! {
-        if #[cfg(context = "esp32c3")] {
+        if #[cfg(context = "esp32")] {
+            let _ = peripherals.I2C0.take().unwrap();
+            let _ = peripherals.I2C1.take().unwrap();
+        } else if #[cfg(context = "esp32c3")] {
             let _ = peripherals.I2C0.take().unwrap();
         } else if #[cfg(context = "esp32c6")] {
             let _ = peripherals.I2C0.take().unwrap();

--- a/src/ariel-os-esp/src/spi/main/mod.rs
+++ b/src/ariel-os-esp/src/spi/main/mod.rs
@@ -132,6 +132,9 @@ macro_rules! define_spi_drivers {
 }
 
 // Define a driver per peripheral
+// SPI0 exists but is not a general-purpose SPI peripheral.
+#[cfg(context = "esp32")]
+define_spi_drivers!(SPI1, SPI2, SPI3);
 // SPI0 and SPI1 exist but are not general-purpose SPI peripherals.
 #[cfg(context = "esp32c3")]
 define_spi_drivers!(SPI2);

--- a/src/ariel-os-esp/src/spi/mod.rs
+++ b/src/ariel-os-esp/src/spi/mod.rs
@@ -25,7 +25,11 @@ fn from_bit_order(bit_order: BitOrder) -> esp_hal::spi::BitOrder {
 pub fn init(peripherals: &mut crate::OptionalPeripherals) {
     // Take all SPI peripherals and do nothing with them.
     cfg_if::cfg_if! {
-        if #[cfg(context = "esp32c3")] {
+        if #[cfg(context = "esp32")] {
+            let _ = peripherals.SPI1.take().unwrap();
+            let _ = peripherals.SPI2.take().unwrap();
+            let _ = peripherals.SPI3.take().unwrap();
+        } else if #[cfg(context = "esp32c3")] {
             let _ = peripherals.SPI2.take().unwrap();
         } else if #[cfg(context = "esp32c6")] {
             let _ = peripherals.SPI2.take().unwrap();


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This should fix our nightly build failure of the I2C controller and SPI main tests.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
