### PR TITLE
docs(book): install-toolchain only goes through rustup and doesn't do ESP

### DIFF
--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -36,6 +36,9 @@ It explains how to compile and run the `hello-word` example to verify your setup
     laze build install-toolchain
     ```
 
+    This invokes rustup to add all easy-to-install targets and components;
+    the ESP toolchain needs additional manual installation steps.
+
 ## Running the `hello-world` example
 
 To check that everything is installed correctly, the `hello-word` example can be compiled and run from the `ariel-os` directory.

--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -10,31 +10,31 @@ It explains how to compile and run the `hello-word` example to verify your setup
 1. Install the needed build dependencies.
    On Ubuntu, the following is sufficient:
 
-```sh
-apt install git rustup ninja-build pkg-config libudev-dev clang gcc-arm-none-eabi
-```
+    ```sh
+    apt install git rustup ninja-build pkg-config libudev-dev clang gcc-arm-none-eabi
+    ```
 
 1. Install the Rust installer [rustup](https://rustup.rs/) using the website's instructions or through your distribution package manager.
 
 1. Install the build system [laze](https://github.com/kaspar030/laze):
 
-```sh
-cargo install laze
-```
+    ```sh
+    cargo install laze
+    ```
 
 1. Install the debugging and flashing utility [probe-rs](https://github.com/probe-rs/probe-rs):
 
-```sh
-cargo install --locked probe-rs-tools
-```
+    ```sh
+    cargo install --locked probe-rs-tools
+    ```
 
 1. Clone the [Ariel OS repository][ariel-os-repo] and `cd` into it.
 
 1. Install the Rust targets:
 
-```sh
-laze build install-toolchain
-```
+    ```sh
+    laze build install-toolchain
+    ```
 
 ## Running the `hello-world` example
 

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1037,6 +1037,7 @@ builders:
       install-toolchain:
         build: false
         cmd:
+          # If this starts doing anything else other than rustup, update the book that currently claims this to be rustup only.
           - rustup target add thumbv6m-none-eabi
           - rustup target add thumbv7m-none-eabi
           - rustup target add thumbv7em-none-eabi


### PR DESCRIPTION
# Description

I tried to build something locally for all boards, and got "error: toolchain 'esp' is not installable" -- so I did what all good users do and went to the book's installation instructions.

The `laze build install-toolchain` command scared me, for I prefer knowing what gets done before I do it -- installing through rustup is fine, and that's what it does, but the docs didn't tell me, so that is fixed here.

A note in the laze-project.yml file ensures that this doesn't change without updating the note.

The note also mentions that ESP32 is *not* installed -- that doesn't help me with my original problem, and apparently we don't have docs for that. If there is some easy third party instruction we can link, I'd add that, otherwise I suggest we merge this here and then work on extra docs to get people started with those.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
