### PR TITLE
fix(dep): bump `linkme` to 0.3.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ esp-wifi-sys = { version = "0.7.1", default-features = false }
 esp-storage = { version = "0.4.0" }
 xtensa-lx-rt = { version = "0.18.0", default-features = false }
 
-linkme = { version = "0.3.21", features = ["used_linker"] }
+linkme = { version = "0.3.31", features = ["used_linker"] }
 
 ariel-os = { path = "src/ariel-os", default-features = false }
 ariel-os-alloc = { path = "src/ariel-os-alloc", default-features = false }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Fixes a soundness bug and adds support for Rust edition 2024.
[Changelog](https://github.com/dtolnay/linkme/releases#:~:text=0.3.31)
The lockfile has no changes as it was already using the newest version.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
