### PR TITLE
feat(coap): remove blockers for ESP32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,6 @@ dependencies = [
  "lakers",
  "lakers-crypto-rustcrypto",
  "liboscore",
- "liboscore-msgbackend",
  "log",
  "minicbor 0.25.1",
  "minicbor-adapters",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3390,9 +3390,9 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "liboscore"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dc508dbff1679752f2920bc4b083b340f3a0b4007b7d7a992636cfd0803b9d"
+checksum = "af6e1648c4033839670d2e5d053540cc441cee37e83ccdd512815c77c1d08f5a"
 dependencies = [
  "bindgen",
  "cbindgen",
@@ -3407,9 +3407,9 @@ dependencies = [
 
 [[package]]
 name = "liboscore-cryptobackend"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5af92747829a4c493c1b8e6e657f411cf293225e793ffdfa4646bbbe0ae0cac9"
+checksum = "b43bf8217ae374d7fb5d47ca584bde97167cca1d975085a453a370184741556a"
 dependencies = [
  "aead",
  "aes",
@@ -3426,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "liboscore-msgbackend"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca9f002a403f35e914deab972dbfb381b28b7fd9c43c312fbd3ba59c5b60cb2"
+checksum = "584661daca0fb237c9018ffd4644ad5aff95473c51ce38b1eee614655fc01e3f"
 dependencies = [
  "coap-message",
  "coap-message-implementations",

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -302,6 +302,7 @@ contexts:
     parent: esp
     selects:
       - xtensa
+      - something-inside-the-esp32s3-blobs-that-contains-a-c-abort
     env:
       CARGO_TOOLCHAIN: +esp
       RUSTFLAGS:
@@ -452,6 +453,9 @@ modules:
       global:
         RUSTFLAGS:
           - --cfg context=\"xtensa\"
+
+  - name: something-inside-the-esp32s3-blobs-that-contains-a-c-abort
+    provides_unique: [c-function-abort]
 
   - name: riscv
     env:
@@ -794,6 +798,8 @@ modules:
     depends:
       - random
       - network
+      - c-function-assert
+      - c-function-abort
     env:
       global:
         FEATURES:
@@ -847,6 +853,22 @@ modules:
     help: Support for CoAP client functionality.
     depends:
       - coap
+
+  - name: liboscore-provide-abort
+    help: Make liboscore provide an implementation of the `abort` C function that it needs.
+    env:
+      global:
+        FEATURES:
+          - ariel-os/liboscore-provide-abort
+    provides_unique: [c-function-abort]
+
+  - name: liboscore-provide-assert
+    help: Make liboscore provide an implementation of the `assert` C function that it needs.
+    env:
+      global:
+        FEATURES:
+          - ariel-os/liboscore-provide-assert
+    provides_unique: [c-function-assert]
 
   - name: random
     help: A system-wide RNG is available (through the ariel_os::random module).

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -455,6 +455,7 @@ modules:
           - --cfg context=\"xtensa\"
 
   - name: something-inside-the-esp32s3-blobs-that-contains-a-c-abort
+    context: esp32s3
     provides_unique: [c-function-abort]
 
   - name: riscv

--- a/src/ariel-os-coap/Cargo.toml
+++ b/src/ariel-os-coap/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-coapcore.path = "../lib/coapcore"
+coapcore = { path = "../lib/coapcore", default-features = false }
 coap-handler = "0.2.0"
 coap-handler-implementations = "0.5.0"
 critical-section.workspace = true
@@ -58,6 +58,10 @@ coap-server = []
 
 coap-server-config-unprotected = []
 coap-server-config-demokeys = []
+
+# Plain feature forwards and selected by laze to fill up the default features on demand.
+liboscore-provide-abort = ["coapcore/liboscore-provide-abort"]
+liboscore-provide-assert = ["coapcore/liboscore-provide-assert"]
 
 ## Enables an arbitrary set of features in dependencies where dependencies fail
 ## if no features are configured at all.

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -71,6 +71,10 @@ coap-server-config-demokeys = ["ariel-os-coap/coap-server-config-demokeys"]
 coap-server-config-unprotected = [
   "ariel-os-coap/coap-server-config-unprotected",
 ]
+# Forwarded features that are not even user selected, but influenced by the
+# build system that knows who provides an abort and assert handler.
+liboscore-provide-abort = ["ariel-os-coap/liboscore-provide-abort"]
+liboscore-provide-assert = ["ariel-os-coap/liboscore-provide-assert"]
 ## Selects static IP configuration.
 network-config-static = ["ariel-os-embassy/network-config-static"]
 

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -26,7 +26,7 @@ coap-message-implementations = { version = "0.1.2", features = ["downcast"] }
 coap-message-utils = "0.3.3"
 coap-numbers = "0.2.3"
 lakers-crypto-rustcrypto = "0.7.2"
-liboscore = "0.2.4"
+liboscore = { version = "0.2.4", default-features = false }
 
 # actually we depend on <https://github.com/twittner/minicbor/pull/9> so it
 # should be
@@ -63,6 +63,21 @@ defmt = ["defmt-or-log/defmt", "dep:defmt", "lakers/defmt"]
 # `log` is not a link because we can't build docs with --all-features, see also
 # https://github.com/t-moe/defmt-or-log/issues/4
 log = ["defmt-or-log/log", "dep:log"]
+
+## Select the liboscore default features
+#
+# libOSCORE generally provides abort and assert symbols for its C code. When
+# used in environments where they are provided by other code (eg. ESP32 some
+# variants), this default feature can be disabled, leaving the user to manually
+# select the right libOSCORE features.
+liboscore-defaults = ["liboscore-provide-abort", "liboscore-provide-assert"]
+
+## Feature passed on to libOSCORE (see `liboscore-defaults`)
+liboscore-provide-abort = ["liboscore/provide-abort"]
+## Feature passed on to libOSCORE (see `liboscore-defaults`)
+liboscore-provide-assert = ["liboscore/provide-assert"]
+
+default = ["liboscore-defaults"]
 
 # Private feature that enables doc_auto_cfg
 _nightly_docs = []

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -27,7 +27,6 @@ coap-message-utils = "0.3.3"
 coap-numbers = "0.2.3"
 lakers-crypto-rustcrypto = "0.7.2"
 liboscore = "0.2.2"
-liboscore-msgbackend = "0.2.2"
 
 # actually we depend on <https://github.com/twittner/minicbor/pull/9> so it
 # should be

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -26,7 +26,7 @@ coap-message-implementations = { version = "0.1.2", features = ["downcast"] }
 coap-message-utils = "0.3.3"
 coap-numbers = "0.2.3"
 lakers-crypto-rustcrypto = "0.7.2"
-liboscore = "0.2.2"
+liboscore = "0.2.4"
 
 # actually we depend on <https://github.com/twittner/minicbor/pull/9> so it
 # should be


### PR DESCRIPTION
# Description

This threads features of libOSCORE through the whole build system so that a particular symbol (`abort()`) that libOSCORE needs to provide by itself on pure-Rust builds is disabled on ESP32S3.

## Caveats and testing

This does not yet enable the ESPs to build (that'll need build script and CI magic); nonetheless, these changes' effectiveness can be tested by removing the conflict from the coap-server example's laze file, and running:

* as a baseline that ESP works (this one doesn't need any particular features)

   ```sh
   $ laze build -b particle-xenon
   $ (source ~/export-esp.sh && CONFIG_WIFI_NETWORK=... CONFIG_WIFI_PASSWORD=... CFLAGS="-mlongcalls" CC=xtensa-esp32-elf-gcc laze -C examples/coap-server/ build -b espressif-esp32-devkitc)
   ```

* to show its effectiveness:

   ```sh
   $ (source ~/export-esp.sh && CONFIG_WIFI_NETWORK=... CONFIG_WIFI_PASSWORD=... CFLAGS="-mlongcalls" CC=xtensa-esp32s3-elf-gcc laze -C examples/coap-server/ build -b espressif-esp32-s3-devkitc-1)
   ```

I've only tested this with ESP32 (not S or other letter) and don't have ESP32S2 hardware around.

## Issues/PRs references

* I guess @kaspar030 has some branch already around where the `export-esp.sh` sourcing happens inside the build system, and on top of that we set the CC and CFLAGS. In combination with that, we could enable building on any esp32.

* Builds on #823

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
