### PR TITLE
ci: disable ESP32 action's overrides

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           version: "1.84.0.0"
           buildtargets: esp32s3
+          override: false
 
       - name: Keep general build environment clean of Xtensa peculiarities
         if: steps.result-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,8 @@ jobs:
 
       - name: Install Rust for Xtensa
         if: steps.result-cache.outputs.cache-hit != 'true'
-        uses: esp-rs/xtensa-toolchain@v1.5
+        # for https://github.com/esp-rs/xtensa-toolchain/pull/36
+        uses: chrysn-pull-requests/xtensa-toolchain@libclang-path-override
         with:
           version: "1.84.0.0"
           buildtargets: esp32s3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
           version: "1.84.0.0"
           buildtargets: esp32s3
           override: false
+          export: false
 
       - name: Keep general build environment clean of Xtensa peculiarities
         if: steps.result-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
# Description

This brings what happens in CI closer to what happens on a host set up as per the book's instructions.

A second commit pulls in https://github.com/esp-rs/xtensa-toolchain/issues/35 to not only unset the cargo override but also to avoid messing with LLVM variables.

## Issues/PRs references

#824, #825 and #826 a related, but I'm trying to keep things testable independently.

## Open Questions

* I think there's a follow-up step that even needs to be done in here, where LIBCLANG_PATH is not exported in that step any more, and we use something #825-ish instead.

## Change checklist

- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
