### PR TITLE
refactor(laze): invert how capabilities are provided

### DIFF
--- a/examples/benchmark/laze.yml
+++ b/examples/benchmark/laze.yml
@@ -1,5 +1,5 @@
 apps:
   - name: example-benchmark
     selects:
-      - sw/benchmark
       - sw/threading
+      - sw/benchmark

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -194,6 +194,8 @@ contexts:
 
   - name: nrf52
     parent: nrf
+    provides:
+      - has_storage_support
     env:
       CARGO_RUNNER:
         - ${SCRIPTS}/debug-openocd.sh
@@ -226,6 +228,8 @@ contexts:
 
   - name: nrf5340
     parent: nrf53
+    provides:
+      - has_storage_support
     selects:
       - cortex-m33f
     env:
@@ -244,6 +248,8 @@ contexts:
       - rp-link-arg
       - cortex-m0-plus
       - ?probe-rs
+    provides:
+      - has_storage_support
     env:
       PROBE_RS_CHIP: RP2040
       CARGO_RUNNER:
@@ -260,6 +266,8 @@ contexts:
     selects:
       - cortex-m33f
       - ?probe-rs
+    provides:
+      - has_storage_support
     env:
       PROBE_RS_CHIP: RP235x
       CARGO_RUNNER:
@@ -389,6 +397,7 @@ contexts:
       # TODO: also has a cortex-m4f
       - cortex-m7f
     provides:
+      - has_storage_support
       - has_swi
     env:
       PROBE_RS_CHIP: STM32H755ZITx
@@ -406,6 +415,7 @@ contexts:
     selects:
       - cortex-m4f
     provides:
+      - has_storage_support
       - has_swi
     env:
       PROBE_RS_CHIP: STM32WB55RGVx
@@ -828,19 +838,18 @@ modules:
           - ariel-os/network-config-static
 
   - name: sw/storage
-    context:
-      - rp2040
-      - rp235xa
-      - nrf52840
-      - nrf5340
-      - stm32h755zitx
-      - stm32wb55rgvx
+    selects:
+      - has_storage_support
     env:
       global:
         FEATURES:
           - ariel-os/storage
         RUSTFLAGS:
           - -Clink-arg=-Tstorage.x
+
+  - name: has_storage_support
+    selects:
+      - doc-only
 
   - name: sw/threading
     selects:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -876,14 +876,18 @@ modules:
           - ariel-os/threading
 
   - name: wifi-cyw43
-    context:
-      - rpi-pico-w
+    selects:
+      - has_wifi_cyw43
     provides_unique:
       - network_device
     env:
       global:
         FEATURES:
           - ariel-os/wifi-cyw43
+
+  - name: has_wifi_cyw43
+    selects:
+      - doc-only
 
   - name: usb-ethernet
     provides_unique:
@@ -1359,6 +1363,7 @@ builders:
     parent: rpi-pico
     provides:
       - has_usb_device_port
+      - has_wifi_cyw43
 
   - name: rpi-pico2
     parent: rp235xa

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -883,20 +883,16 @@ modules:
 
   - name: hw/usb-device-port
     help: provided if a device has a USB device port wired up
-    context:
-      - espressif-esp32-s3-devkitc-1
-      - nrf5340dk
-      - nrf52840dk
-      - rpi-pico
-      - rpi-pico-w
-      - rpi-pico2
-      - particle-xenon
-      - st-nucleo-h755zi-q
-      - st-nucleo-wb55
+    selects:
+      - has_usb_device_port
     env:
       global:
         RUSTFLAGS:
           - --cfg capability=\"hw/usb-device-port\"
+
+  - name: has_usb_device_port
+    selects:
+      - doc-only
 
   - name: hw/device-identity
     help: provided if the device implements ariel-os-identity
@@ -1286,6 +1282,8 @@ builders:
 
   - name: nrf52840dk
     parent: nrf52840
+    provides:
+      - has_usb_device_port
 
   - name: dwm1001
     parent: nrf52832
@@ -1324,15 +1322,23 @@ builders:
 
   - name: particle-xenon
     parent: nrf52840
+    provides:
+      - has_usb_device_port
 
   - name: rpi-pico
     parent: rp2040
+    provides:
+      - has_usb_device_port
 
   - name: rpi-pico-w
     parent: rpi-pico
+    provides:
+      - has_usb_device_port
 
   - name: rpi-pico2
     parent: rp235xa
+    provides:
+      - has_usb_device_port
 
   - name: ai-c3
     parent: esp-c3-01m
