### PR TITLE
feat(build): invert executor-interrupt SWI requirements

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -155,6 +155,8 @@ contexts:
     parent: ariel-os
     selects:
       - ?probe-rs
+    provides:
+      - has_swi
 
   - name: nrf51
     parent: nrf
@@ -205,6 +207,8 @@ contexts:
   - name: rp
     help: Raspberry Pi Pico (2) MCU support (based on embassy-rp)
     parent: ariel-os
+    provides:
+      - has_swi
 
   - name: rp2040
     parent: rp
@@ -993,9 +997,8 @@ modules:
   # interrupt.
   - name: executor-interrupt
     help: use the Embassy interrupt executor
-    context:
-      - nrf
-      - rp
+    selects:
+      - has_swi
     provides_unique:
       - executor
     env:


### PR DESCRIPTION
# Description

Make the swi requirement of `executor-interrupt` explicit with the `has_swi` capablility module.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
