### PR TITLE
feat(stm32): add support for non-`USB_LP` USB drivers

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -392,7 +392,7 @@ contexts:
       PROBE_RS_PROTOCOL: swd
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
-        - --cfg capability=\"hw/stm32-usb\"
+        - --cfg capability=\"hw/stm32-usb-lp\"
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.
         - CONFIG_SWI=LPUART1

--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -45,7 +45,7 @@ pub mod hwrng;
 
 #[cfg(feature = "usb")]
 cfg_if::cfg_if! {
-    if #[cfg(capability = "hw/stm32-usb")] {
+    if #[cfg(any(capability = "hw/stm32-usb", capability = "hw/stm32-usb-lp"))] {
         #[doc(hidden)]
         #[path = "usb.rs"]
         pub mod usb;

--- a/src/ariel-os-stm32/src/usb.rs
+++ b/src/ariel-os-stm32/src/usb.rs
@@ -1,6 +1,9 @@
 use embassy_stm32::{bind_interrupts, peripherals, usb, usb::Driver};
 
 bind_interrupts!(struct Irqs {
+    #[cfg(capability = "hw/stm32-usb")]
+    USB => usb::InterruptHandler<peripherals::USB>;
+    #[cfg(capability = "hw/stm32-usb-lp")]
     USB_LP => usb::InterruptHandler<peripherals::USB>;
 });
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This accommodates STM32 MCUs which use a `USB` interrupt instead of a `USB_LP` interrupt (e.g, the [STM32L433CC is one such MCU](https://docs.embassy.dev/embassy-stm32/git/stm32l433cc/interrupt/typelevel/index.html)).
This renames the existing `stm32-usb` laze capability to `stm32-usb-lp`; I'm of the opinion that this is not a breaking change as we weren't documenting this capability.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
This is not intended to be as complete as #911, support for other USB interrupts will be introduced later.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