@@ -1345,9 +1351,13 @@ builders:
 
   - name: espressif-esp32-s3-devkitc-1
     parent: esp32-s3-wroom-1
+    provides:
+      - has_usb_device_port
 
   - name: nrf5340dk
     parent: nrf5340
+    provides:
+      - has_usb_device_port
 
   - name: st-nucleo-c031c6
     parent: stm32c031c6tx
@@ -1357,9 +1367,13 @@ builders:
 
   - name: st-nucleo-h755zi-q
     parent: stm32h755zitx
+    provides:
+      - has_usb_device_port
 
   - name: st-nucleo-wb55
     parent: stm32wb55rgvx
+    provides:
+      - has_usb_device_port
 
   - name: st-nucleo-wba55
     parent: stm32wba55cgux

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -175,6 +175,7 @@ contexts:
     selects:
       - ?probe-rs
     provides:
+      - has_device_identity
       - has_swi
 
   - name: nrf51
@@ -355,6 +356,8 @@ contexts:
     parent: ariel-os
     selects:
       - ?probe-rs
+    provides:
+      - has_device_identity
     env:
       OPENOCD_ARGS: foo
 
@@ -905,13 +908,16 @@ modules:
 
   - name: hw/device-identity
     help: provided if the device implements ariel-os-identity
-    context:
-      - nrf
-      - stm32
+    selects:
+      - has_device_identity
     env:
       global:
         RUSTFLAGS:
           - --cfg capability=\"hw/device-identity\"
+
+  - name: has_device_identity
+    selects:
+      - doc-only
 
   - name: hwrng
     help: The board's peripherals are suitable for passing into ariel_os_random::construct_rng.

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -254,6 +254,7 @@ contexts:
       - cortex-m0-plus
       - ?probe-rs
     provides:
+      - has_multi_core_support
       - has_storage_support
     env:
       PROBE_RS_CHIP: RP2040
@@ -272,6 +273,7 @@ contexts:
       - cortex-m33f
       - ?probe-rs
     provides:
+      - has_multi_core_support
       - has_storage_support
     env:
       PROBE_RS_CHIP: RP235x
@@ -345,6 +347,8 @@ contexts:
     parent: esp
     selects:
       - xtensa
+    provides:
+      - has_multi_core_support
     provides_unique: [c-function-abort]
     env:
       CARGO_TOOLCHAIN: +esp
@@ -1155,16 +1159,18 @@ modules:
 
   - name: multi-core
     help: usage platform as multi-core system
-    context:
-      - rp2040
-      - rp235xa
-      - esp32s3
+    selects:
+      - has_multi_core_support
     provides_unique:
       - critical-section
     env:
       global:
         FEATURES:
           - ariel-os/multi-core
+
+  - name: has_multi_core_support
+    selects:
+      - doc-only
 
   - name: rtt-target
     help: use rtt-target in ariel-os-debug

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -292,6 +292,7 @@ contexts:
       - ?debug-console
       - ?esp-println
     provides:
+      - has_executor_single_thread_support
       - has_hwrng
     env:
       RUSTFLAGS:
@@ -1117,8 +1118,8 @@ modules:
 
   - name: executor-single-thread
     help: use Embassy executor within single "thread mode" thread
-    context:
-      - esp
+    selects:
+      - has_executor_single_thread_support
     provides_unique:
       - executor
     conflicts:
@@ -1127,6 +1128,10 @@ modules:
       global:
         FEATURES:
           - ariel-os/executor-single-thread
+
+  - name: has_executor_single_thread_support
+    selects:
+      - doc-only
 
   # Enabled for MCU families that provide a dedicated software interrupt (SWI),
   # and thus do not require to sacrifice another, arbitrarily-chosen peripheral

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -177,6 +177,7 @@ contexts:
     provides:
       - has_device_identity
       - has_swi
+      - sw/benchmark
 
   - name: nrf51
     parent: nrf
@@ -245,6 +246,7 @@ contexts:
     provides:
       - has_hwrng
       - has_swi
+      - sw/benchmark
 
   - name: rp2040
     parent: rp
@@ -320,6 +322,8 @@ contexts:
     parent: esp
     selects:
       - riscv
+    provides:
+      - sw/benchmark
     provides_unique: [c-function-abort]
     env:
       RUSTC_TARGET: riscv32imc-unknown-none-elf
@@ -334,6 +338,8 @@ contexts:
     parent: esp
     selects:
       - riscv
