### PR TITLE
chore(coapcore): update libOSCORE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,6 @@ dependencies = [
  "lakers",
  "lakers-crypto-rustcrypto",
  "liboscore",
- "liboscore-msgbackend",
  "log",
  "minicbor 0.25.1",
  "minicbor-adapters",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3390,9 +3390,9 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "liboscore"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dc508dbff1679752f2920bc4b083b340f3a0b4007b7d7a992636cfd0803b9d"
+checksum = "af6e1648c4033839670d2e5d053540cc441cee37e83ccdd512815c77c1d08f5a"
 dependencies = [
  "bindgen",
  "cbindgen",
@@ -3407,9 +3407,9 @@ dependencies = [
 
 [[package]]
 name = "liboscore-cryptobackend"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5af92747829a4c493c1b8e6e657f411cf293225e793ffdfa4646bbbe0ae0cac9"
+checksum = "b43bf8217ae374d7fb5d47ca584bde97167cca1d975085a453a370184741556a"
 dependencies = [
  "aead",
  "aes",
@@ -3426,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "liboscore-msgbackend"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca9f002a403f35e914deab972dbfb381b28b7fd9c43c312fbd3ba59c5b60cb2"
+checksum = "584661daca0fb237c9018ffd4644ad5aff95473c51ce38b1eee614655fc01e3f"
 dependencies = [
  "coap-message",
  "coap-message-implementations",

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -27,7 +27,6 @@ coap-message-utils = "0.3.3"
 coap-numbers = "0.2.3"
 lakers-crypto-rustcrypto = "0.7.2"
 liboscore = "0.2.2"
-liboscore-msgbackend = "0.2.2"
 
 # actually we depend on <https://github.com/twittner/minicbor/pull/9> so it
 # should be

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -26,7 +26,7 @@ coap-message-implementations = { version = "0.1.2", features = ["downcast"] }
 coap-message-utils = "0.3.3"
 coap-numbers = "0.2.3"
 lakers-crypto-rustcrypto = "0.7.2"
-liboscore = "0.2.2"
+liboscore = "0.2.4"
 
 # actually we depend on <https://github.com/twittner/minicbor/pull/9> so it
 # should be


### PR DESCRIPTION
# Description

Updting libOSCORE enables being selective about symbols to be shipped by libOSCORE, which is relevant for ESP builds.

It does not yet enable libOSCORE builds because they will need concrete settings (something like `CFLAGS="-mlongcalls" CC=xtensa-esp32-elf-gcc`, and maybe more controlled sourcing of the export-esp.sh environment) in CI.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
