### PR TITLE
feat(build): make use of `workdir` in laze files

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1,4 +1,4 @@
-laze_required_version: 0.1.31
+laze_required_version: 0.1.33
 
 contexts:
   # base context that all other contexts inherit from
@@ -97,23 +97,27 @@ contexts:
           - ${CARGO_PRESHELL} ${CARGO_ENV}
 
       cargo:
+        workdir: ${relpath}
         cmd:
-          - cd ${relpath} && ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS}
+          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS}
         build: false
 
       run:
         build: false
+        workdir: ${appdir}
         cmd:
-          - cd ${appdir} && ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --${PROFILE} ${FEATURES}
+          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --${PROFILE} ${FEATURES}
 
       clippy:
         build: false
+        workdir: ${appdir}
         cmd:
-          - cd ${appdir} && ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} clippy ${FEATURES}
+          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} clippy ${FEATURES}
 
       debug:
+        workdir: ${appdir}
         cmd:
-          - cd ${appdir} && ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --${PROFILE} ${FEATURES}
+          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --${PROFILE} ${FEATURES}
         build: false
         ignore_ctrl_c: true
 
@@ -124,13 +128,15 @@ contexts:
         ignore_ctrl_c: true
 
       bloat:
+        workdir: ${appdir}
         cmd:
-          - cd ${appdir} && ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} bloat --${PROFILE} ${FEATURES}
+          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} bloat --${PROFILE} ${FEATURES}
         build: false
 
       tree:
+        workdir: ${appdir}
         cmd:
-          - cd ${appdir} && ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} tree ${FEATURES}
+          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} tree ${FEATURES}
         build: false
 
       size:
@@ -1107,8 +1113,9 @@ modules:
           - RUSTFLAGS
           - RUSTDOCFLAGS
         build: false
+        workdir: ${appdir}
         cmd:
-          - cd ${appdir} && ${CARGO} test --features _test
+          - ${CARGO} test --features _test
 
   - name: embedded-test
     context: ariel-os


### PR DESCRIPTION
# Description

laze v0.1.33 just dropped, with a new way to change working directory for tasks. no more `cd ${appdir} && ...`.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
