### PR TITLE
fix(lints): warn about possibly missing `#[must_use]` attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,5 +163,9 @@ missing_safety_doc = { level = "warn" }
 too_long_first_doc_paragraph = "warn"
 unused_result_ok = "deny"
 
+# TODO: remove these when we enable pedantic
+must_use_candidate = "warn"
+return_self_not_must_use = "warn"
+
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/src/ariel-os-embassy-common/src/spi/main/mod.rs
+++ b/src/ariel-os-embassy-common/src/spi/main/mod.rs
@@ -62,14 +62,17 @@ macro_rules! impl_spi_frequency_const_functions {
     ($MAX_FREQUENCY:ident) => {
         #[doc(hidden)]
         impl Frequency {
+            #[must_use]
             pub const fn first() -> Self {
                 Self::F(Kilohertz::kHz(1))
             }
 
+            #[must_use]
             pub const fn last() -> Self {
                 Self::F(MAX_FREQUENCY)
             }
 
+            #[must_use]
             pub const fn next(self) -> Option<Self> {
                 match self {
                     Self::F(kilohertz) => {
@@ -83,6 +86,7 @@ macro_rules! impl_spi_frequency_const_functions {
                 }
             }
 
+            #[must_use]
             pub const fn prev(self) -> Option<Self> {
                 const MIN_FREQUENCY: Kilohertz = Kilohertz::kHz(1);
 
@@ -98,6 +102,7 @@ macro_rules! impl_spi_frequency_const_functions {
                 }
             }
 
+            #[must_use]
             pub const fn khz(self) -> u32 {
                 match self {
                     Self::F(kilohertz) => kilohertz.to_kHz(),

--- a/src/ariel-os-embassy/src/delegate.rs
+++ b/src/ariel-os-embassy/src/delegate.rs
@@ -47,6 +47,7 @@ impl<T> !Send for Delegate<T> {}
 
 impl<T> Delegate<T> {
     /// Creates a new [`Delegate`].
+    #[must_use]
     pub const fn new() -> Self {
         Self {
             send: Signal::new(),

--- a/src/ariel-os-embassy/src/gpio.rs
+++ b/src/ariel-os-embassy/src/gpio.rs
@@ -32,16 +32,19 @@ pub use ariel_os_embassy_common::gpio::{DriveStrength, Level, Pull, Speed};
 macro_rules! inner_impl_input_methods {
     ($inner:ident) => {
         /// Returns whether the input level is high.
+        #[must_use]
         pub fn is_high(&self) -> bool {
             self.$inner.is_high()
         }
 
         /// Returns whether the input level is low.
+        #[must_use]
         pub fn is_low(&self) -> bool {
             self.$inner.is_low()
         }
 
         /// Returns the input level.
+        #[must_use]
         pub fn get_level(&self) -> Level {
             #[cfg(context = "esp")]
             let level = hal::gpio::input::into_level(self.$inner.level());
@@ -211,6 +214,7 @@ pub mod input {
         ///
         /// Fails to compile if the HAL does not support configuring Schmitt trigger on
         /// inputs.
+        #[must_use]
         pub fn schmitt_trigger(self, enable: bool) -> Self {
             #[expect(
                 clippy::assertions_on_constants,
@@ -233,6 +237,7 @@ pub mod input {
         // commit to them being part of our API for now.
         // We may remove them in the future if we realize they are never useful.
         #[doc(hidden)]
+        #[must_use]
         pub fn opt_schmitt_trigger(self, enable: bool) -> Self {
             if hal::gpio::input::SCHMITT_TRIGGER_CONFIGURABLE {
                 // We cannot reuse the non-`opt_*()`, otherwise the const assert inside it would always
@@ -358,6 +363,7 @@ pub mod output {
                 ///
                 /// Fails to compile if the HALs does not support configuring drive strength of
                 /// outputs.
+                #[must_use]
                 pub fn drive_strength(
                     self,
                     drive_strength: DriveStrength<HalDriveStrength>,
@@ -379,6 +385,7 @@ pub mod output {
                 // commit to them being part of our API for now.
                 // We may remove them in the future if we realize they are never useful.
                 #[doc(hidden)]
+                #[must_use]
                 // TODO: or `drive_strength_opt`?
                 pub fn opt_drive_strength(
                     self,
@@ -401,6 +408,7 @@ pub mod output {
                 /// # Note
                 ///
                 /// Fails to compile if the HAL does not support configuring speed of outputs.
+                #[must_use]
                 pub fn speed(self, speed: Speed<HalSpeed>) -> Self {
                     const {
                         assert!(
@@ -416,6 +424,7 @@ pub mod output {
                 // commit to them being part of our API for now.
                 // We may remove them in the future if we realize they are never useful.
                 #[doc(hidden)]
+                #[must_use]
                 // TODO: or `speed_opt`?
                 pub fn opt_speed(self, speed: Speed<HalSpeed>) -> Self {
                     if hal::gpio::output::SPEED_CONFIGURABLE {

--- a/src/ariel-os-embassy/src/i2c/controller/mod.rs
+++ b/src/ariel-os-embassy/src/i2c/controller/mod.rs
@@ -39,6 +39,7 @@ pub type I2cDevice = InnerI2cDevice<'static, CriticalSectionRawMutex, hal::i2c::
 ///
 /// This function is only intended to be used in a `const` context.
 /// It panics if no suitable frequency can be found.
+#[must_use]
 pub const fn highest_freq_in(
     range: core::ops::RangeInclusive<ariel_os_embassy_common::i2c::controller::Kilohertz>,
 ) -> hal::i2c::controller::Frequency {

--- a/src/ariel-os-embassy/src/spi/main/mod.rs
+++ b/src/ariel-os-embassy/src/spi/main/mod.rs
@@ -43,6 +43,7 @@ pub type SpiDevice =
 ///
 /// This function is only intended to be used in a `const` context.
 /// It panics if no suitable frequency can be found.
+#[must_use]
 pub const fn highest_freq_in(
     range: core::ops::RangeInclusive<ariel_os_embassy_common::spi::main::Kilohertz>,
 ) -> hal::spi::main::Frequency {

--- a/src/ariel-os-esp/src/i2c/controller/mod.rs
+++ b/src/ariel-os-esp/src/i2c/controller/mod.rs
@@ -37,14 +37,17 @@ pub enum Frequency {
 
 #[doc(hidden)]
 impl Frequency {
+    #[must_use]
     pub const fn first() -> Self {
         Self::_100k
     }
 
+    #[must_use]
     pub const fn last() -> Self {
         Self::_400k
     }
 
+    #[must_use]
     pub const fn next(self) -> Option<Self> {
         match self {
             Self::_100k => Some(Self::_400k),
@@ -52,6 +55,7 @@ impl Frequency {
         }
     }
 
+    #[must_use]
     pub const fn prev(self) -> Option<Self> {
         match self {
             Self::_100k => None,
@@ -59,6 +63,7 @@ impl Frequency {
         }
     }
 
+    #[must_use]
     pub const fn khz(self) -> u32 {
         match self {
             Self::_100k => 100,

--- a/src/ariel-os-esp/src/lib.rs
+++ b/src/ariel-os-esp/src/lib.rs
@@ -115,6 +115,7 @@ pub use esp_hal::peripherals::OptionalPeripherals;
 pub use esp_hal_embassy::Executor;
 
 #[doc(hidden)]
+#[must_use]
 pub fn init() -> OptionalPeripherals {
     let mut config = esp_hal::Config::default();
     config.cpu_clock = esp_hal::clock::CpuClock::max();

--- a/src/ariel-os-nrf/src/i2c/controller/mod.rs
+++ b/src/ariel-os-nrf/src/i2c/controller/mod.rs
@@ -60,14 +60,17 @@ pub enum Frequency {
 
 #[doc(hidden)]
 impl Frequency {
+    #[must_use]
     pub const fn first() -> Self {
         Self::_100k
     }
 
+    #[must_use]
     pub const fn last() -> Self {
         Self::_400k
     }
 
+    #[must_use]
     pub const fn next(self) -> Option<Self> {
         match self {
             #[cfg(context = "nrf52840")]
@@ -80,6 +83,7 @@ impl Frequency {
         }
     }
 
+    #[must_use]
     pub const fn prev(self) -> Option<Self> {
         match self {
             Self::_100k => None,
@@ -92,6 +96,7 @@ impl Frequency {
         }
     }
 
+    #[must_use]
     pub const fn khz(self) -> u32 {
         match self {
             Self::_100k => 100,

--- a/src/ariel-os-nrf/src/lib.rs
+++ b/src/ariel-os-nrf/src/lib.rs
@@ -60,6 +60,7 @@ pub use embassy_nrf::peripherals;
 pub static EXECUTOR: Executor = Executor::new();
 
 #[doc(hidden)]
+#[must_use]
 pub fn init() -> OptionalPeripherals {
     let peripherals = embassy_nrf::init(Config::default());
     OptionalPeripherals::from(peripherals)

--- a/src/ariel-os-nrf/src/spi/main/mod.rs
+++ b/src/ariel-os-nrf/src/spi/main/mod.rs
@@ -65,14 +65,17 @@ pub enum Frequency {
 
 #[doc(hidden)]
 impl Frequency {
+    #[must_use]
     pub const fn first() -> Self {
         Self::_125k
     }
 
+    #[must_use]
     pub const fn last() -> Self {
         Self::_8M
     }
 
+    #[must_use]
     pub const fn next(self) -> Option<Self> {
         match self {
             Self::_125k => Some(Self::_250k),
@@ -85,6 +88,7 @@ impl Frequency {
         }
     }
 
+    #[must_use]
     pub const fn prev(self) -> Option<Self> {
         match self {
             Self::_125k => None,
@@ -97,6 +101,7 @@ impl Frequency {
         }
     }
 
+    #[must_use]
     pub const fn khz(self) -> u32 {
         match self {
             Self::_125k => 125,

--- a/src/ariel-os-rp/src/i2c/controller/mod.rs
+++ b/src/ariel-os-rp/src/i2c/controller/mod.rs
@@ -42,14 +42,17 @@ pub enum Frequency {
 
 #[doc(hidden)]
 impl Frequency {
+    #[must_use]
     pub const fn first() -> Self {
         Self::UpTo100k(Kilohertz::kHz(1))
     }
 
+    #[must_use]
     pub const fn last() -> Self {
         Self::UpTo400k(Kilohertz::kHz(400))
     }
 
+    #[must_use]
     pub const fn next(self) -> Option<Self> {
         match self {
             Self::UpTo100k(f) => {
@@ -71,6 +74,7 @@ impl Frequency {
         }
     }
 
+    #[must_use]
     pub const fn prev(self) -> Option<Self> {
         match self {
             Self::UpTo100k(f) => {
@@ -92,6 +96,7 @@ impl Frequency {
         }
     }
 
+    #[must_use]
     pub const fn khz(self) -> u32 {
         match self {
             Self::UpTo100k(f) | Self::UpTo400k(f) => f.to_kHz(),

--- a/src/ariel-os-rp/src/lib.rs
+++ b/src/ariel-os-rp/src/lib.rs
@@ -68,6 +68,7 @@ ariel_os_embassy_common::executor_swi!(SWI_IRQ_1);
 pub static EXECUTOR: Executor = Executor::new();
 
 #[doc(hidden)]
+#[must_use]
 pub fn init() -> OptionalPeripherals {
     #[cfg(feature = "executor-interrupt")]
     {

--- a/src/ariel-os-stm32/src/i2c/controller/mod.rs
+++ b/src/ariel-os-stm32/src/i2c/controller/mod.rs
@@ -48,14 +48,17 @@ pub enum Frequency {
 
 #[doc(hidden)]
 impl Frequency {
+    #[must_use]
     pub const fn first() -> Self {
         Self::UpTo100k(Kilohertz::kHz(1))
     }
 
+    #[must_use]
     pub const fn last() -> Self {
         Self::UpTo400k(Kilohertz::kHz(400))
     }
 
+    #[must_use]
     pub const fn next(self) -> Option<Self> {
         match self {
             Self::UpTo100k(f) => {
@@ -77,6 +80,7 @@ impl Frequency {
         }
     }
 
+    #[must_use]
     pub const fn prev(self) -> Option<Self> {
         match self {
             Self::UpTo100k(f) => {
@@ -98,6 +102,7 @@ impl Frequency {
         }
     }
 
+    #[must_use]
     pub const fn khz(self) -> u32 {
         match self {
             Self::UpTo100k(f) | Self::UpTo400k(f) => f.to_kHz(),

--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -73,6 +73,7 @@ static SHARED_DATA: MaybeUninit<SharedData> = MaybeUninit::uninit();
 pub static EXECUTOR: Executor = Executor::new();
 
 #[doc(hidden)]
+#[must_use]
 pub fn init() -> OptionalPeripherals {
     let mut config = Config::default();
     board_config(&mut config);

--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -623,6 +623,7 @@ pub fn current_tid() -> Option<ThreadId> {
 }
 
 /// Returns the id of the CPU that this thread is running on.
+#[must_use]
 pub fn core_id() -> CoreId {
     #[cfg(not(feature = "multi-core"))]
     {

--- a/src/ariel-os-threads/src/sync/channel.rs
+++ b/src/ariel-os-threads/src/sync/channel.rs
@@ -23,6 +23,7 @@ pub struct Channel<T> {
 unsafe impl<T> Sync for Channel<T> {}
 
 impl<T: Copy + Send> Channel<T> {
+    #[must_use]
     pub const fn new() -> Self {
         Channel {
             state: UnsafeCell::new(ChannelState::Idle),

--- a/src/ariel-os-threads/src/sync/lock.rs
+++ b/src/ariel-os-threads/src/sync/lock.rs
@@ -20,6 +20,7 @@ enum LockState {
 
 impl Lock {
     /// Creates new **unlocked** Lock.
+    #[must_use]
     pub const fn new() -> Self {
         Self {
             state: UnsafeCell::new(LockState::Unlocked),
@@ -27,6 +28,7 @@ impl Lock {
     }
 
     /// Creates new **locked** Lock.
+    #[must_use]
     pub const fn new_locked() -> Self {
         Self {
             state: UnsafeCell::new(LockState::Locked(ThreadList::new())),

--- a/src/lib/coapcore/src/lib.rs
+++ b/src/lib/coapcore/src/lib.rs
@@ -26,6 +26,7 @@
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![no_std]
 #![cfg_attr(feature = "_nightly_docs", feature(doc_auto_cfg))]
+#![expect(clippy::pedantic)]
 
 mod iana;
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This PR adds missing [`#[must_use]` attributes](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute), and enables the relevant lints at workspace level; these will be removed when we enabled `pedantic`, as these lints are already part of the `pedantic` group.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
This is extracted from #279 to make it easier to review.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
