### PR TITLE
ci: pin laze version to 0.1.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
         uses: taiki-e/install-action@v2
         if: steps.result-cache.outputs.cache-hit != 'true'
         with:
-          tool: laze
+          tool: laze@0.1
 
       - name: "installing prerequisites"
         if: steps.result-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install laze
         uses: taiki-e/install-action@v2
         with:
-          tool: laze
+          tool: laze@0.1
 
       - name: Install prerequisites
         run: sudo apt-get install ninja-build gcc-arm-none-eabi


### PR DESCRIPTION
# Description

This is pinning laze to 0.1.x so when it might release a breaking change, our CI doesn't break.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
