### PR TITLE
chore: add -Z emit-stack-sizes and keep them through linking

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -394,7 +394,9 @@ modules:
           - -Clink-arg=-Teheap.x
           - -Clink-arg=-Tdevice.x
           - -Clink-arg=-Tisr_stack.x
+          - -Clink-arg=-Tkeep-stack-sizes.x
           - --cfg context=\"cortex-m\"
+          - -Z emit-stack-sizes
 
   - name: thumbv6m-none-eabi
     depends:

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -8,10 +8,12 @@ fn main() {
     std::fs::copy("isr_stack.ld.in", out.join("isr_stack.x")).unwrap();
     std::fs::copy("linkme.x", out.join("linkme.x")).unwrap();
     std::fs::copy("eheap.x", out.join("eheap.x")).unwrap();
+    std::fs::copy("keep-stack-sizes.x", out.join("keep-stack-sizes.x")).unwrap();
 
     println!("cargo:rerun-if-changed=isr_stack.x");
     println!("cargo:rerun-if-changed=linkme.x");
     println!("cargo:rerun-if-changed=eheap.x");
+    println!("cargo:rerun-if-changed=keep-stack-sizes.x");
 
     println!("cargo:rustc-link-search={}", out.display());
 }

--- a/src/ariel-os-rt/keep-stack-sizes.x
+++ b/src/ariel-os-rt/keep-stack-sizes.x
@@ -1,0 +1,12 @@
+/* SPDX-FileCopyrightText: The Rust Project Developers (see https://thanks.rust-lang.org)
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ * As recommended on https://doc.rust-lang.org/beta/unstable-book/compiler-flags/emit-stack-sizes.html */
+SECTIONS
+{
+  /* `INFO` makes the section not allocatable so it won't be loaded into memory */
+  .stack_sizes (INFO) :
+  {
+    KEEP(*(.stack_sizes));
+  }
+}


### PR DESCRIPTION
# Description

Rust and LLVM can export some information about the stack sizes by
* rustc emitting them into some section, and
* the linker (as guided by the linker script) keeping them without emitting them into the binary

This is not used by any tools yet, but emits information usable, for example, by a [small script listed in #804](https://github.com/ariel-os/ariel-os/issues/804#issuecomment-2655105100).

## Issues/PRs references

Contributes to #804 by setting some groundwork.

## Other remarks

* I've copied linker script verbatim from the docs, and set the appropriate SPDX / reuse comments.
* This adds a nightly-only flag unconditionally; once we approach building on stable, we can make it conditional (but no point in doing that now).
* I don't think there's considerable cost to it; it's just a few hundred bytes added to the ELF.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.
  (documentation would make sense once this is a public feature and/or configurable)
