### PR TITLE
refactor(identity): depend on `ariel-os-hal` directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,8 +318,8 @@ version = "0.1.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
- "ariel-os-embassy",
  "ariel-os-embassy-common",
+ "ariel-os-hal",
  "embedded-test",
 ]
 

--- a/src/ariel-os-identity/Cargo.toml
+++ b/src/ariel-os-identity/Cargo.toml
@@ -12,8 +12,8 @@ harness = false
 workspace = true
 
 [dependencies]
-ariel-os-embassy = { workspace = true }
 ariel-os-embassy-common = { workspace = true }
+ariel-os-hal = { workspace = true }
 
 [target.'cfg(context = "ariel-os")'.dev-dependencies]
 ariel-os = { path = "../../src/ariel-os" }
@@ -22,4 +22,4 @@ ariel-os-boards = { path = "../../src/ariel-os-boards" }
 embedded-test = { workspace = true }
 
 [features]
-_test = ["ariel-os-embassy/executor-none"]
+_test = []

--- a/src/ariel-os-identity/src/lib.rs
+++ b/src/ariel-os-identity/src/lib.rs
@@ -47,7 +47,7 @@ pub use ariel_os_embassy_common::identity::Eui48;
 pub fn device_id_bytes() -> Result<impl AsRef<[u8]>, impl core::error::Error> {
     use ariel_os_embassy_common::identity::DeviceId;
 
-    ariel_os_embassy::hal::identity::DeviceId::get().map(|d| d.bytes())
+    ariel_os_hal::identity::DeviceId::get().map(|d| d.bytes())
 }
 
 /// Generates an EUI-48 identifier ("6-byte MAC address") based on the device identity.
@@ -75,7 +75,7 @@ pub fn device_id_bytes() -> Result<impl AsRef<[u8]>, impl core::error::Error> {
 pub fn interface_eui48(if_index: u32) -> Result<Eui48, impl core::error::Error> {
     use ariel_os_embassy_common::identity::DeviceId;
 
-    ariel_os_embassy::hal::identity::DeviceId::get().map(|d| d.interface_eui48(if_index))
+    ariel_os_hal::identity::DeviceId::get().map(|d| d.interface_eui48(if_index))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This makes `ariel-os-identity` depend on `ariel-os-hal` directly instead of depending on `ariel-os-embassy`. This avoids future cyclic dependencies.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
