### PR TITLE
ci(support-matrix): check the generation exit code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -332,6 +332,9 @@ jobs:
       - name: typos
         uses: crate-ci/typos@v1.22.0
 
+      - name: Check the support matrix generation exit code
+        run: ./doc/gen_support_matrix_html.rs generate doc/support_matrix.yml /dev/null
+
       - name: Install mdbook and mdbook utils
         uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The `mdbook-cmdrun` preprocessor, which is used to render the table in the book, cannot make the mdbook run fail in case of non-zero exit code, so we check this separately in the lint step.
[Relevant issue on `mdbook-cmdrun`](https://github.com/FauconFan/mdbook-cmdrun/issues/18)

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
This is why the need for #867 wasn't detected as part of #861.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
