### PR TITLE
ci: split lint steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -221,8 +221,23 @@ jobs:
             --
             --deny warnings
 
-      # Reset `RUSTFLAGS`
-      - run: echo 'RUSTFLAGS=' >> $GITHUB_ENV
+  lint-rustdoc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - id: get_toolchain
+        run: echo "toolchain=$(scripts/rust-toolchain.sh)" >> $GITHUB_OUTPUT
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.get_toolchain.outputs.toolchain }}
+
+      - name: rust cache
+        uses: Swatinem/rust-cache@v2
 
       - name: rustdoc
         run: |
@@ -307,14 +322,35 @@ jobs:
                     " \
                 -p ariel-os-stm32
 
+  lint-rustfmt:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
       - name: rustfmt
         run: cargo fmt --check --all
+
+  lint-yamllint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
 
       - name: yamllint
         uses: karancode/yamllint-github-action@master
         with:
           yamllint_comment: true # Insert inline PR comments
           yamllint_strict: true # Set error code on warnings
+
+  lint-taplo:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
 
       - name: Install taplo
         uses: taiki-e/install-action@v2
@@ -324,10 +360,24 @@ jobs:
       - name: Check toml formatting
         run: taplo fmt --check
 
+  lint-ruff:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
       - name: Ruff
         uses: chartboost/ruff-action@v1
         with:
           args: format --check # Only check formatting for now
+
+  lint-spell:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
 
       - name: typos
         uses: crate-ci/typos@v1


### PR DESCRIPTION
# Description

Even easy PRs regularly send me to many context switches because first there is something cargo-doc complains about, I fix that, force push because otherwise the squash checks show up read, then that passes and something is not perfectly rustformatted because I applied something from a suggestion, again a few minutes later taplo is unhappy with a line not being wrapped, and eventually things stall again over a typo.

This moves most checks into parallel tasks, that don't just run in parallel, but more importantly should also all run to completion even when one of them fails (which previously stopped the later steps).

## Open Questions

* Did I catch all running prerequisites?
* Did I miss any "cancel this bunch any fails" configuration?

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.
