### PR TITLE
refactor: rename `SendCell` to `SameExecutorCell`

### DIFF
--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -18,7 +18,7 @@ mod udp_nal;
 mod stored;
 
 use ariel_os_debug::log::info;
-use ariel_os_embassy::sendcell::SendCell;
+use ariel_os_embassy::cell::SameExecutorCell;
 use coap_handler_implementations::ReportingHandlerBuilder;
 use embassy_net::udp::{PacketMetadata, UdpSocket};
 use embassy_sync::watch::Watch;
@@ -28,7 +28,7 @@ const CONCURRENT_REQUESTS: usize = 3;
 
 static CLIENT_READY: Watch<
     embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex,
-    SendCell<&'static embedded_nal_coap::CoAPRuntimeClient<'static, CONCURRENT_REQUESTS>>,
+    SameExecutorCell<&'static embedded_nal_coap::CoAPRuntimeClient<'static, CONCURRENT_REQUESTS>>,
     1,
 > = Watch::new();
 
@@ -187,7 +187,7 @@ async fn coap_run_impl(handler: impl coap_handler::Handler + coap_handler::Repor
 
     CLIENT_READY
         .sender()
-        .send(SendCell::new_async(&*CLIENT.init(client)).await);
+        .send(SameExecutorCell::new_async(&*CLIENT.init(client)).await);
 
     server
         .run(

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -95,8 +95,8 @@ cfg_if::cfg_if! {
 pub use net::NetworkStack;
 
 pub mod asynch;
+pub mod cell;
 pub mod delegate;
-pub mod sendcell;
 
 #[cfg(feature = "executor-thread")]
 pub mod thread_executor;
@@ -289,7 +289,7 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
         use embassy_net::StackResources;
         use static_cell::StaticCell;
 
-        use crate::sendcell::SendCell;
+        use crate::cell::SameExecutorCell;
 
         const MAX_CONCURRENT_SOCKETS: usize = ariel_os_utils::usize_from_env_or!(
             "CONFIG_NETWORK_MAX_CONCURRENT_SOCKETS",
@@ -320,7 +320,7 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
         spawner.spawn(net::net_task(runner)).unwrap();
 
         if crate::net::STACK
-            .init(SendCell::new(stack, spawner))
+            .init(SameExecutorCell::new(stack, spawner))
             .is_err()
         {
             unreachable!();

--- a/src/ariel-os-embassy/src/net.rs
+++ b/src/ariel-os-embassy/src/net.rs
@@ -9,7 +9,7 @@
 use embassy_net::{Runner, Stack};
 use embassy_sync::once_lock::OnceLock;
 
-use crate::{sendcell::SendCell, NetworkDevice};
+use crate::{cell::SameExecutorCell, NetworkDevice};
 
 #[allow(dead_code)]
 pub(crate) const ETHERNET_MTU: usize = 1514;
@@ -19,7 +19,7 @@ pub(crate) const ETHERNET_MTU: usize = 1514;
 /// Required to create a UDP or TCP socket.
 pub type NetworkStack = Stack<'static>;
 
-pub(crate) static STACK: OnceLock<SendCell<NetworkStack>> = OnceLock::new();
+pub(crate) static STACK: OnceLock<SameExecutorCell<NetworkStack>> = OnceLock::new();
 
 /// Returns a new [`NetworkStack`].
 ///


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Renames `SendCell` to `SameExecutorCell`, and the `ariel_os_embassy::sendcell` module to `cell` as discussed a few weeks ago.
This is not a breaking change as neither the `ariel_os_embassy::cell` module (formerly `sendcell`) nor the `SameExecutorCell` cell (formerly `SendCell`) are documented (on purpose).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
