### PR TITLE
fix(coapcore): address various lints

### DIFF
--- a/src/lib/coapcore/src/ace.rs
+++ b/src/lib/coapcore/src/ace.rs
@@ -19,7 +19,7 @@ const MAX_SUPPORTED_PEER_NONCE_LEN: usize = 16;
 
 /// Maximum size a CWT processed by this module can have (at least when it needs to be copied)
 const MAX_SUPPORTED_ACCESSTOKEN_LEN: usize = 256;
-/// Maximum size of a COSE_Encrypt0 protected header (used to size the AAD buffer)
+/// Maximum size of a `COSE_Encrypt0` protected header (used to size the AAD buffer)
 const MAX_SUPPORTED_ENCRYPT_PROTECTED_LEN: usize = 32;
 
 /// The content of an application/ace+cbor file.
@@ -78,7 +78,7 @@ impl HeaderMap<'_> {
     }
 }
 
-/// A COSE_Key as described in Section 7 of RFC9052.
+/// A `COSE_Key` as described in Section 7 of RFC9052.
 ///
 /// This combines [COSE Key Common
 /// Parameters](https://www.iana.org/assignments/cose/cose.xhtml#key-common-parameters) with [COSE
@@ -109,7 +109,7 @@ pub(crate) struct CoseKey<'a> {
     pub(crate) y: Option<&'a [u8]>, // or bool (unsupported here so far)
 }
 
-/// A COSE_Encrypt0 structure as defined in [RFC8152](https://www.rfc-editor.org/rfc/rfc8152)
+/// A `COSE_Encrypt0` structure as defined in [RFC8152](https://www.rfc-editor.org/rfc/rfc8152)
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(minicbor::Decode)]
 #[cbor(tag(16))]
@@ -176,7 +176,7 @@ impl CoseEncrypt0<'_> {
 
 type EncryptedCwt<'a> = CoseEncrypt0<'a>;
 
-/// A COSE_Sign1 structure as defined in [RFC8152](https://www.rfc-editor.org/rfc/rfc8152)
+/// A `COSE_Sign1` structure as defined in [RFC8152](https://www.rfc-editor.org/rfc/rfc8152)
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(minicbor::Decode)]
 #[cbor(tag(18))]
@@ -243,7 +243,7 @@ struct Cnf<'a> {
     cose_key: Option<minicbor_adapters::WithOpaque<'a, CoseKey<'a>>>,
 }
 
-/// OSCORE_Input_Material.
+/// `OSCORE_Input_Material`.
 ///
 /// All current parameters are described in [Section 3.2.1 of
 /// RFC9203](https://datatracker.ietf.org/doc/html/rfc9203#name-the-oscore_input_material); the

--- a/src/lib/coapcore/src/ace.rs
+++ b/src/lib/coapcore/src/ace.rs
@@ -166,6 +166,10 @@ impl CoseEncrypt0<'_> {
         // Copying around is not a constraint of this function (well that too but that could
         // change) -- but the callers don't usually get their data in a mutable buffer for in-place
         // decryption.
+        #[expect(
+            clippy::ignored_unit_patterns,
+            reason = "heapless has non-recommended error type"
+        )]
         buffer
             .extend_from_slice(self.encrypted)
             .map_err(|_| CredentialErrorDetail::ConstraintExceeded)?;

--- a/src/lib/coapcore/src/helpers.rs
+++ b/src/lib/coapcore/src/helpers.rs
@@ -2,13 +2,13 @@
 
 /// An own identifier for a security context.
 ///
-/// This is used with EDHOC as C_I when in an initiator role, C_R when in a responder role, and
+/// This is used with EDHOC as `C_I` when in an initiator role, `C_R` when in a responder role, and
 /// recipient ID in OSCORE.
 ///
 /// This type represents any of the 48 efficient identifiers that use CBOR one-byte integer
 /// encodings (see RFC9528 Section 3.3.2), or equivalently the 1-byte long OSCORE identifiers
 ///
