### PR TITLE
refactor(stm32): replace Cargo features with laze capabilities

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -344,6 +344,8 @@ contexts:
     env:
       PROBE_RS_CHIP: STM32WB55RGVx
       PROBE_RS_PROTOCOL: swd
+      RUSTFLAGS:
+        - --cfg capability=\"hw/stm32-usb\"
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.
         - CONFIG_SWI=LPUART1
@@ -372,6 +374,7 @@ contexts:
       PROBE_RS_PROTOCOL: swd
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-dual-core\"
+        - --cfg capability=\"hw/stm32-usb-synopsis\"
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.
         - CONFIG_SWI=UART5

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -345,6 +345,7 @@ contexts:
       PROBE_RS_CHIP: STM32WB55RGVx
       PROBE_RS_PROTOCOL: swd
       RUSTFLAGS:
+        - --cfg capability=\"hw/stm32-rng\"
         - --cfg capability=\"hw/stm32-usb\"
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.
@@ -362,6 +363,8 @@ contexts:
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.
         - CONFIG_SWI=LPUART1
+      RUSTFLAGS:
+        - --cfg capability=\"hw/stm32-rng\"
 
   - name: stm32h755zitx
     parent: stm32
@@ -374,6 +377,7 @@ contexts:
       PROBE_RS_PROTOCOL: swd
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-dual-core\"
+        - --cfg capability=\"hw/stm32-hash-rng\"
         - --cfg capability=\"hw/stm32-usb-synopsis\"
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.

--- a/src/ariel-os-boards/st-nucleo-h755zi-q/Cargo.toml
+++ b/src/ariel-os-boards/st-nucleo-h755zi-q/Cargo.toml
@@ -12,8 +12,5 @@ embassy-stm32 = { workspace = true, features = [
 ] }
 ariel-os-debug = { workspace = true, features = ["rtt-target"] }
 ariel-os-rt.workspace = true
-ariel-os-stm32 = { workspace = true, features = [
-  "stm32-hash-rng",
-  "stm32-usb-synopsis",
-] }
+ariel-os-stm32 = { workspace = true, features = ["stm32-hash-rng"] }
 stm32 = { path = "../../ariel-os-chips/stm32" }

--- a/src/ariel-os-boards/st-nucleo-h755zi-q/Cargo.toml
+++ b/src/ariel-os-boards/st-nucleo-h755zi-q/Cargo.toml
@@ -12,5 +12,5 @@ embassy-stm32 = { workspace = true, features = [
 ] }
 ariel-os-debug = { workspace = true, features = ["rtt-target"] }
 ariel-os-rt.workspace = true
-ariel-os-stm32 = { workspace = true, features = ["stm32-hash-rng"] }
+ariel-os-stm32 = { workspace = true }
 stm32 = { path = "../../ariel-os-chips/stm32" }

--- a/src/ariel-os-boards/st-nucleo-wb55/Cargo.toml
+++ b/src/ariel-os-boards/st-nucleo-wb55/Cargo.toml
@@ -8,5 +8,5 @@ edition.workspace = true
 [dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb55rg"] }
 ariel-os-debug = { workspace = true, features = ["rtt-target"] }
-ariel-os-stm32 = { workspace = true, features = ["stm32-rng", "stm32-usb"] }
+ariel-os-stm32 = { workspace = true, features = ["stm32-rng"] }
 ariel-os-rt.workspace = true

--- a/src/ariel-os-boards/st-nucleo-wb55/Cargo.toml
+++ b/src/ariel-os-boards/st-nucleo-wb55/Cargo.toml
@@ -8,5 +8,5 @@ edition.workspace = true
 [dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb55rg"] }
 ariel-os-debug = { workspace = true, features = ["rtt-target"] }
-ariel-os-stm32 = { workspace = true, features = ["stm32-rng"] }
+ariel-os-stm32 = { workspace = true }
 ariel-os-rt.workspace = true

--- a/src/ariel-os-boards/st-nucleo-wba55/Cargo.toml
+++ b/src/ariel-os-boards/st-nucleo-wba55/Cargo.toml
@@ -8,5 +8,5 @@ edition.workspace = true
 [dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba55cg"] }
 ariel-os-debug = { workspace = true, features = ["rtt-target"] }
-ariel-os-stm32 = { workspace = true, features = ["stm32-rng"] }
+ariel-os-stm32 = { workspace = true }
 ariel-os-rt.workspace = true

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -58,10 +58,6 @@ storage = ["dep:embassy-embedded-hal"]
 
 ## Enables USB support.
 usb = []
-# These are chosen automatically by ariel-os-boards and select the correct stm32
-# usb peripheral support.
-stm32-usb = []
-stm32-usb-synopsis = []
 
 ## Enables defmt support.
 defmt = ["dep:defmt", "embassy-stm32/defmt"]

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -37,10 +37,6 @@ external-interrupts = [
 
 ## Enables seeding the random number generator from hardware.
 hwrng = ["dep:ariel-os-random"]
-# These are chosen automatically by ariel-os-boards and select the correct stm32
-# rng peripheral support.
-stm32-hash-rng = []
-stm32-rng = []
 
 ## Enables I2C support.
 # Time-related features are required for timeout support.

--- a/src/ariel-os-stm32/src/hwrng.rs
+++ b/src/ariel-os-stm32/src/hwrng.rs
@@ -1,15 +1,15 @@
 use embassy_stm32::rng::Rng;
 use embassy_stm32::{bind_interrupts, peripherals, rng};
 
-#[cfg(not(any(feature = "stm32-hash-rng", feature = "stm32-rng")))]
-compile_error!("no stm32 rng feature enabled");
+#[cfg(not(any(capability = "hw/stm32-hash-rng", capability = "hw/stm32-rng")))]
+compile_error!("no stm32 RNG capability enabled");
 
-#[cfg(feature = "stm32-hash-rng")]
+#[cfg(capability = "hw/stm32-hash-rng")]
 bind_interrupts!(struct Irqs {
     HASH_RNG => rng::InterruptHandler<peripherals::RNG>;
 });
 
-#[cfg(feature = "stm32-rng")]
+#[cfg(capability = "hw/stm32-rng")]
 bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<peripherals::RNG>;
 });

--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -45,16 +45,16 @@ pub mod hwrng;
 
 #[cfg(feature = "usb")]
 cfg_if::cfg_if! {
-    if #[cfg(feature = "stm32-usb")] {
+    if #[cfg(capability = "hw/stm32-usb")] {
         #[doc(hidden)]
         #[path = "usb.rs"]
         pub mod usb;
-    } else if #[cfg(feature = "stm32-usb-synopsis")] {
+    } else if #[cfg(capability = "hw/stm32-usb-synopsis")] {
         #[doc(hidden)]
         #[path = "usb_synopsis_otg.rs"]
         pub mod usb;
     } else {
-        compile_error!("stm32: usb enabled but no flavor selected. Choose `stm32-usb` or `stm32-usb-synopsis`.");
+        compile_error!("stm32: USB enabled but no capability selected`.");
     }
 }
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This replaces Cargo features on our SMT32 HAL crate with laze capabilities to remove the need for board crates for selecting these.
This is extracted from #852 to make it easier to review.

## How to review this PR

Possibly compile the `random` and `udp-echo` examples on st-nucleo-h755zi-q and st-nucleo-wb55, but this is already done by CI.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
