### PR TITLE
chore: make CARGO_PRESHELL a list variable

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -8,7 +8,6 @@ contexts:
       CARGO:
         - ${CARGO_WRAPPER}
         - cargo
-      CARGO_PRESHELL: true &&
 
     tasks:
       info-modules:
@@ -59,6 +58,7 @@ contexts:
         -semihosting-config enable=on,target=native
         -kernel
       PROBE_RS_PROTOCOL: swd
+      CARGO_PRESHELL: []
 
     var_options:
       # this turns ${FEATURES} from a list to "--features=feature1,feature2"
@@ -67,6 +67,11 @@ contexts:
         joiner: ","
       LOG:
         joiner: ","
+      CARGO_PRESHELL:
+        # List of extra commands to be executed by the shell that runs cargo before cargo is run.
+        #
+        # This is typically used to source additional shell scripts that set up extra environment.
+        suffix: " && "
 
       # this prefixes `--protocol=` to `PROBE_RS_PROTOCOL`
       PROBE_RS_PROTOCOL:
@@ -496,7 +501,7 @@ modules:
           # Note that one \ escapes for YAML, the reaming \ escapes for laze,
           # and the second $ escapes for laze's internal ninja, resulting in
           # the shell to see just ${ESPUP_...
-          - . $\\${ESPUP_EXPORT_FILE:-~/export-esp.sh} &&
+          - . $\\${ESPUP_EXPORT_FILE:-~/export-esp.sh}
 
   - name: riscv
     env:


### PR DESCRIPTION
# Description

After #826, running `cargo … run` broke; #841 fixed that by introducing a fallback `true` in the position of CARGO_PRESHELL as a hot fix (aiming to restore functionality).

That #841 had open ToDos: cleanup, and finding out what exactly happened.

What happened was that when CARGO_PRESHELL is undefined, it is left for the shell to expand; strace gives:

```
[pid 3509585] execve("/usr/bin/sh", ["sh", "-x", "-c", "cd examples/blinky && ${CARGO_PRESHELL} OPENOCD_ARGS=\"-f board/"...], 0x7ffdfb8bce40 /* 55 vars */) = 0
```

This PR cleans up after that hot fix by
* documenting CARGO_PRESHELL
* making it into a list variable (with an empty list default and ` && ` suffix)

thus reducing the visual clutter of having `&& true` as part of every shell command. Scalability to multiple CARGO_PRESHELL commands is a convenient side effect.

## Testing

I can't run the ESP tests right now (probably due to an issue with my only board), I'd appreciate if a reviewer once build for, and once run on an ESP.

## Open Questions

* Unlike CARGO_WRAPPER (but like CARGO_ENV), CARGO_PRESHELL is explicitly part of the cargo invocations; should we unify on either side? (Also, they're spread over the default and ariel-os contexts).

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
