### PR TITLE
docs: exclude `doc/` from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ members = [
   "tests/threading-mutex",
 ]
 
-exclude = ["src/lib"]
+exclude = ["src/lib", "doc"]
 
 default-members = ["examples/hello-world"]
 resolver = "2"


### PR DESCRIPTION
# Description

Something must have changed, but the cargo script that generates our support matrix suddenly thought it is part of the workspace.
cargo suggests either adding an empty `[workspace]` to the offending crate's manifest, or add its folder to the main workspace' `exclude`. The former doesn't work for "embedded manifests", so this PR implements the second.

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

Fixes #866.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
