### PR TITLE
docs(networking): document the previously missing `network` laze module

### DIFF
--- a/book/src/networking.md
+++ b/book/src/networking.md
@@ -1,19 +1,22 @@
 # Networking
 
+## Enabling Networking
+
+Networking is enabled by selecting the `network` [laze module][laze-modules-book].
+When enabled, a network link is automatically selected among the ones available on the target board, currently preferring Wi-Fi networking.
+Overriding this default selection is possible by explicitly selecting the desired [network link module](#network-link-selection).
+
 ## Network Link Selection
 
 Ariel OS currently supports two different networking links: Ethernet-over-USB (aka CDC-NCM) and Wi-Fi.
 Boards may support both of them, only one of them, or none of them. However, currently the network stack supports at most one interface.
 
-Which link layer is used for networking must be selected at compile time,
-through [laze modules](./build_system.md#laze-modules):
+Which link layer is used for networking is selected at compile time,
+through [laze modules][laze-modules-book].
 
 - `usb-ethernet`: Selects Ethernet-over-USB.
 - `wifi-cyw43`: Selects Wi-Fi using the CYW43 chip along an RP2040 MCU (e.g., on the Raspberry Pi Pico W).
 - `wifi-esp`: Selects Wi-Fi on an ESP32 MCU.
-
-When available on the device, one of these module is always selected by default, currently preferring Wi-Fi networking.
-Overriding this default selection is possible by explicitly [selecting the desired module][laze-modules-book].
 
 ## Network Credentials
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Documentation for the main laze module was missing from #677.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