-/// Lakers supports a much larger value space for C_x, and coapcore processes larger values
+/// Lakers supports a much larger value space for `C_x`, and coapcore processes larger values
 /// selected by the peer -- but on its own, will select only those that fit in this type.
 // FIXME Could even limit to positive values if MAX_CONTEXTS < 24
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/src/lib/coapcore/src/helpers.rs
+++ b/src/lib/coapcore/src/helpers.rs
@@ -30,6 +30,11 @@ impl COwn {
     /// Find a value of self that is not found in the iterator.
     ///
     /// This asserts that the iterator is (known to be) short enough that this will always succeed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the iterator produces (or even may produce, per its size hints) more items than
+    /// `GENERATABLE_VALUES`.
     pub(crate) fn not_in_iter(iterator: impl Iterator<Item = Self>) -> Self {
         // In theory, this would allow the compiler to see that the unreachable below is indeed
         // unreachable
@@ -57,10 +62,18 @@ impl COwn {
         // trailing_ones = n implies that bit 1<<n is a zero and thus COwn(n) is free
         let pos_to = seen_pos.trailing_ones();
         if pos_to < 24 {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "ensured by the GENERATABLE_VALUES check"
+            )]
             return Self(pos_to as u8);
         }
         let neg_to = seen_neg.trailing_ones();
         if neg_to < 24 {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "ensured by the GENERATABLE_VALUES check"
+            )]
             return Self(0x20 | neg_to as u8);
         }
         unreachable!("Iterator is not long enough to set this many bits.");

--- a/src/lib/coapcore/src/lib.rs
+++ b/src/lib/coapcore/src/lib.rs
@@ -57,6 +57,7 @@
 #![no_std]
 #![cfg_attr(feature = "_nightly_docs", feature(doc_auto_cfg))]
 #![deny(missing_docs)]
+#![deny(clippy::pedantic)]
 
 mod iana;
 

--- a/src/lib/coapcore/src/lib.rs
+++ b/src/lib/coapcore/src/lib.rs
@@ -56,6 +56,7 @@
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![no_std]
 #![cfg_attr(feature = "_nightly_docs", feature(doc_auto_cfg))]
+#![deny(missing_docs)]
 
 mod iana;
 

--- a/src/lib/coapcore/src/lib.rs
+++ b/src/lib/coapcore/src/lib.rs
@@ -47,10 +47,15 @@
 //!
 //! **Warning**: At the Debug level, this module may show cryptographic key material. This will be
 //! revised once all components have been interop-tested.
+//!
+//! # Caveats
+//!
+//! Currently, this has hidden dependencies on a particular implementation of the [`coap-message`]
+//! provided (it needs to be a [`coap_message_implementations::inmemory_write::Message`]) by the
+//! stack. There are plans for removing this limitation by integrating deeper with libOSCORE.
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![no_std]
 #![cfg_attr(feature = "_nightly_docs", feature(doc_auto_cfg))]
-#![expect(clippy::pedantic)]
 
 mod iana;
 

