### PR TITLE
fix(coap): use correct default peers.yml path

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -868,9 +868,12 @@ modules:
       global:
         FEATURES:
           - ariel-os/coap-server-config-storage
-        PEERS_YML: ${appdir}/peers.yml
+        # Path is relative to the appdir from which CARGO_ENV will be interpreted
+        PEERS_YML: peers.yml
         CARGO_ENV:
-          - PEERS_YML=${PEERS_YML}
+          # By the time a build script sees this, Cargo has chdir'd into *its*
+          # source, so we better pass an absolute path.
+          - PEERS_YML=$$(realpath ${PEERS_YML})
 
   - name: coap-server-config-unprotected
     help: Configure the CoAP server to accept any request without authorization checks.

--- a/src/ariel-os-coap/build.rs
+++ b/src/ariel-os-coap/build.rs
@@ -64,8 +64,16 @@ fn main() {
     let peers_yml = std::path::PathBuf::from(std::env::var("PEERS_YML").unwrap());
 
     build::rerun_if_changed(&peers_yml);
-    let peers_file =
-        std::fs::File::open(peers_yml).expect("no peers.yml usable in specified location");
+    let peers_file = std::fs::File::open(&peers_yml)
+        .map_err(|e| {
+            format!(
+                "{} while opening {} inside {}",
+                e,
+                peers_yml.display(),
+                std::env::current_dir().unwrap().display()
+            )
+        })
+        .expect("no peers.yml usable in specified location");
 
     let peers: Vec<Peer> = serde_yml::from_reader(peers_file).expect("failed to parse peers.yml");
 


### PR DESCRIPTION
# Description

Follow-up to fix broken new tests from #814: When the PEERS_YML variable was switched late in the review process to use a Laze variable instead, I only re-tested it with an explicit override in place and not without one.

## Tests performed

```sh
$ cd tests/coap
$ laze build -b particle-xenon -D LOG=trace -s coap-server-config-storage
$ cd ../../
$ laze -C tests/coap build -b particle-xenon -D LOG=trace -s coap-server-config-storage
$ laze -C tests/coap build -b particle-xenon -D LOG=trace -s coap-server-config-storage -D PEERS_YML=${PWD}/tests/coap/peers.yml
```

## Next steps

Look at whether laze can help with the confusion that `-D some-file` meaning the same thing no matter which directory this is being called from. (Generally arguments are understood relative to the working directory of the program that is being launched, passing them in as a define makes this muddy.)

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