+    provides:
+      - sw/benchmark
     provides_unique: [c-function-abort]
     env:
       RUSTC_TARGET: riscv32imac-unknown-none-elf
@@ -350,6 +356,7 @@ contexts:
       - xtensa
     provides:
       - has_multi_core_support
+      - sw/benchmark
     provides_unique: [c-function-abort]
     env:
       CARGO_TOOLCHAIN: +esp
@@ -369,6 +376,7 @@ contexts:
       - ?probe-rs
     provides:
       - has_device_identity
+      - sw/benchmark
     env:
       OPENOCD_ARGS: foo
 
@@ -1074,19 +1082,8 @@ modules:
 
   - name: sw/benchmark
     help: provided if a target supports `benchmark()`
-    context:
-      # The Cortex-M implementation is using Systick.
-      - nrf
-      - rp
-      - stm32
-      # The esp32 implementation is using systimer.
-      - esp32c3
-      - esp32c6
-      - esp32s3
-      # These esp32 also have a systimer, uncomment when support is added.
-      # - esp32c2
-      # - esp32h2
-      # - esp32s2
+    selects:
+      - doc-only
 
   - name: wifi-esp
     selects:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -182,6 +182,8 @@ contexts:
     parent: nrf
     selects:
       - cortex-m0
+    provides:
+      - has_hwrng
 
   - name: bbc-microbit-base
     # this is a context, not a builder, to be used as parent by  "bbc-microbit" and
@@ -196,6 +198,7 @@ contexts:
   - name: nrf52
     parent: nrf
     provides:
+      - has_hwrng
       - has_storage_support
     env:
       CARGO_RUNNER:
@@ -240,6 +243,7 @@ contexts:
     help: Raspberry Pi Pico (2) MCU support (based on embassy-rp)
     parent: ariel-os
     provides:
+      - has_hwrng
       - has_swi
 
   - name: rp2040
@@ -285,6 +289,8 @@ contexts:
     selects:
       - ?debug-console
       - ?esp-println
+    provides:
+      - has_hwrng
     env:
       RUSTFLAGS:
         # linkall first
@@ -400,6 +406,7 @@ contexts:
       # TODO: also has a cortex-m4f
       - cortex-m7f
     provides:
+      - has_hwrng
       - has_storage_support
       - has_swi
     env:
@@ -418,6 +425,7 @@ contexts:
     selects:
       - cortex-m4f
     provides:
+      - has_hwrng
       - has_storage_support
       - has_swi
     env:
@@ -435,6 +443,7 @@ contexts:
     selects:
       - cortex-m33f
     provides:
+      - has_hwrng
       - has_swi
     env:
       PROBE_RS_CHIP: STM32WBA55CGUx
@@ -921,21 +930,16 @@ modules:
 
   - name: hwrng
     help: The board's peripherals are suitable for passing into ariel_os_random::construct_rng.
-    context:
-      # these are precisely those for which the hwrng feature of
-      # ariel-os-embassy builds, which would fail if the big if(context=...)
-      # doesn't have an entry in the cfg(feature = "hwrng") part of init_task
-      - esp
-      - nrf51
-      - nrf52
-      - rp
-      - stm32h755zitx
-      - stm32wb55rgvx
-      - stm32wba55cgux
+    selects:
+      - has_hwrng
     env:
       global:
         FEATURES:
           - ariel-os/hwrng
+
+  - name: has_hwrng
+    selects:
+      - doc-only
 
   - name: coap
     help: Basic support for the CoAP protocol.

--- a/tests/benchmarks/bench_sched_flags/laze.yml
+++ b/tests/benchmarks/bench_sched_flags/laze.yml
@@ -1,5 +1,5 @@
 apps:
   - name: bench_sched_flags
     selects:
-      - sw/benchmark
       - sw/threading
+      - sw/benchmark

--- a/tests/benchmarks/bench_sched_yield/laze.yml
+++ b/tests/benchmarks/bench_sched_yield/laze.yml
@@ -1,5 +1,5 @@
 apps:
   - name: bench_sched_yield
     selects:
-      - sw/benchmark
       - sw/threading
+      - sw/benchmark


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Right now, each capability declares the list of contexts (i.e., MCUs, boards) on which it is provided. However, this means that adding support for new MCUs/boards involves modifying the existing definitions of these capabilities, which wouldn't work for out-of-tree board definitions, which we want to support.
This PR therefore instead makes each MCU/board context list the capabilities it provides, instead of the other way around.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
This is also related to #640.
Depends on #838.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
