### PR TITLE
chore: update minicbor to move off fork branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "ariel-os-embassy-common",
  "ariel-os-random",
  "ariel-os-rt",
+ "ariel-os-threads",
  "ariel-os-utils",
  "cfg-if",
  "defmt",
@@ -286,6 +287,7 @@ dependencies = [
  "esp-hal",
  "esp-hal-embassy",
  "esp-wifi",
+ "esp-wifi-sys",
  "fugit",
  "once_cell",
  "paste",
@@ -1084,7 +1086,7 @@ dependencies = [
  "lakers-crypto-rustcrypto",
  "liboscore",
  "log",
- "minicbor 0.25.1",
+ "minicbor 0.26.0",
  "minicbor-adapters",
  "p256",
  "rand_core",
@@ -2161,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "esp-alloc"
 version = "0.6.0"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os#6569d3a6c6b78c5d66b639f03c7d7558cb69255c"
+source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -2173,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "esp-build"
 version = "0.2.0"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os#6569d3a6c6b78c5d66b639f03c7d7558cb69255c"
+source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"
 dependencies = [
  "quote",
  "syn 2.0.96",
@@ -2183,7 +2185,7 @@ dependencies = [
 [[package]]
 name = "esp-config"
 version = "0.3.0"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os#6569d3a6c6b78c5d66b639f03c7d7558cb69255c"
+source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"
 dependencies = [
  "document-features",
 ]
@@ -2191,7 +2193,7 @@ dependencies = [
 [[package]]
 name = "esp-hal"
 version = "0.23.1"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os#6569d3a6c6b78c5d66b639f03c7d7558cb69255c"
+source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"
 dependencies = [
  "basic-toml",
  "bitfield 0.17.0",
@@ -2232,6 +2234,7 @@ dependencies = [
  "instability",
  "log",
  "nb 1.1.0",
+ "optfield",
  "paste",
  "portable-atomic",
  "rand_core",
@@ -2248,7 +2251,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-embassy"
 version = "0.6.0"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os#6569d3a6c6b78c5d66b639f03c7d7558cb69255c"
+source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"
 dependencies = [
  "critical-section",
  "document-features",
@@ -2270,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.16.0"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os#6569d3a6c6b78c5d66b639f03c7d7558cb69255c"
+source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"
 dependencies = [
  "darling",
  "document-features",
@@ -2286,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "esp-metadata"
 version = "0.5.0"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os#6569d3a6c6b78c5d66b639f03c7d7558cb69255c"
+source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"
 dependencies = [
  "anyhow",
  "basic-toml",
@@ -2297,7 +2300,7 @@ dependencies = [
 [[package]]
 name = "esp-println"
 version = "0.13.0"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os#6569d3a6c6b78c5d66b639f03c7d7558cb69255c"
+source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"
 dependencies = [
  "critical-section",
  "defmt",
@@ -2309,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "esp-riscv-rt"
 version = "0.9.1"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os#6569d3a6c6b78c5d66b639f03c7d7558cb69255c"
+source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"
 dependencies = [
  "document-features",
  "riscv",
@@ -2332,7 +2335,7 @@ dependencies = [
 [[package]]
 name = "esp-wifi"
 version = "0.12.0"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os#6569d3a6c6b78c5d66b639f03c7d7558cb69255c"
+source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"
 dependencies = [
  "bt-hci",
  "cfg-if",
@@ -3536,26 +3539,27 @@ version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29be4f60e41fde478b36998b88821946aafac540e53591e76db53921a0cc225b"
 dependencies = [
- "minicbor-derive 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "minicbor-derive 0.15.3",
 ]
 
 [[package]]
 name = "minicbor"
-version = "0.25.1"
-source = "git+https://github.com/chrysn-pull-requests/minicbor?branch=negativ-indices#83946a374f54c59923bb6340d83e893294495aad"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661deac75bd438730c7335469ea8aee72a607e2bc93282386ef765b4ea7cdc0"
 dependencies = [
- "minicbor-derive 0.15.3 (git+https://github.com/chrysn-pull-requests/minicbor?branch=negativ-indices)",
+ "minicbor-derive 0.16.0",
 ]
 
 [[package]]
 name = "minicbor-adapters"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d622b25f962a1d24f2ec19702fa9ad3b13f494e100c15fa29aa14312b68280e"
+checksum = "548808f4038a8f55c06ee593d5732b0132459e719a6bbffc0db9c93101c56e7a"
 dependencies = [
  "cboritem",
  "heapless 0.8.0",
- "minicbor 0.25.1",
+ "minicbor 0.26.0",
 ]
 
 [[package]]
@@ -3571,8 +3575,9 @@ dependencies = [
 
 [[package]]
 name = "minicbor-derive"
-version = "0.15.3"
-source = "git+https://github.com/chrysn-pull-requests/minicbor?branch=negativ-indices#83946a374f54c59923bb6340d83e893294495aad"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1164934feccd1ca0b67754a8656c409ec80c5888bcbdb6a7ccd2e43722d819c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5758,7 +5763,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 [[package]]
 name = "xtensa-lx"
 version = "0.10.0"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os#6569d3a6c6b78c5d66b639f03c7d7558cb69255c"
+source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"
 dependencies = [
  "critical-section",
  "document-features",
@@ -5767,7 +5772,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt"
 version = "0.18.0"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os#6569d3a6c6b78c5d66b639f03c7d7558cb69255c"
+source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"
 dependencies = [
  "anyhow",
  "document-features",
@@ -5784,7 +5789,7 @@ dependencies = [
 [[package]]
 name = "xtensa-lx-rt-proc-macros"
 version = "0.2.2"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os#6569d3a6c6b78c5d66b639f03c7d7558cb69255c"
+source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5889,4 +5894,4 @@ dependencies = [
 [[patch.unused]]
 name = "esp-storage"
 version = "0.4.0"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os#6569d3a6c6b78c5d66b639f03c7d7558cb69255c"
+source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"

--- a/_typos.toml
+++ b/_typos.toml
@@ -5,8 +5,6 @@ extint = "extint"     # External interrupt
 synopsys = "synopsys" # Manufacturer name
 COSE = "COSE"         # A technology we use
 
-negativ = "negativ" # Typo in a branch name in ariel-os-cargo.toml
-
 [files]
 extend-exclude = [
   "book/src/*.svg",

--- a/ariel-os-cargo.toml
+++ b/ariel-os-cargo.toml
@@ -39,6 +39,3 @@ try-lock = { git = "https://github.com/seanmonstar/try-lock", rev = "a1aadfac984
 
 # added Ariel OS support
 embedded-test = { git = "https://github.com/ariel-os/embedded-test", branch = "v0.6.0+ariel-os" }
-
-# see src/lib/coapcore/Cargo.toml: Support for negative integers <https://github.com/twittner/minicbor/pull/9>
-minicbor = { git = "https://github.com/chrysn-pull-requests/minicbor", branch = "negativ-indices" }

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -28,14 +28,8 @@ coap-numbers = "0.2.3"
 lakers-crypto-rustcrypto = "0.7.2"
 liboscore = { version = "0.2.4", default-features = false }
 
-# actually we depend on <https://github.com/twittner/minicbor/pull/9> so it
-# should be
-#     minicbor = { git = "https://github.com/chrysn-pull-requests/minicbor", branch = "negativ-indices", features = ["derive"] }
-# and it could be patched locally because it is a non-pub dependency, but as
-# minicbor-adapters needs to use the same types, this still has to go into
-# patch.crates-io to also catch minicbor-adapters.
-minicbor = { version = "0.25.1", features = ["derive"] }
-minicbor-adapters = "0.0.3"
+minicbor = { version = "0.26.0", features = ["derive"] }
+minicbor-adapters = "0.0.4"
 heapless = "0.8.0"
 defmt-or-log = { version = "0.2.1", default-features = false }
 defmt = { workspace = true, optional = true }


### PR DESCRIPTION
# Description

We depended on a branch which I had on minicbor.

This reduces the number of patch.crates-io lines, and allows me to delete the branch in the upstream repo.

Also, this allows me to finally get that typo out of our system again.

As a downside, this probably increases the number of minicbor versions, but that's not addressed by not doing this, but by updating dependencies elsewhere.

## Issues/PRs references

Applies https://github.com/twittner/minicbor/pull/9

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
