### PR TITLE
chore: source extensa environment on demand, unblocking coap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,8 @@ jobs:
           laze --version
           arm-none-eabi-gcc --version
           clang --version
+          cat ${ESPUP_EXPORT_FILE:-~/export-esp.sh}
+          (. ${ESPUP_EXPORT_FILE:-~/export-esp.sh}; xtensa-esp32s3-elf-gcc --version)
           set +x
           # Check which alternative versions are installed
           IFS=":"; for p in $PATH; do ls $p/llvm-config-* $p/clang-* 2>/dev/null; done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,20 +79,6 @@ jobs:
           override: false
           export: false
 
-      - name: Keep general build environment clean of Xtensa peculiarities
-        if: steps.result-cache.outputs.cache-hit != 'true'
-        # The Xtensa setup unconditionally sets LIBCLANG_PATH in GITHUB_ENV --
-        # we can't undo that. (It also sets it in ~/exports, but that is just
-        # what it uses internally to get that data around into the action
-        # script)
-        #
-        # As the shell apparently does not source any files, and until
-        # https://github.com/actions/runner/issues/1126 is fixed by GitHub, the
-        # best remedy is to stow the workaround and source it wherever we can.
-        run: |
-          set -x
-          echo 'unset LIBCLANG_PATH' >> ~/source-this-first.sh
-
       - name: rust cache
         if: steps.result-cache.outputs.cache-hit != 'true'
         uses: Swatinem/rust-cache@v2
@@ -107,7 +93,6 @@ jobs:
       - name: "installing prerequisites"
         if: steps.result-cache.outputs.cache-hit != 'true'
         run: |
-          source ~/source-this-first.sh
           git config --global init.defaultBranch main
           git config --global user.email "ci@riot-labs.de"
           git config --global user.name "CI"
@@ -134,13 +119,11 @@ jobs:
       - name: "limit build unless nightly build"
         if: github.event_name != 'schedule' && steps.result-cache.outputs.cache-hit != 'true'
         run: |
-          source ~/source-this-first.sh
           echo "LAZE_BUILDERS=ai-c3,espressif-esp32-devkitc,espressif-esp32-c6-devkitc-1,espressif-esp32-s3-devkitc-1,bbc-microbit-v2,nrf52840dk,nrf5340dk,rpi-pico,rpi-pico-w,st-nucleo-h755zi-q,st-nucleo-wb55" >> "$GITHUB_ENV"
 
       - name: "ariel-os compilation test"
         if: steps.result-cache.outputs.cache-hit != 'true'
         run: |
