### PR TITLE
ci(cargo-test): enable `rust-cache` for the `cargo-test` job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install prerequisites
         run: sudo apt-get install ninja-build gcc-arm-none-eabi
 
+      - name: rust cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Run host-side crate tests
         run: laze build --builders host --multiple-tasks --global --keep-going=0 test
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Running the `cargo-test` job twice (the first time to initialize the cache, the second time to test it), this brings its execution time from about 4 min 30 s down to 3 min 15 s. Installing the apt dependencies takes about 1 min 20 s and compiling liboscore takes 40 s.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #846.

## Open Questions

<!-- Unresolved questions, if any. -->
Is it worth it?

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
