### PR TITLE
ci(build): restrict build runs based on PR labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,54 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL &
 
+      # Need to get two commits so we can get the PR's commit, not just the
+      # merge commit.
       - name: Check out repository code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      # Get the second parent of the merge commit created by the `checkout`
+      # action.
+      - name: "Get the commit ID of the pull request branch"
+        id: get-commit-id
+        shell: bash
+        run: echo "commit_id=$(git rev-parse HEAD^2)" >> $GITHUB_OUTPUT
+
+      # We use this instead of accessing the PR labels through the trigger event
+      # because that would not work for the merge queue.
+      - name: "Get PR build labels through the commit hash of the pull request"
+        id: get-pr-labels
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const commitId = "${{ steps.get-commit-id.outputs.commit_id }}";
+            console.log(`Commit ID: ${commitId}`);
+            const { data: { items } } = await github.rest.search.issuesAndPullRequests({
+              q: `${commitId} type:pr`,
+            });
+            console.log(`Number of PRs containing commit ${commitId}: ${items.length}`);
+            // Find a PR where that commit is the tip of the PR's branch.
+            // Would be incorrect if multiple PRs are open for exactly the same commit.
+            for (const pr of items) {
+              const prNumber = pr.number;
+              const { data: commits } = await github.rest.pulls.listCommits({ owner: 'ariel-os', repo: 'ariel-os', pull_number: prNumber });
+              const tipCommitId = commits[commits.length - 1].sha;
+              if (tipCommitId != commitId) {
+                console.log(`Wrong PR: tip is ${tipCommitId}`);
+                continue;
+              }
+              const prLabels = pr.labels.map((label) => label.name);
+              console.log(`The labels of PR #${prNumber} are ${prLabels}`);
+              const VALID_LABELS = ['ci-build:skip', 'ci-build:small'];
+              const buildLabels = prLabels.filter((label) => VALID_LABELS.includes(label));
+              if (buildLabels.length > 1) { throw 'Only one build label must be attached.'; }
+              const buildLabel = buildLabels[0];
+              if (!buildLabel) { throw 'A build label must be attached'; }
+              console.log(`The build label is ${buildLabel}`);
+              return buildLabel;
+            }
 
       - name: Get git tree hash
         id: get-tree-hash
@@ -54,6 +100,13 @@ jobs:
         with:
           path: .tree-hash
           key: success-${{ steps.get-tree-hash.outputs.hash }}-${{ matrix.partition }}-${{ github.event_name == 'schedule' && 'full' || 'limited' }}
+
+      - name: Whether to skip next steps
+        id: should-skip
+        run: |
+          result="result=${{ steps.result-cache.outputs.cache-hit == 'true' || steps.get-pr-labels.outputs.result == 'ci-build:skip' }}"
+          echo "${result}"
+          echo "${result}" >> $GITHUB_OUTPUT
 
       - name: Run sccache-cache
         if: steps.result-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The initial goal of this was to require specific labels on PR that would allow us to specify whether to run the `Build` CI workflow, and if so, for which set of boards.
Now, the goal is simply to make the Build workflow fail quickly if no `ci-build:*` label is attached, and to collect information which would help us actually deploy the initial idea later, with minimal breakage.

This is intended to support the following scenarios when running for PRs:

- No `ci-build:*` labels: fail job
- `ci-build:small`: build with restricted build set
- ~`ci-build:large`: build with full build set (at least for now)~ (removed from this initial PR)
- ~`ci-build:skip`: skip building~ (removed from this initial PR)
- Two or more `ci-build:*` labels: fail job

**Runs for the merge queue and on main must take these labels into account as well.**

## Future work

- We may want to introduce other kinds of build labels, to target specific MCU subfamilies as well (e.g., `ci-build:stm32f4`).
- We could consider some forms of auto-labeling, e.g., attaching `ci-build:skip` if only the book is changed by a PR.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Supersedes #581.

## Open Questions

<!-- Unresolved questions, if any. -->
- ~This looks up the top commit ID of the PR in an attempt to find "its" PR; however multiple PRs could contain that commit (in case of stacked PRs).~ This should now be addressed, it could now only fail to find the proper PR if multiple PRs were opened for *exactly the same commit id*, which should never happen anyway.
- We may want to introduce more "T-shirt sizes" for build sets later (e.g., `ci-build:medium`, `ci-build:xxlarge`); should the current `ci-build:small` be set in stone now? If we change the definition of labels later, this may look slightly misleading when looking back on PRs later.  

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
