### PR TITLE
feat(network): seed `embassy_net` from the device ID when no RNG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "ariel-os-debug",
  "ariel-os-embassy-common",
  "ariel-os-hal",
+ "ariel-os-identity",
  "ariel-os-macros",
  "ariel-os-random",
  "ariel-os-rt",

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -34,6 +34,7 @@ embedded-hal-async = { workspace = true }
 ariel-os-buildinfo = { workspace = true }
 ariel-os-embassy-common = { workspace = true }
 ariel-os-hal = { path = "../ariel-os-hal" }
+ariel-os-identity = { path = "../ariel-os-identity" }
 ariel-os-threads = { path = "../ariel-os-threads", optional = true }
 ariel-os-debug = { workspace = true }
 ariel-os-macros = { path = "../ariel-os-macros" }

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -305,11 +305,7 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
 
         let config = net::config();
 
-        // This seed is mostly used by smoltcp and does not have to be cryptographically secure.
-        #[cfg(feature = "random")]
-        let seed = rand_core::RngCore::next_u64(&mut ariel_os_random::fast_rng());
-        #[cfg(not(feature = "random"))]
-        let seed = 1234u64;
+        let seed = net::unique_seed();
         debug!("Network stack seed: {:#x}", seed);
 
         // Init network stack


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This seed is used internally by `embassy_net` to randomize port numbers and is passed to `smoltcp` as [`random_seed`](https://docs.rs/smoltcp/latest/smoltcp/iface/struct.Config.html#structfield.random_seed) which also uses it randomize initial TCP sequence numbers.

That seed doesn't need to be cryptographically secure but there are still [mild security considerations](https://github.com/smoltcp-rs/smoltcp/pull/465#discussion_r726278895), as a *blind* attacker could spoof packets if these were predictable.

This PR aims to improve on what #770 introduced:

- If an RNG is present *and already enabled by the application*, we use it to obtain a seed that is unique and different on each reboot.
- Otherwise, if the device provides a hardware-backed device ID, unique by definition, we use the EUI-48 identifier derived from it (because its length is already normalized across devices and because it is already supposed to be unique by definition).
- If none of these is available, we fallback to the hard-coded value we already have.

## How to review this PR

This can be tested in hardware using (stm32 MCUs with a HWRNG would be suitable as well):

```sh
laze -C examples/udp-echo/ build -DLOG=debug -b nrf52840dk run
```

The seed will be printed as: `DEBUG Network stack seed: <seed>` and will be the same across reboots.

The `random` module can then be selected manually:

```sh
laze -C examples/udp-echo/ build --selected random -DLOG=debug -b nrf52840dk run
```

and the printed seed will now be different on each boot.

## Future work

This is a best-effort attempt to reduce the set of devices/applications on which we fallback to the hard-coded value right now.
I hope to later work with upstream (`smoltcp` and then `embassy_net`) to clarify the semantics of this seed and make sure they guarantee its requirements. When this is done, we'll then be able to document our behavior in our user documentation.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Builds on #770.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
