### PR TITLE
chore: run espup through laze and document it

### DIFF
--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -10,11 +10,21 @@ It explains how to compile and run the `hello-word` example to verify your setup
 1. Install the needed build dependencies.
    On Ubuntu, the following is sufficient:
 
+   <!-- gcc and curl are only required for espup, but it doesn't hurt to install those here. -->
+
     ```sh
-    apt install git rustup ninja-build pkg-config libudev-dev clang gcc-arm-none-eabi gcc-riscv64-unknown-elf
+    apt install git rustup ninja-build pkg-config libudev-dev clang gcc-arm-none-eabi gcc-riscv64-unknown-elf gcc curl
     ```
 
 1. Install the Rust installer [rustup](https://rustup.rs/) using the website's instructions or through your distribution package manager.
+
+1. Only for using ESP devices, install [espup](https://github.com/esp-rs/espup) and related tools:
+
+   ```sh
+   cargo install espup
+   espup install
+   cargo install espflash
+   ```
 
 1. Install the build system [laze](https://github.com/kaspar030/laze):
 
@@ -36,8 +46,8 @@ It explains how to compile and run the `hello-word` example to verify your setup
     laze build install-toolchain
     ```
 
-    This invokes rustup to add all easy-to-install targets and components;
-    the ESP toolchain needs additional manual installation steps.
+    This invokes rustup to add all easy-to-install targets and components,
+    and invokes espup if it is installed.
 
 ## Running the `hello-world` example
 

--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -26,6 +26,9 @@ It explains how to compile and run the `hello-word` example to verify your setup
    cargo install espflash
    ```
 
+   There is no need to actively source the `~/export-esp.sh` file which `espup` produces:
+   Ariel OS's build system will consult that file when building for ESP.
+
 1. Install the build system [laze](https://github.com/kaspar030/laze):
 
     ```sh

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1169,7 +1169,7 @@ builders:
       install-toolchain:
         build: false
         cmd:
-          # If this starts doing anything else other than rustup, update the book that currently claims this to be rustup only.
+          # If this starts doing anything else other than rustup and espup, update the book that currently claims this to be rustup only.
           - rustup target add thumbv6m-none-eabi
           - rustup target add thumbv7m-none-eabi
           - rustup target add thumbv7em-none-eabi
@@ -1179,6 +1179,7 @@ builders:
           - rustup target add riscv32imc-unknown-none-elf
           - rustup target add riscv32imac-unknown-none-elf
           - rustup component add rust-src
+          - if command -v espup >/dev/null; then espup update --targets=esp32,esp32s3; fi
 
       install-c2rust:
         build: false


### PR DESCRIPTION
# Description

Docs were incomplete w/rt ESP installation: Support for updating espup through espup is added to the build scripts, and documented.

## Open questions

This does *not* act on the "source this thing" line; would it make sense to do that in the same PR, given that we are now taking some responsibility (at least in the sense of guiding the user) toward setting this up?

(I think that selectively sourcing espup's exports is generally a good idea, especially as it allows the user to keep their LLVM environment variables clean, and thus keep them from messing with othe)

## Issues/PRs references

Follow-up for #812

Blocked by https://github.com/ariel-os/ariel-os/pull/826

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
