### PR TITLE
docs: hide the `storage` Cargo feature from users

### DIFF
--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -33,7 +33,7 @@ default = ["ariel-os-rt/_panic-handler"]
 alloc = ["ariel-os-rt/alloc"]
 ## Enables GPIO interrupt support.
 external-interrupts = ["ariel-os-embassy/external-interrupts"]
-## Enables storage support.
+# Enables storage support.
 storage = ["dep:ariel-os-storage", "ariel-os-embassy/storage"]
 # Enables threading support, see the [`macro@thread`] attribute macro.
 threading = [


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The `sw/storage` laze module must be used instead, as documented in the book.
Could have been part of #737.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
