### PR TITLE
feat(storage)!: change ariel init marker in storage

### DIFF
--- a/src/ariel-os-storage/src/lib.rs
+++ b/src/ariel-os-storage/src/lib.rs
@@ -28,8 +28,8 @@ pub use storage::*;
 
 static STORAGE: OnceLock<Mutex<CriticalSectionRawMutex, Storage<Flash>>> = OnceLock::new();
 
-const MARKER_KEY: &str = "0xdeadcafe";
-const MARKER_VALUE: u32 = 0xdead_cafe;
+const MARKER_KEY: &str = "ARIEL_INIT_MARK";
+const MARKER_VALUE: u8 = 0;
 
 /// Gets a [`Range`] from the linker that can be used for a global [`Storage`].
 ///
@@ -90,7 +90,7 @@ pub async fn init(p: &mut OptionalPeripherals) {
     embassy_time::Timer::after_millis(10).await;
 
     // Use a marker to ensure that this storage is initialized.
-    match get::<u32>(MARKER_KEY).await {
+    match get::<u8>(MARKER_KEY).await {
         Ok(Some(val)) if val == MARKER_VALUE => {
             // all good
         }


### PR DESCRIPTION
# Description

This is a minimal improvement over the key-value pair inserted by Ariel OS in the storage on initialization by changing the key to a name clearly from Ariel and a unit type value.

## Issues/PRs references


## Open Questions

We can probably do better than this by storing some metadata about the storage itself.

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
