### PR TITLE
fix(rtt): switch channel sequence

### DIFF
--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -86,20 +86,20 @@ mod backend {
                 up: {
                     0: {
                         size: 1024,
-                        mode: NoBlockTrim,
-                        name: "Terminal"
-                    }
-                    1: {
-                        size: 1024,
                         mode: NoBlockSkip,
                         // probe-run autodetects whether defmt is in use based on this channel name
                         name: "defmt"
                     }
+                    1: {
+                        size: 1024,
+                        mode: NoBlockTrim,
+                        name: "Terminal"
+                    }
                 }
             };
 
-            rtt_target::set_print_channel(channels.up.0);
-            rtt_target::set_defmt_channel(channels.up.1);
+            rtt_target::set_print_channel(channels.up.1);
+            rtt_target::set_defmt_channel(channels.up.0);
         }
     }
 }


### PR DESCRIPTION
# Description

probe-rs refactored its internals, and the heuristics changed, and our defmt channel is not recognized any more by current probe-rs HEAD.

Upstream is very helpful and active on fixing this -- nonetheless, we need a quick workaround. Changing the order of channels should have zero practical impact, but ensures that the current heuristics match.

## Issues/PRs references

Workaround-For: https://github.com/probe-rs/probe-rs/issues/3130

The change can persist even after that is fixed: the code is no better or worse either way.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.
