### PR TITLE
docs: fix broken links on internal items

### DIFF
--- a/src/ariel-os-storage/src/postcard_value.rs
+++ b/src/ariel-os-storage/src/postcard_value.rs
@@ -1,4 +1,4 @@
-//! A [`Storage`] value serialized using Postcard.
+//! A [`Storage`][crate::storage::Storage] value serialized using Postcard.
 use core::ops::Deref;
 
 use postcard::{from_bytes, to_slice};

--- a/src/lib/coapcore/src/error.rs
+++ b/src/lib/coapcore/src/error.rs
@@ -15,14 +15,15 @@ pub struct CredentialError {
 pub(crate) enum CredentialErrorDetail {
     /// Input data contains items that violate a protocol.
     ///
-    /// This is somewhat fuzzy towards [`UnsupportedExtension`] if extension points are not clearly
-    /// documented or understood in a protocol.
+    /// This is somewhat fuzzy towards
+    /// [`UnsupportedExtension`][CredentialErrorDetail::UnsupportedExtension] if extension points
+    /// are not clearly documented or understood in a protocol.
     ProtocolViolation,
     /// Input data contains items that are understood in principle, but not supported by the
     /// implementation.
     ///
-    /// In the fuzziness towards [`ProtocolViolation`], it is preferred to err on the side of
-    /// `UnsupportedExtension`.
+    /// In the fuzziness towards [`ProtocolViolation`][CredentialErrorDetail::ProtocolViolation],
+    /// it is preferred to err on the side of `UnsupportedExtension`.
     UnsupportedExtension,
     /// Input data uses a COSE algorithm that is not supported by the implementation.
     UnsupportedAlgorithm,


### PR DESCRIPTION
# Description

Trivial fixes of links that lit up red when building docs with `--document-private-items` in the hunt for "why is trait X implemented for Y".

## Testing

By doc building now passing

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.