### PR TITLE
feat(coap): express unauthenticated credentials

### DIFF
--- a/src/ariel-os-coap/src/stored.rs
+++ b/src/ariel-os-coap/src/stored.rs
@@ -43,6 +43,10 @@ impl ServerSecurityConfig for StoredPolicy {
         }
         None
     }
+
+    fn nosec_authorization(&self) -> Option<Self::GeneralClaims> {
+        flash_peers::unauthenticated_scope().map(|scope| StoredClaims { scope })
+    }
 }
 
 /// Generates a private key and some credential matching it.

--- a/src/ariel-os-coap/src/stored.rs
+++ b/src/ariel-os-coap/src/stored.rs
@@ -41,6 +41,16 @@ impl ServerSecurityConfig for StoredPolicy {
                 return Some((credential, StoredClaims { scope }));
             }
         }
+
+        // FIXME: This should be a default behavior -- but should it be part of a utility function
+        // for expand_id_cred_x, or should it be where that is called?
+        if let Some(credential_by_value) = id_cred_x.get_ccs() {
+            if let Some(unauthorized_claims) = self.nosec_authorization() {
+                #[expect(clippy::clone_on_copy, reason = "Lakers items are overly copy happy")]
+                return Some((credential_by_value.clone(), unauthorized_claims));
+            }
+        }
+
         None
     }
 

--- a/tests/coap/README.md
+++ b/tests/coap/README.md
@@ -33,9 +33,15 @@ This application is a work in progress demo of running CoAP with OSCORE/EDHOC se
       <!-- FIXME: should be trivial after https://github.com/knurling-rs/defmt/pull/916 -->
       after running the hex values there through https://cbor.me's bytes to diagnostic converter.
 
-    The build system now reads `peers.yml`, which currently encodes the same authorization for the demo key as the demo setup,
+    The build system now reads `peers.yml`, which currently encodes similar authorizations for the demo key as the demo setup,
     but in a user configurable way:
     You can add your own private key there, or replace the demo key, and configure resources that should be accessible.
+
+    That file also describes that unauthenticated users may access the `/poem` resource.
+    You can access that in an unauthenticated way by running aiocoap without `--credentials` as in NoSec mode.
+    You can also access them over an encrypted connection:
+    Remove the `own_cred`, `own_cred_style` and `private_key_file` from `client.diag` and replace them with `"own_cred": {"unauthenticated": true}`.
+    Now, the request is encrypted, and the client tool verifies the server's identity without identifying itself.
 
     Instead of using a hard-coded key, the device generates one at first startup,
     and reports the credential that contains its public key in the standard output.

--- a/tests/coap/peers.yml
+++ b/tests/coap/peers.yml
@@ -3,6 +3,14 @@
 # <https://ariel-os.github.io/ariel-os/dev/docs/book/tooling/coap.html#outlook-interacting-with-an-ariel-os-coap-server-from-the-host>);
 # the general gist is that it lists who may do what on the device.
 
+- from: unauthenticated
+  scope:
+    # Authorizations assigned to matching clients (here: everyone). Keys are
+    # paths on the device, values are single or lists of CoAP methods that may
+    # be performed.
+    /.well-known/core: GET
+    /poem: GET
+
 - kccs: |
     # The CWT Claims Set that needs to be used (by value or by reference) by
     # the client to gain access to the device.
@@ -10,13 +18,5 @@
     # It is expressed in CBOR diagnostic notation (which at the YAML level is
     # just a string), and compatible with aiocoap's credentials.
     {2: "42-50-31-FF-EF-37-32-39", 8: {1: {1: 2, 2: h'2b', -1: 1, -2: h'ac75e9ece3e50bfc8ed60399889522405c47bf16df96660a41298cb4307f7eb6', -3: h'6e5de611388a4b8a8211334ac7d37ecb52a387d257e6db3c2a93df21ff3affc8'}}}
-  scope:
-    # Authorizations assigned to clients authenticating with the credential
-    # above. Keys are paths on the device, values are single or lists of CoAP
-    # methods that may be performed.
-    #
-    # Instead of a dictionary, the scope can also be a single string
-    # "allow-all".
-    /stdout: [GET, FETCH]
-    /.well-known/core: GET
-    /poem: GET
+  # This simple alternative to per-resource permission allows all requests.
+  scope: allow-all


### PR DESCRIPTION
# Description

Users can't utilize all the coapcore facilities from ariel-os-coap yet; this one addresses giving authorizations to an unauthenticated user.

Note that this doesn't necessarily mean "insecure": Such a client could be given read-only access to a resource, and while any client can choose to go insecure, they can also start EDHOC with a KCCS, verify the server's identity, and it's about just as confidential as HTTPS (nobody other than the client and server knows what is going on precisely).

## Issues/PRs references

Closes: #900

## Testing

* Go to tests/coap, and follow the README step by step.

## Open Questions

* Should we make it easy to pull in "whatever Ariel OS thinks should be allowed" more easily? That's best answered when we actually do have OS provided services.
* Should we add a way to express "do anything but just read-only"? Probably can be done later when we have a good example (possibly on OS provided services).

## Change checklist

- [ ] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation. (**Here this means mainly the READMEs**)