--- a/src/lib/coapcore/src/oluru.rs
+++ b/src/lib/coapcore/src/oluru.rs
@@ -245,10 +245,7 @@ impl<T: PriorityLevel, const N: usize, const L: usize> OrderedPool<T, N, L> {
         {
             new_position -= 1;
         }
-        if new_position != position {
-            // Push our entry out right and in left in the front
-            self.sorted[new_position..=position].rotate_right(1);
-        } else {
+        if new_position == position {
             // Level may instead have increased
             while new_position < self.sorted.len() - 1
                 && self.entries[usize::from(self.sorted[new_position + 1])].level() < level
@@ -259,6 +256,9 @@ impl<T: PriorityLevel, const N: usize, const L: usize> OrderedPool<T, N, L> {
             if new_position != position {
                 self.sorted[position..=new_position].rotate_left(1);
             }
+        } else {
+            // Push our entry out right and in left in the front
+            self.sorted[new_position..=position].rotate_right(1);
         }
     }
 

--- a/src/lib/coapcore/src/oluru.rs
+++ b/src/lib/coapcore/src/oluru.rs
@@ -120,6 +120,7 @@ pub struct OrderedPool<T: PriorityLevel, const N: usize, const L: usize> {
 
 impl<T: PriorityLevel, const N: usize, const L: usize> OrderedPool<T, N, L> {
     /// Create an empty cache.
+    #[must_use]
     pub const fn new() -> Self {
         assert!(N < u16::MAX as usize, "Capacity overflow");
         // Clipping levels to u16 because they may be stored if the implementation changes.

--- a/src/lib/coapcore/src/oluru.rs
+++ b/src/lib/coapcore/src/oluru.rs
@@ -14,6 +14,7 @@
 //! to "large").
 #![forbid(unsafe_code)]
 #![expect(clippy::indexing_slicing, reason = "module is scheduled for overhaul")]
+#![expect(clippy::pedantic)]
 
 use arrayvec::ArrayVec;
 

--- a/src/lib/coapcore/src/scope.rs
+++ b/src/lib/coapcore/src/scope.rs
@@ -67,6 +67,12 @@ const AIF_SCOPE_MAX_LEN: usize = 64;
 pub struct AifValue([u8; AIF_SCOPE_MAX_LEN]);
 
 impl AifValue {
+    /// Ingests an AIF scope, verifying that it satisfies the constraints of this type.
+    ///
+    /// # Errors
+    ///
+    /// This produces errors if the input (which is typically received from the network) is
+    /// malformed or contains unsupported items.
     pub fn parse(bytes: &[u8]) -> Result<Self, InvalidScope> {
         let mut buffer = [0; AIF_SCOPE_MAX_LEN];
 

--- a/src/lib/coapcore/src/scope.rs
+++ b/src/lib/coapcore/src/scope.rs
@@ -81,7 +81,7 @@ impl AifValue {
             .map_err(|_| InvalidScope)?
         {
             let (path, _mask) = item.map_err(|_| InvalidScope)?;
-            if !path.starts_with("/") {
+            if !path.starts_with('/') {
                 return Err(InvalidScope);
             }
         }
@@ -117,9 +117,7 @@ impl Scope for AifValue {
                 // Special case: For consistency should be a single empty option.
                 return true;
             }
-            if !path.starts_with("/") {
-                panic!("Invalid AIF");
-            }
+            assert!(path.starts_with('/'), "Invalid AIF");
             let mut remainder = &path[1..];
             while !remainder.is_empty() {
                 let (next_part, next_remainder) = match remainder.split_once('/') {

--- a/src/lib/coapcore/src/scope.rs
+++ b/src/lib/coapcore/src/scope.rs
@@ -160,8 +160,11 @@ impl Scope for AifValue {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone)]
 pub enum UnionScope {
+    /// Contains an [`AifValue`].
     AifValue(AifValue),
+    /// Allows all requests.
     AllowAll,
+    /// Denies all requests.
     DenyAll,
 }
 

--- a/src/lib/coapcore/src/seccfg.rs
+++ b/src/lib/coapcore/src/seccfg.rs
@@ -599,8 +599,11 @@ impl ConfigBuilder {
 /// [`AifValue`][crate::scope::AifValue]), a [`TimeConstraint`], and a flag for importance.
 #[derive(Debug)]
 pub struct ConfigBuilderClaims {
+    /// The scope of the claims (providing [`GeneralClaims::scope()`]).
     pub scope: crate::scope::UnionScope,
+    /// Time constraints on the claims (providing [`GeneralClaims::time_constraint()`]).
     pub time_constraint: crate::time::TimeConstraint,
+    /// Importance of the security context (providing [`GeneralClaims::is_important()`], see there).
     pub is_important: bool,
 }
 

--- a/src/lib/coapcore/src/seccfg.rs
+++ b/src/lib/coapcore/src/seccfg.rs
@@ -82,7 +82,7 @@ pub trait ServerSecurityConfig {
     ///
     /// `signed_payload` is the payload part of the signed CWT; while it is part of `signed_data` and
     /// can be recovered from it, `signed_data` currently typically resides in a copied buffer
-    /// created for signature verification, and signed_payload is around inside the caller for
+    /// created for signature verification, and `signed_payload` is around inside the caller for
     /// longer. As common with signed data, it should only be parsed once the signature has been
     /// verified.
     ///
@@ -430,6 +430,7 @@ impl ConfigBuilder {
     /// Creates an empty server security configuration.
     ///
     /// Without any additional building steps, this is equivalent to [`DenyAll`].
+    #[must_use]
     pub fn new() -> Self {
         Self {
             as_key_31: None,
@@ -460,6 +461,7 @@ impl ConfigBuilder {
     ///
     /// Currently, keys are taken as byte sequence. With the expected flexibilization of crypto
     /// backends, this may later allow a more generic type that reflects secure element key slots.
+    #[must_use]
     pub fn with_aif_symmetric_as_aesccm256(self, key: [u8; 32]) -> Self {
         Self {
             as_key_31: Some(key),
@@ -480,6 +482,7 @@ impl ConfigBuilder {
     ///
     /// Same from [`Self::with_aif_symmetric_as_aesccm256`] apply, minus the considerations for
     /// secure key storage.
+    #[must_use]
     pub fn with_aif_asymmetric_es256(
         self,
         x: [u8; 32],
@@ -502,6 +505,7 @@ impl ConfigBuilder {
     /// Currently, this type just supports a single credential; it should therefore only be called
     /// once, and the latest value overwrites any earlier. (See
     /// [`Self::with_aif_symmetric_as_aesccm256`] for plans).
+    #[must_use]
     pub fn with_known_edhoc_credential(
         self,
         credential: lakers::Credential,
@@ -519,6 +523,7 @@ impl ConfigBuilder {
     ///
     /// When debug assertions are enabled, this panics if an own credential has already been
     /// configured.
+    #[must_use]
     pub fn with_own_edhoc_credential(
         self,
         credential: lakers::Credential,
@@ -540,6 +545,7 @@ impl ConfigBuilder {
     ///
     /// When debug assertions are enabled, this panics if an unauthenticated scope has already been
     /// configured.
+    #[must_use]
     pub fn allow_unauthenticated(self, scope: crate::scope::UnionScope) -> Self {
         debug_assert!(
             self.unauthenticated_scope.is_none(),
@@ -557,6 +563,7 @@ impl ConfigBuilder {
     ///
     /// When debug assertions are enabled, this panics if an unauthenticated scope has already been
     /// configured.
+    #[must_use]
     pub fn with_request_creation_hints(self, request_creation_hints: &'static [u8]) -> Self {
         debug_assert!(
             self.request_creation_hints.is_empty(),

--- a/src/lib/coapcore/src/seccontext.rs
+++ b/src/lib/coapcore/src/seccontext.rs
@@ -210,7 +210,7 @@ impl<
         }
     }
 
-    /// Produces a COwn (as a recipient identifier) that is both available and not equal to the
+    /// Produces a [`COwn`] (as a recipient identifier) that is both available and not equal to the
     /// peer's recipient identifier.
     fn cown_but_not(&self, c_peer: &[u8]) -> COwn {
         // Let's pick one now already: this allows us to use the identifier in our
@@ -643,7 +643,7 @@ impl<
     }
 
     /// Builds an OSCORE response message after successful processing of a request in
-    /// [Self::extract_oscore_edhoc()].
+    /// [`Self::extract_oscore_edhoc()`].
     fn build_oscore_response<M: MutableWritableMessage>(
         &mut self,
         response: &mut M,
@@ -711,7 +711,7 @@ impl<
                                                 // FIXME rewind message
                                                 response.set_code(coap_numbers::code::INTERNAL_SERVER_ERROR);
                                             }
-                                        };
+                                        }
                                     },
                                 },
                                 AuthorizationChecked::Allowed(Err(inner_request_error)) => {
@@ -781,8 +781,7 @@ impl<
                 error!("{}", Debug2Format(&e));
                 e.position
                     // FIXME: Could also come from processing inner
-                    .map(CoAPError::bad_request_with_rbep)
-                    .unwrap_or(CoAPError::bad_request())
+                    .map_or(CoAPError::bad_request(), CoAPError::bad_request_with_rbep)
             })?;
 
         debug!("Established OSCORE context with recipient ID {:?} and authorization {:?} through ACE-OSCORE", oscore.recipient_id(), Debug2Format(&generalclaims));
@@ -846,19 +845,20 @@ pub enum OwnRequestData<I> {
 fn too_small(e: lakers::MessageBufferError) -> CoAPError {
     match e {
         lakers::MessageBufferError::BufferAlreadyFull => {
-            error!("Lakers buffer size exceeded: Buffer full.")
+            error!("Lakers buffer size exceeded: Buffer full.");
         }
         lakers::MessageBufferError::SliceTooLong => {
-            error!("Lakers buffer size exceeded: Slice too long.")
+            error!("Lakers buffer size exceeded: Slice too long.");
         }
-    };
+    }
     CoAPError::bad_request()
 }
 
 /// Renders a [`lakers::EDHOCError`] into the common Error type.
 ///
-/// It is yet to be decided based on the EDHOC specification which EDHOCError values would be
-/// reported with precise data, and which should rather produce a generic response.
+/// It is yet to be decided based on the EDHOC specification which
+/// [`EDHOCError`][lakers::EDHOCError] values would be reported with precise data, and which should
+/// rather produce a generic response.
 ///
 /// Places using this function may be simplified if From/Into is specified (possibly after
 /// enlarging the Error type)
@@ -871,12 +871,12 @@ fn render_error(e: lakers::EDHOCError) -> CoAPError {
         lakers::EDHOCError::MacVerificationFailed => error!("Lakers error: MacVerificationFailed"),
         lakers::EDHOCError::UnsupportedMethod => error!("Lakers error: UnsupportedMethod"),
         lakers::EDHOCError::UnsupportedCipherSuite => {
-            error!("Lakers error: UnsupportedCipherSuite")
+            error!("Lakers error: UnsupportedCipherSuite");
         }
         lakers::EDHOCError::ParsingError => error!("Lakers error: ParsingError"),
         lakers::EDHOCError::EncodingError => error!("Lakers error: EncodingError"),
         lakers::EDHOCError::CredentialTooLongError => {
-            error!("Lakers error: CredentialTooLongError")
+            error!("Lakers error: CredentialTooLongError");
         }
         lakers::EDHOCError::EadLabelTooLongError => error!("Lakers error: EadLabelTooLongError"),
         lakers::EDHOCError::EadTooLongError => error!("Lakers error: EadTooLongError"),
@@ -976,7 +976,7 @@ impl<
         impl<SSC: ServerSecurityConfig> Recognition<SSC> {
             /// Given a state and an option, produce the next state and whether the option should
             /// be counted as consumed for the purpose of assessing .well-known/edchoc's
-            /// ignore_elective_others().
+            /// [`ignore_elective_others()`][coap_message_utils::option_processing::OptionsExt::ignore_elective_others].
             fn update(self, o: &impl MessageOption) -> (Self, bool) {
                 use coap_numbers::option;
 
@@ -1132,7 +1132,7 @@ impl<
                 if !SSC::HAS_EDHOC {
                     unreachable!("State is not constructed");
                 }
-                self.build_edhoc_message_2(response, c_r).map_err(Own)?
+                self.build_edhoc_message_2(response, c_r).map_err(Own)?;
             }
             Own(OwnRequestData::ProcessedToken(r)) => {
                 if !SSC::PARSES_TOKENS {
@@ -1152,14 +1152,14 @@ impl<
                     .map_err(Own)?;
             }
             Inner(AuthorizationChecked::Allowed(i)) => {
-                self.inner.build_response(response, i).map_err(Inner)?
+                self.inner.build_response(response, i).map_err(Inner)?;
             }
             Inner(AuthorizationChecked::NotAllowed) => {
                 self.authorities
                     .render_not_allowed(response)
                     .map_err(|_| Own(Ok(CoAPError::unauthorized())))?;
             }
-        };
+        }
         Ok(())
     }
 }

--- a/src/lib/coapcore/src/seccontext.rs
+++ b/src/lib/coapcore/src/seccontext.rs
@@ -1,4 +1,8 @@
 //! The main workhorse module of this crate.
+#![expect(
+    clippy::redundant_closure_for_method_calls,
+    reason = "all occurrences of this make the code strictly less obvious to understand"
+)]
 
 use core::marker::PhantomData;
 
@@ -24,6 +28,22 @@ const _MAX_CONTEXTS_CHECK: () = assert!(MAX_CONTEXTS <= COwn::GENERATABLE_VALUES
 const fn has_oscore<SSC: ServerSecurityConfig>() -> bool {
     SSC::HAS_EDHOC || SSC::PARSES_TOKENS
 }
+
+/// Space allocated for the message into which an EDHOC request is copied to remove EDHOC option
+/// and payload.
+///
+/// embedded-nal-coap uses this max size, and our messages are same size or smaller,
+/// so it's a guaranteed fit.
+///
+/// # FIXME: Having a buffer here should just go away
+///
+/// Until liboscore can work on an arbitrary message, in particular a
+/// `StrippingTheEdhocOptionAndPayloadPart<M>`, we have to create a copy to remove the EDHOC option
+/// and payload. (Conveniently, that also sidesteps the need to `downcast_from` to a type libOSCORE
+/// knows, but that's not why we do it, that's what downcasting would be for.)
+///
+/// Furthermore, we need mutable access (something we can't easily gain by just downcasting).
+const EDHOC_COPY_BUFFER_SIZE: usize = 1152;
 
 /// A pool of security contexts shareable by several users inside a thread.
 type SecContextPool<Crypto, Claims> =
@@ -127,8 +147,8 @@ impl<Crypto: lakers::Crypto, GeneralClaims: generalclaims::GeneralClaims>
             SecContextStage::Empty => None,
             // We're keeping a c_r in there assigned early so that we can find the context when
             // building the response; nothing in the responder is tied to c_r yet.
-            SecContextStage::EdhocResponderProcessedM1 { c_r, .. } => Some(*c_r),
-            SecContextStage::EdhocResponderSentM2 { c_r, .. } => Some(*c_r),
+            SecContextStage::EdhocResponderProcessedM1 { c_r, .. }
+            | SecContextStage::EdhocResponderSentM2 { c_r, .. } => Some(*c_r),
             SecContextStage::Oscore(ctx) => COwn::from_kid(ctx.recipient_id()),
         }
     }
@@ -203,7 +223,7 @@ impl<
         time: TP,
     ) -> Self {
         Self {
-            pool: Default::default(),
+            pool: crate::oluru::OrderedPool::new(),
             inner,
             crypto_factory,
             authorities,
@@ -224,7 +244,7 @@ impl<
                 // C_R does not only need to be unique, it also must not be identical
                 // to C_I. If it is not expressible as a COwn (as_slice gives []),
                 // that's fine and we don't have to consider it.
-                .chain(COwn::from_kid(c_peer).as_slice().iter().cloned()),
+                .chain(COwn::from_kid(c_peer).as_slice().iter().copied()),
         )
     }
 
@@ -232,6 +252,11 @@ impl<
     ///
     /// The caller has already checked Uri-Path and all other critical options, and that the
     /// request was a POST.
+    ///
+    /// # Errors
+    ///
+    /// This produces errors if the input (which is typically received from the network) is
+    /// malformed or contains unsupported items.
     #[allow(
         clippy::type_complexity,
         reason = "Type is subset of RequestData that has no alias in the type"
@@ -296,6 +321,11 @@ impl<
 
     /// Builds an EDHOC response message 2 after successful processing of a request in
     /// [`Self::extract_edhoc()`]
+    ///
+    /// # Errors
+    ///
+    /// This produces errors if the input (which is typically received from the network) is
+    /// malformed or contains unsupported items.
     fn build_edhoc_message_2<M: MutableWritableMessage>(
         &mut self,
         response: &mut M,
@@ -373,20 +403,25 @@ impl<
     }
 
     /// Processes a CoAP request containing an OSCORE option and possibly an EDHOC option.
+    ///
+    /// # Errors
+    ///
+    /// This produces errors if the input (which is typically received from the network) is
+    /// malformed, contains unsupported items, or is too large for the allocated buffers.
     #[allow(
         clippy::type_complexity,
-        reason = "Type is subset of RequestData that has no alias in the type"
+        reason = "type is subset of RequestData that has no alias in the type"
     )]
     fn extract_oscore_edhoc<M: ReadableMessage>(
         &mut self,
         request: &M,
-        oscore_option: OscoreOption,
+        oscore_option: &OscoreOption,
         with_edhoc: bool,
     ) -> Result<OwnRequestData<Result<H::RequestData, H::ExtractRequestError>>, CoAPError> {
         let payload = request.payload();
 
         // We know this to not fail b/c we only got here due to its presence
-        let oscore_option = liboscore::OscoreOption::parse(&oscore_option).map_err(|_| {
+        let oscore_option = liboscore::OscoreOption::parse(oscore_option).map_err(|_| {
             error!("OSCORE option could not be parsed");
             CoAPError::bad_option(coap_numbers::option::OSCORE)
         })?;
@@ -448,16 +483,8 @@ impl<
             return Err(CoAPError::bad_request());
         }
 
-        // Until liboscore can work on an arbitrary message, in particular a
-        // `StrippingTheEdhocOptionAndPayloadPart<M>`, we have to create a copy.
-        // (Conveniently, that also sidesteps the need to `downcast_from` to a type
-        // libOSCORE knows, but that's not why we do it, that's what downcasting would be
-        // for.)
-
-        // embedded-nal-coap uses this max size, and our messages are same size or smaller,
-        // so it's a guaranteed fit.
-        const MAX_SIZE: usize = 1152;
-        let mut read_copy = [0u8; MAX_SIZE];
+        // See comment on EDHOC_COPY_BUFFER_SIZE
+        let mut read_copy = [0u8; EDHOC_COPY_BUFFER_SIZE];
         let mut code_copy = 0;
         let mut copied_message = coap_message_implementations::inmemory_write::Message::new(
             &mut code_copy,
@@ -478,12 +505,18 @@ impl<
             }
             copied_message
                 .add_option(opt.number(), opt.value())
-                .unwrap();
+                .map_err(|_| {
+                    error!("Options produced in unexpected sequence.");
+                    CoAPError::internal_server_error()
+                })?;
         }
         #[allow(clippy::indexing_slicing, reason = "slice fits by construction")]
         copied_message
             .set_payload(&payload[front_trim_payload..])
-            .unwrap();
+            .map_err(|_| {
+                error!("Unexpectedly large EDHOC-less message");
+                CoAPError::internal_server_error()
+            })?;
 
         let decrypted = liboscore::unprotect_request(
             &mut copied_message,
@@ -502,6 +535,7 @@ impl<
         //
         // Storing it even on decryption failure to avoid DoS from the first message (but
         // FIXME, should we increment an error count and lower priority?)
+        #[allow(clippy::used_underscore_binding, reason = "used only in debug asserts")]
         let _evicted = self.pool.force_insert(SecContextState {
             protocol_stage: SecContextStage::Oscore(oscore_context),
             authorization: Some(authorization),
@@ -523,6 +557,16 @@ impl<
 
     /// Processes an EDHOC message 3 at the beginning of a payload, and returns the number of bytes
     /// that were in the message.
+    ///
+    /// # Errors
+    ///
+    /// This produces errors if the input (which is typically received from the network) is
+    /// malformed or contains unsupported items.
+    ///
+    /// # Panics
+    ///
+    /// This panics if cipher suite negotiation passed for a suite whose algorithms are unsupported
+    /// in libOSCORE.
     fn process_edhoc_in_payload(
         &self,
         payload: &[u8],
@@ -646,6 +690,16 @@ impl<
 
     /// Builds an OSCORE response message after successful processing of a request in
     /// [`Self::extract_oscore_edhoc()`].
+    ///
+    /// # Errors
+    ///
+    /// This produces errors if requests are processed in unexpected out-of-order ways.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the writable message is not a
+    /// [`coap_message_implementations::inmemory_write::Message`]. See module level documentation
+    /// for details.
     fn build_oscore_response<M: MutableWritableMessage>(
         &mut self,
         response: &mut M,
@@ -765,6 +819,11 @@ impl<
     /// This assumes that the content format was pre-checked to be application/ace+cbor, both in
     /// Content-Format and Accept (absence is fine too), no other critical options are present,
     /// and the code was POST.
+    ///
+    /// # Errors
+    ///
+    /// This produces errors if the input (which is typically received from the network) is
+    /// malformed or contains unsupported items.
     fn extract_token(
         &mut self,
         payload: &[u8],
@@ -957,6 +1016,7 @@ impl<
     type BuildResponseError<M: MinimalWritableMessage> =
         OrInner<Result<CoAPError, M::UnionError>, H::BuildResponseError<M>>;
 
+    #[expect(clippy::too_many_lines, reason = "no good refactoring point known")]
     fn extract_request_data<M: ReadableMessage>(
         &mut self,
         request: &M,
@@ -1113,7 +1173,7 @@ impl<
                     // unreachable when HAS_EDHOC is not set.
                     unreachable!("State is not constructed");
                 }
-                self.extract_oscore_edhoc(&request, oscore, true)
+                self.extract_oscore_edhoc(&request, &oscore, true)
                     .map(Own)
                     .map_err(Own)
             }
@@ -1121,7 +1181,7 @@ impl<
                 if !has_oscore::<SSC>() {
                     unreachable!("State is not constructed");
                 }
-                self.extract_oscore_edhoc(&request, oscore, false)
+                self.extract_oscore_edhoc(&request, &oscore, false)
                     .map(Own)
                     .map_err(Own)
             }

--- a/src/lib/coapcore/src/time.rs
+++ b/src/lib/coapcore/src/time.rs
@@ -35,7 +35,7 @@ impl<T: TimeProvider> TimeProvider for &mut T {
     }
 
     fn past_trusted(&mut self, timestamp: u64) {
-        (*self).past_trusted(timestamp)
+        (*self).past_trusted(timestamp);
     }
 }
 
@@ -61,6 +61,7 @@ pub struct TimeConstraint {
 
 impl TimeConstraint {
     /// Creates a [`TimeConstraint`] with no bounds; it is valid at any time.
+    #[must_use]
     pub fn unbounded() -> Self {
         Self { exp: None }
     }
@@ -69,6 +70,7 @@ impl TimeConstraint {
     ///
     /// This is infallible as long as all relevant constraints on the value can be encoded in the
     /// ace module; doing that is preferable because it eases error tracking.
+    #[must_use]
     pub fn from_claims_set(claims: &crate::ace::CwtClaimsSet<'_>) -> Self {
         TimeConstraint {
             exp: Some(claims.exp),


### PR DESCRIPTION
# Description

In https://github.com/ariel-os/ariel-os/pull/886#discussion_r1979639409 the coapcore crate was exempted from the pedantic lints. While I disagree with many of them, having a big exception hover here is not great either. (And I have to admit that a few of those even improve the code).

## Issues/PRs references

Blocked by https://github.com/ariel-os/ariel-os/pull/865 as that is bound to produce conflicts once I fix "documentation missing" errors.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.
