### PR TITLE
fix(coap): simplify examples

### DIFF
--- a/examples/coap-server/src/main.rs
+++ b/examples/coap-server/src/main.rs
@@ -11,8 +11,7 @@ async fn coap_run() {
 
     let handler = new_dispatcher()
         // We offer a single resource: /hello, which responds just with a text string.
-        .at(&["hello"], SimpleRendered("Hello from Ariel OS"))
-        .with_wkc();
+        .at(&["hello"], SimpleRendered("Hello from Ariel OS"));
 
     ariel_os::coap::coap_run(handler).await;
 }

--- a/tests/coap-blinky/src/main.rs
+++ b/tests/coap-blinky/src/main.rs
@@ -23,8 +23,7 @@ async fn coap_run(peripherals: pins::LedPeripherals) {
         .at(
             &["led"],
             riot_coap_handler_demos::gpio::handler_for_output(led),
-        )
-        .with_wkc();
+        );
 
     ariel_os::coap::coap_run(handler).await;
 }


### PR DESCRIPTION
# Description

Just a small simplification: The .well-known/core resource (created by `.with_wkc()`) is already provided by ariel-os-coap, no need to do that in the example.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