-          source ~/source-this-first.sh
           sccache --start-server || true # work around https://github.com/ninja-build/ninja/issues/2052
 
           CONFIG_WIFI_NETWORK='test' CONFIG_WIFI_PASSWORD='password' laze build --global --partition hash:${{ matrix.partition }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
           git config --global user.name "CI"
           cargo binstall --no-confirm --no-symlinks --force --no-discover-github-token laze
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          sudo apt-get install ninja-build gcc-arm-none-eabi
+          sudo apt-get install ninja-build gcc-arm-none-eabi gcc-riscv64-unknown-elf
 
       - name: "Show installed versions"
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,10 +71,13 @@ jobs:
 
       - name: Install Rust for Xtensa
         if: steps.result-cache.outputs.cache-hit != 'true'
-        uses: esp-rs/xtensa-toolchain@v1.5
+        # No tag yet after https://github.com/esp-rs/xtensa-toolchain/pull/38 (will probably be @v1.5.5)
+        uses: esp-rs/xtensa-toolchain@main
         with:
           version: "1.84.0.0"
           buildtargets: esp32s3
+          override: false
+          export: false
 
       - name: Keep general build environment clean of Xtensa peculiarities
         if: steps.result-cache.outputs.cache-hit != 'true'

--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -11,7 +11,7 @@ It explains how to compile and run the `hello-word` example to verify your setup
    On Ubuntu, the following is sufficient:
 
     ```sh
-    apt install git rustup ninja-build pkg-config libudev-dev clang gcc-arm-none-eabi
+    apt install git rustup ninja-build pkg-config libudev-dev clang gcc-arm-none-eabi gcc-riscv64-unknown-elf
     ```
 
 1. Install the Rust installer [rustup](https://rustup.rs/) using the website's instructions or through your distribution package manager.

--- a/examples/coap-client/laze.yml
+++ b/examples/coap-client/laze.yml
@@ -6,6 +6,3 @@ apps:
           - CONFIG_ISR_STACKSIZE=32768
     selects:
       - coap-client
-    conflicts:
-      # see https://github.com/ariel-os/ariel-os/issues/418
-      - thumbv6m-none-eabi

--- a/examples/coap-client/laze.yml
+++ b/examples/coap-client/laze.yml
@@ -9,5 +9,3 @@ apps:
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi
-      # no riscv gcc on CI
-      - riscv

--- a/examples/coap-client/laze.yml
+++ b/examples/coap-client/laze.yml
@@ -9,6 +9,5 @@ apps:
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi
-      # no xtensa / riscv gcc on CI
-      - xtensa
+      # no riscv gcc on CI
       - riscv

--- a/examples/coap-server/laze.yml
+++ b/examples/coap-server/laze.yml
@@ -10,5 +10,3 @@ apps:
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi
-      # no riscv gcc on CI
-      - riscv

--- a/examples/coap-server/laze.yml
+++ b/examples/coap-server/laze.yml
@@ -10,6 +10,5 @@ apps:
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi
-      # no xtensa / riscv gcc on CI
-      - xtensa
+      # no riscv gcc on CI
       - riscv

--- a/examples/coap-server/laze.yml
+++ b/examples/coap-server/laze.yml
@@ -7,6 +7,3 @@ apps:
     selects:
       - coap-server
       - ?coap-server-config-demokeys
-    conflicts:
-      # see https://github.com/ariel-os/ariel-os/issues/418
-      - thumbv6m-none-eabi

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -321,6 +321,7 @@ contexts:
     parent: esp
     selects:
       - xtensa
+    provides_unique: [c-function-abort]
     env:
       CARGO_TOOLCHAIN: +esp
       RUSTFLAGS:
@@ -864,6 +865,10 @@ modules:
       # buildable without a C compiler, but right now it's easier to just make
       # the C compiler a prerequisite.
       - c-compiler
+      # These are usually provided by liboscore's features, which are selected through this
+      # unless provided by the context.
+      - c-function-assert
+      - c-function-abort
     env:
       global:
         FEATURES:
@@ -917,6 +922,22 @@ modules:
     help: Support for CoAP client functionality.
     depends:
       - coap
+
+  - name: liboscore-provide-abort
+    help: Make liboscore provide an implementation of the `abort` C function that it needs.
+    env:
+      global:
+        FEATURES:
+          - ariel-os/liboscore-provide-abort
+    provides_unique: [c-function-abort]
+
+  - name: liboscore-provide-assert
+    help: Make liboscore provide an implementation of the `assert` C function that it needs.
+    env:
+      global:
+        FEATURES:
+          - ariel-os/liboscore-provide-assert
+    provides_unique: [c-function-assert]
 
   - name: random
     help: A system-wide RNG is available (through the ariel_os::random module).

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -78,7 +78,7 @@ contexts:
         always: true
         cmd: >-
           test "${SKIP_CARGO_BUILD}" = "1" && exit 0;
-          cd ${relpath} && ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} build --${PROFILE} ${FEATURES}
+          cd ${relpath} && ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} build --${PROFILE} ${FEATURES}
           && cp ${relroot}/${build-dir}/bin/${builder}/cargo/${RUSTC_TARGET}/${PROFILE}/${riot_binary} ${relroot}/${out}
           ${POST_LINK}
 
@@ -89,26 +89,26 @@ contexts:
       exec:
         build: false
         cmd:
-          - ${CARGO_ENV}
+          - ${CARGO_PRESHELL} ${CARGO_ENV}
 
       cargo:
         cmd:
-          - cd ${relpath} && ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS}
+          - cd ${relpath} && ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS}
         build: false
 
       run:
         build: false
         cmd:
-          - cd ${appdir} && ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --${PROFILE} ${FEATURES}
+          - cd ${appdir} && ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --${PROFILE} ${FEATURES}
 
       clippy:
         build: false
         cmd:
-          - cd ${appdir} && ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} clippy ${FEATURES}
+          - cd ${appdir} && ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} clippy ${FEATURES}
 
       debug:
         cmd:
-          - cd ${appdir} && ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --${PROFILE} ${FEATURES}
+          - cd ${appdir} && ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --${PROFILE} ${FEATURES}
         build: false
         ignore_ctrl_c: true
 
@@ -120,12 +120,12 @@ contexts:
 
       bloat:
         cmd:
-          - cd ${appdir} && ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} bloat --${PROFILE} ${FEATURES}
+          - cd ${appdir} && ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} bloat --${PROFILE} ${FEATURES}
         build: false
 
       tree:
         cmd:
-          - cd ${appdir} && ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} tree ${FEATURES}
+          - cd ${appdir} && ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} tree ${FEATURES}
         build: false
 
       size:
@@ -480,6 +480,15 @@ modules:
       global:
         RUSTFLAGS:
           - --cfg context=\"xtensa\"
+        CARGO_PRESHELL:
+          # ~/export-esp.sh is the common location, but espup install can
+          # override it with its --export-file argument, which is done in CI;
+          # the environment variable is used by espup and exported by its action.
+          #
+          # Note that one \ escapes for YAML, the reaming \ escapes for laze,
+          # and the second $ escapes for laze's internal ninja, resulting in
+          # the shell to see just ${ESPUP_...
+          - '. $\\${ESPUP_EXPORT_FILE:-~/export-esp.sh} &&'
 
   - name: riscv
     env:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -285,6 +285,7 @@ contexts:
     parent: esp
     selects:
       - riscv
+    provides_unique: [c-function-abort]
     env:
       RUSTFLAGS:
         - --cfg context=\"esp32c3\"
@@ -303,6 +304,7 @@ contexts:
     parent: esp
     selects:
       - riscv
+    provides_unique: [c-function-abort]
     env:
       RUSTFLAGS:
         - --cfg context=\"esp32c6\"

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1,4 +1,4 @@
-laze_required_version: 0.1.28
+laze_required_version: 0.1.31
 
 contexts:
   # base context that all other contexts inherit from

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -273,6 +273,7 @@ contexts:
         - --cfg context=\"esp32\"
       RUSTC_TARGET: xtensa-esp32-none-elf
       CARGO_TARGET_PREFIX: CARGO_TARGET_XTENSA_ESP32_NONE_ELF
+      CC: xtensa-esp32-elf-gcc
 
   - name: esp-wroom-32
     parent: esp32
@@ -328,6 +329,7 @@ contexts:
       PROBE_RS_CHIP: esp32s3
       PROBE_RS_PROTOCOL: jtag
       CARGO_TARGET_PREFIX: CARGO_TARGET_XTENSA_ESP32S3_NONE_ELF
+      CC: xtensa-esp32s3-elf-gcc
 
   - name: esp32-s3-wroom-1
     parent: esp32s3
@@ -480,6 +482,8 @@ modules:
       global:
         RUSTFLAGS:
           - --cfg context=\"xtensa\"
+        CFLAGS:
+          - -mlongcalls
         CARGO_PRESHELL:
           # ~/export-esp.sh is the common location, but espup install can
           # override it with its --export-file argument, which is done in CI;
@@ -511,6 +515,19 @@ modules:
       global:
         FEATURES:
           - ariel-os/alloc
+
+  - name: c-compiler
+    help: Configures a C compiler (which is used by build crates such as `cc`).
+    # This may later also check for whether a C compiler is present on the
+    # selected platform in the first place.
+    env:
+      global:
+        # It's fine if either is not set -- that is how the ARM platforms work,
+        # the `cc` crate figures out a good compiler. On ESP, things are not so
+        # solid, and the context contributes variables.
+        CARGO_ENV:
+          - CC="${CC}"
+          - CFLAGS="${CFLAGS}"
 
   - name: debug-console
     context: ariel-os
@@ -843,6 +860,10 @@ modules:
     depends:
       - random
       - network
+      # A NoSec version (coap-server-config-unprotected) could be made to be
+      # buildable without a C compiler, but right now it's easier to just make
+      # the C compiler a prerequisite.
+      - c-compiler
     env:
       global:
         FEATURES:

--- a/src/ariel-os-coap/Cargo.toml
+++ b/src/ariel-os-coap/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 repository.workspace = true
 
 [dependencies]
-coapcore.path = "../lib/coapcore"
+coapcore = { path = "../lib/coapcore", default-features = false }
 coap-handler = "0.2.0"
 coap-handler-implementations = "0.5.0"
 critical-section.workspace = true
@@ -58,6 +58,10 @@ coap-server = []
 
 coap-server-config-unprotected = []
 coap-server-config-demokeys = []
+
+# Plain feature forwards and selected by laze to fill up the default features on demand.
+liboscore-provide-abort = ["coapcore/liboscore-provide-abort"]
+liboscore-provide-assert = ["coapcore/liboscore-provide-assert"]
 
 ## Enables an arbitrary set of features in dependencies where dependencies fail
 ## if no features are configured at all.

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -71,6 +71,10 @@ coap-server-config-demokeys = ["ariel-os-coap/coap-server-config-demokeys"]
 coap-server-config-unprotected = [
   "ariel-os-coap/coap-server-config-unprotected",
 ]
