### PR TITLE
refactor(laze): reorder and fix Arm-related modules

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -384,22 +384,6 @@ contexts:
         - CONFIG_SWI=UART5
 
 modules:
-  - name: cortex-m
-    env:
-      global:
-        OBJCOPY: arm-none-eabi-objcopy
-        RUSTFLAGS:
-          - -Clink-arg=${LINK_ARG_PREFIX}--nmagic
-          - -Clink-arg=${LINK_ARG_PREFIX}--no-eh-frame-hdr
-          - -Clink-arg=-Tlinkme.x
-          - -Clink-arg=-Tlink.x
-          - -Clink-arg=-Teheap.x
-          - -Clink-arg=-Tdevice.x
-          - -Clink-arg=-Tisr_stack.x
-          - -Clink-arg=-Tkeep-stack-sizes.x
-          - --cfg context=\"cortex-m\"
-          - -Z emit-stack-sizes
-
   - name: thumbv6m-none-eabi
     selects:
       - cortex-m
@@ -409,6 +393,16 @@ modules:
         CARGO_TARGET_PREFIX: CARGO_TARGET_THUMBV6M_NONE_EABI
         RUSTFLAGS:
           - --cfg armv6m
+
+  - name: thumbv7m-none-eabi
+    selects:
+      - cortex-m
+    env:
+      global:
+        RUSTC_TARGET: thumbv7m-none-eabi
+        CARGO_TARGET_PREFIX: CARGO_TARGET_THUMBV7M_NONE_EABI
+        RUSTFLAGS:
+          - --cfg armv7m
 
   - name: thumbv7em-none-eabi
     selects:
@@ -420,13 +414,13 @@ modules:
         RUSTFLAGS:
           - --cfg armv7m
 
-  - name: thumbv7m-none-eabi
+  - name: thumbv7em-none-eabihf
     selects:
       - cortex-m
     env:
       global:
-        RUSTC_TARGET: thumbv7m-none-eabi
-        CARGO_TARGET_PREFIX: CARGO_TARGET_THUMBV7M_NONE_EABI
+        RUSTC_TARGET: thumbv7em-none-eabihf
+        CARGO_ENV_TARGET: CARGO_TARGET_THUMBV7EM_NONE_EABIHF
         RUSTFLAGS:
           - --cfg armv7m
 
@@ -450,15 +444,21 @@ modules:
         RUSTFLAGS:
           - --cfg armv8m
 
-  - name: thumbv7em-none-eabihf
-    selects:
-      - cortex-m
+  - name: cortex-m
     env:
       global:
-        RUSTC_TARGET: thumbv7em-none-eabihf
-        CARGO_ENV_TARGET: CARGO_TARGET_THUMBV7EM_NONE_EABIHF
+        OBJCOPY: arm-none-eabi-objcopy
         RUSTFLAGS:
-          - --cfg armv7m
+          - -Clink-arg=${LINK_ARG_PREFIX}--nmagic
+          - -Clink-arg=${LINK_ARG_PREFIX}--no-eh-frame-hdr
+          - -Clink-arg=-Tlinkme.x
+          - -Clink-arg=-Tlink.x
+          - -Clink-arg=-Teheap.x
+          - -Clink-arg=-Tdevice.x
+          - -Clink-arg=-Tisr_stack.x
+          - -Clink-arg=-Tkeep-stack-sizes.x
+          - --cfg context=\"cortex-m\"
+          - -Z emit-stack-sizes
 
   - name: xtensa
     env:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -339,6 +339,23 @@ contexts:
         # This ISR is unused on a naked board. Configured here for testing.
         - CONFIG_SWI=USART2
 
+  - name: stm32h755zitx
+    parent: stm32
+    selects:
+      - thumbv7em-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
+    provides:
+      - has_swi
+    env:
+      PROBE_RS_CHIP: STM32H755ZITx
+      PROBE_RS_PROTOCOL: swd
+      RUSTFLAGS:
+        - --cfg capability=\"hw/stm32-dual-core\"
+        - --cfg capability=\"hw/stm32-hash-rng\"
+        - --cfg capability=\"hw/stm32-usb-synopsis\"
+      CARGO_ENV:
+        # This ISR is unused on a naked board. Configured here for testing.
+        - CONFIG_SWI=UART5
+
   - name: stm32wb55rgvx
     parent: stm32
     selects:
@@ -369,23 +386,6 @@ contexts:
         - CONFIG_SWI=LPUART1
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
-
-  - name: stm32h755zitx
-    parent: stm32
-    selects:
-      - thumbv7em-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
-    provides:
-      - has_swi
-    env:
-      PROBE_RS_CHIP: STM32H755ZITx
-      PROBE_RS_PROTOCOL: swd
-      RUSTFLAGS:
-        - --cfg capability=\"hw/stm32-dual-core\"
-        - --cfg capability=\"hw/stm32-hash-rng\"
-        - --cfg capability=\"hw/stm32-usb-synopsis\"
-      CARGO_ENV:
-        # This ISR is unused on a naked board. Configured here for testing.
-        - CONFIG_SWI=UART5
 
 modules:
   - name: thumbv6m-none-eabi

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -182,10 +182,11 @@ contexts:
         - ${SCRIPTS}/debug-openocd.sh
       OPENOCD_ARGS:
         - "-f board/nordic_nrf52_dk.cfg"
-      PROBE_RS_CHIP: nrf52832_xxAA
 
   - name: nrf52832
     parent: nrf52
+    env:
+      PROBE_RS_CHIP: nrf52832_xxAA
 
   - name: nrf52833
     parent: nrf52

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -198,10 +198,13 @@ contexts:
     env:
       PROBE_RS_CHIP: nrf52840_xxAA
 
-  - name: nrf5340
+  - name: nrf53
     parent: nrf
     selects:
       - thumbv8m.main-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
+
+  - name: nrf5340
+    parent: nrf53
     env:
       PROBE_RS_CHIP: nrf5340_xxAA
 

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -184,13 +184,6 @@ contexts:
         - "-f board/nordic_nrf52_dk.cfg"
       PROBE_RS_CHIP: nrf52832_xxAA
 
-  - name: nrf5340
-    parent: nrf
-    selects:
-      - thumbv8m.main-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
-    env:
-      PROBE_RS_CHIP: nrf5340_xxAA
-
   - name: nrf52832
     parent: nrf52
 
@@ -203,6 +196,13 @@ contexts:
     parent: nrf52
     env:
       PROBE_RS_CHIP: nrf52840_xxAA
+
+  - name: nrf5340
+    parent: nrf
+    selects:
+      - thumbv8m.main-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
+    env:
+      PROBE_RS_CHIP: nrf5340_xxAA
 
   - name: rp
     help: Raspberry Pi Pico (2) MCU support (based on embassy-rp)


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This reorders the Arm-related modules (e.g., `thumbv*`, `nrf*`, `stm32*`) in lexicographical order.
This also fixes a minor modeling issue in one of the nrf52 modules regarding the `PROBE_RS_CHIP` variable.
An intermediate `nrf53` module is also introduced.

This prepares for #882 which introduces `cortex-m*` modules.

## How to review this PR

This PR is definitely better reviewed commit by commit.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