+# Forwarded features that are not even user selected, but influenced by the
+# build system that knows who provides an abort and assert handler.
+liboscore-provide-abort = ["ariel-os-coap/liboscore-provide-abort"]
+liboscore-provide-assert = ["ariel-os-coap/liboscore-provide-assert"]
 ## Selects static IP configuration.
 network-config-static = ["ariel-os-embassy/network-config-static"]
 

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -26,7 +26,7 @@ coap-message-implementations = { version = "0.1.2", features = ["downcast"] }
 coap-message-utils = "0.3.3"
 coap-numbers = "0.2.3"
 lakers-crypto-rustcrypto = "0.7.2"
-liboscore = "0.2.4"
+liboscore = { version = "0.2.4", default-features = false }
 
 # actually we depend on <https://github.com/twittner/minicbor/pull/9> so it
 # should be
@@ -63,6 +63,21 @@ defmt = ["defmt-or-log/defmt", "dep:defmt", "lakers/defmt"]
 # `log` is not a link because we can't build docs with --all-features, see also
 # https://github.com/t-moe/defmt-or-log/issues/4
 log = ["defmt-or-log/log", "dep:log"]
+
+## Select the liboscore default features
+#
+# libOSCORE generally provides abort and assert symbols for its C code. When
+# used in environments where they are provided by other code (eg. ESP32 some
+# variants), this default feature can be disabled, leaving the user to manually
+# select the right libOSCORE features.
+liboscore-defaults = ["liboscore-provide-abort", "liboscore-provide-assert"]
+
+## Feature passed on to libOSCORE (see `liboscore-defaults`)
+liboscore-provide-abort = ["liboscore/provide-abort"]
+## Feature passed on to libOSCORE (see `liboscore-defaults`)
+liboscore-provide-assert = ["liboscore/provide-assert"]
+
+default = ["liboscore-defaults"]
 
 # Private feature that enables doc_auto_cfg
 _nightly_docs = []

--- a/tests/coap-blinky/laze.yml
+++ b/tests/coap-blinky/laze.yml
@@ -10,8 +10,7 @@ apps:
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi
-      # no xtensa / riscv gcc on CI
-      - xtensa
+      # no riscv gcc on CI
       - riscv
     context:
       # list of contexts that have an entry in `pins.rs`

--- a/tests/coap-blinky/laze.yml
+++ b/tests/coap-blinky/laze.yml
@@ -10,8 +10,6 @@ apps:
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi
-      # no riscv gcc on CI
-      - riscv
     context:
       # list of contexts that have an entry in `pins.rs`
       - bbc-microbit-v2

--- a/tests/coap-blinky/laze.yml
+++ b/tests/coap-blinky/laze.yml
@@ -7,9 +7,6 @@ apps:
     selects:
       - coap-server
       - ?coap-server-config-demokeys
-    conflicts:
-      # see https://github.com/ariel-os/ariel-os/issues/418
-      - thumbv6m-none-eabi
     context:
       # list of contexts that have an entry in `pins.rs`
       - bbc-microbit-v2

--- a/tests/coap/laze.yml
+++ b/tests/coap/laze.yml
@@ -8,6 +8,3 @@ apps:
       - coap-server
       - ?coap-server-config-demokeys
       - coap-client
-    conflicts:
-      # see https://github.com/ariel-os/ariel-os/issues/418
-      - thumbv6m-none-eabi

--- a/tests/coap/laze.yml
+++ b/tests/coap/laze.yml
@@ -11,6 +11,5 @@ apps:
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi
-      # no xtensa / riscv gcc on CI
-      - xtensa
+      # no riscv gcc on CI
       - riscv

--- a/tests/coap/laze.yml
+++ b/tests/coap/laze.yml
@@ -11,5 +11,3 @@ apps:
     conflicts:
       # see https://github.com/ariel-os/ariel-os/issues/418
       - thumbv6m-none-eabi
-      # no riscv gcc on CI
-      - riscv


### PR DESCRIPTION
# Description

This combines #825, #824 and a commit that removes the blockers for the tests/examples and xtensa.

This will need a rebase when both dependencies are in.

## Open Questions

* <del>Will it blend?</del> It even loses the taste of stale workarounds and inaccessible platforms after blending.

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
