### PR TITLE
docs(logo): Use paths and not text in logo

### DIFF
--- a/book/src/figures/ariel-hexacube-orange-rounded.svg
+++ b/book/src/figures/ariel-hexacube-orange-rounded.svg
@@ -1,43 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
    version="1.2"
-   viewBox="0 0 8536 8936.1553"
+   viewBox="0 0 7689.6731 8536.1566"
    preserveAspectRatio="xMidYMid"
    fill-rule="evenodd"
    stroke-width="28.222"
    stroke-linejoin="round"
    xml:space="preserve"
    id="svg5971"
-   width="650"
-   height="680"
-   sodipodi:docname="Ariel-HexaCube-brick (rounded) (small).svg"
-   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
-   inkscape:export-filename="Ariel-HexaCube-brick (rounded) (small export).svg"
-   inkscape:export-xdpi="7.3102155"
-   inkscape:export-ydpi="7.3102155"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   width="585.55383"
+   height="649.56195"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:ooo="http://xml.openoffice.org/svg/export"><sodipodi:namedview
-   id="namedview126"
-   pagecolor="#ffffff"
-   bordercolor="#000000"
-   borderopacity="0.25"
-   inkscape:showpageshadow="2"
-   inkscape:pageopacity="0.0"
-   inkscape:pagecheckerboard="0"
-   inkscape:deskcolor="#d1d1d1"
-   showgrid="false"
-   inkscape:zoom="0.030790089"
-   inkscape:cx="4222.1378"
-   inkscape:cy="5423.8232"
-   inkscape:window-width="1920"
-   inkscape:window-height="1085"
-   inkscape:window-x="0"
-   inkscape:window-y="1112"
-   inkscape:window-maximized="1"
-   inkscape:current-layer="svg5971" />
+   xmlns:ooo="http://xml.openoffice.org/svg/export">
  <defs
    id="presentation-animations"><clipPath
      clipPathUnits="userSpaceOnUse"
@@ -59,7 +34,7 @@
  
 <g
    id="layer1"
-   transform="translate(370.1806,102.5454)"
+   transform="translate(-2.9565809,-71.870599)"
    clip-path="url(#clipPath3986)"><g
      style="fill-rule:evenodd;stroke-width:28.222;stroke-linejoin:round"
      id="g13827"
@@ -162,242 +137,6 @@
       </g>
      </g></g><g
      style="fill-rule:evenodd;stroke-width:28.222;stroke-linejoin:round"
-     id="g21149"
-     transform="matrix(1.6132692,0,0,1.8298837,-20336.465,-10870.989)"><g
-       class="Page"
-       id="g20963"
-       style="fill-rule:evenodd;stroke-width:28.222;stroke-linejoin:round">
-      <g
-   ooo:text-adjust="center"
-   class="TextShape"
-   id="g20888">
-       <g
-   id="id6-0">
-        <rect
-   class="BoundingBox"
-   stroke="none"
-   fill="none"
-   x="13778"
-   y="7721"
-   width="1525"
-   height="1776"
-   id="rect20877" />
-        <text
-   class="SVGTextShape"
-   id="text20885"><tspan
-     class="TextParagraph"
-     id="tspan20883"><tspan
-       class="TextPosition"
-       x="14028"
-       y="8942"
-       id="tspan20881"><tspan
-         font-family="'URW Gothic', sans-serif"
-         font-size="1482px"
-         font-weight="400"
-         fill="#eeeeee"
-         stroke="none"
-         style="white-space:pre"
-         id="tspan20879">R</tspan></tspan></tspan></text>
-       </g>
-      </g>
-      <g
-   ooo:text-adjust="center"
-   class="TextShape"
-   id="g20901">
-       <g
-   id="id7-8">
-        <rect
-   class="BoundingBox"
-   stroke="none"
-   fill="none"
-   x="14678"
-   y="7721"
-   width="1525"
-   height="1777"
-   id="rect20890" />
-        <text
-   class="SVGTextShape"
-   id="text20898"><tspan
-     class="TextParagraph"
-     id="tspan20896"><tspan
-       class="TextPosition"
-       x="14928"
-       y="8942"
-       id="tspan20894"><tspan
-         font-family="'URW Gothic', sans-serif"
-         font-size="1482px"
-         font-weight="400"
-         fill="#eeeeee"
-         stroke="none"
-         style="white-space:pre"
-         id="tspan20892">i</tspan></tspan></tspan></text>
-       </g>
-      </g>
-      <g
-   ooo:text-adjust="center"
-   class="TextShape"
-   id="g20914">
-       <g
-   id="id8-5">
-        <rect
-   class="BoundingBox"
-   stroke="none"
-   fill="none"
-   x="14778"
-   y="7722"
-   width="1525"
-   height="1776"
-   id="rect20903" />
-        <text
-   class="SVGTextShape"
-   id="text20911"><tspan
-     class="TextParagraph"
-     id="tspan20909"><tspan
-       class="TextPosition"
-       x="15028"
-       y="8943"
-       id="tspan20907"><tspan
-         font-family="'URW Gothic', sans-serif"
-         font-size="1482px"
-         font-weight="400"
-         fill="#eeeeee"
-         stroke="none"
-         style="white-space:pre"
-         id="tspan20905">E</tspan></tspan></tspan></text>
-       </g>
-      </g>
-      <g
-   ooo:text-adjust="center"
-   class="TextShape"
-   id="g20927">
-       <g
-   id="id9-0">
-        <rect
-   class="BoundingBox"
-   stroke="none"
-   fill="none"
-   x="15545"
-   y="7722"
-   width="1525"
-   height="1777"
-   id="rect20916" />
-        <text
-   class="SVGTextShape"
-   id="text20924"><tspan
-     class="TextParagraph"
-     id="tspan20922"><tspan
-       class="TextPosition"
-       x="15795"
-       y="8943"
-       id="tspan20920"><tspan
-         font-family="'URW Gothic', sans-serif"
-         font-size="1482px"
-         font-weight="400"
-         fill="#eeeeee"
-         stroke="none"
-         style="white-space:pre"
-         id="tspan20918">L</tspan></tspan></tspan></text>
-       </g>
-      </g>
-      <g
-   class="com.sun.star.drawing.CustomShape"
-   id="g20934">
-       <g
-   id="id10">
-        <rect
-   class="BoundingBox"
-   stroke="none"
-   fill="none"
-   x="14124"
-   y="7720"
-   width="255"
-   height="1525"
-   id="rect20929" />
-        <path
-   fill="#d94b26"
-   stroke="none"
-   d="m 14251,9244 h -127 V 7720 h 254 v 1524 z"
-   id="path20931" />
-       </g>
-      </g>
-      <g
-   class="com.sun.star.drawing.CustomShape"
-   id="g20941">
-       <g
-   id="id11">
-        <rect
-   class="BoundingBox"
-   stroke="none"
-   fill="none"
-   x="15124"
-   y="7720"
-   width="171"
-   height="1525"
-   id="rect20936" />
-        <path
-   fill="#d94b26"
-   stroke="none"
-   d="m 15209,9244 h -85 V 7720 h 170 v 1524 z"
-   id="path20938" />
-       </g>
-      </g>
-      <g
-   ooo:text-adjust="center"
-   class="TextShape"
-   id="g20954">
-       <g
-   id="id12">
-        <rect
-   class="BoundingBox"
-   stroke="none"
-   fill="none"
-   x="13054"
-   y="7720"
-   width="1525"
-   height="1777"
-   id="rect20943" />
-        <text
-   class="SVGTextShape"
-   id="text20951"><tspan
-     class="TextParagraph"
-     id="tspan20949"><tspan
-       class="TextPosition"
-       x="13304"
-       y="8941"
-       id="tspan20947"><tspan
-         font-family="'URW Gothic', sans-serif"
-         font-size="1482px"
-         font-style="italic"
-         font-weight="400"
-         fill="#eeeeee"
-         stroke="none"
-         style="white-space:pre"
-         id="tspan20945">A</tspan></tspan></tspan></text>
-       </g>
-      </g>
-      <g
-   class="com.sun.star.drawing.CustomShape"
-   id="g20961">
-       <g
-   id="id13">
-        <rect
-   class="BoundingBox"
-   stroke="none"
-   fill="none"
-   x="15124"
-   y="7720"
-   width="171"
-   height="1525"
-   id="rect20956" />
-        <path
-   fill="#d94b26"
-   stroke="none"
-   d="m 15209,9244 h -85 V 7720 h 170 v 1524 z"
-   id="path20958" />
-       </g>
-      </g>
-     </g></g><g
-     style="fill-rule:evenodd;stroke-width:28.222;stroke-linejoin:round"
      id="g21149-3"
      transform="matrix(1.6132692,0,0,1.8298837,-20336.465,-10870.989)"><g
        style="fill-rule:evenodd;stroke-width:28.222;stroke-linejoin:round"
@@ -416,22 +155,12 @@
    width="1525"
    height="1776"
    id="rect20877-9" />
-        <text
+        <path
+   d="m 14560.038,8532.968 c 210.444,-22.23 323.076,-137.826 323.076,-334.932 0,-136.344 -57.798,-240.084 -164.502,-297.882 -68.172,-37.05 -161.538,-53.352 -306.774,-53.352 h -271.206 V 8942 h 109.668 v -995.904 h 154.128 c 115.596,0 192.66,11.856 251.94,40.014 74.1,35.568 115.596,109.668 115.596,208.962 0,124.488 -56.316,203.034 -165.984,231.192 -51.87,13.338 -123.006,19.266 -244.53,19.266 l 369.018,496.47 h 136.344 z"
+   id="text20885-1"
+   aria-label="R"
    class="SVGTextShape"
-   id="text20885-1"><tspan
-     class="TextParagraph"
-     id="tspan20883-2"><tspan
-       class="TextPosition"
-       x="14028"
-       y="8942"
-       id="tspan20881-7"><tspan
-         font-family="'URW Gothic', sans-serif"
-         font-size="1482px"
-         font-weight="400"
-         fill="#eeeeee"
-         stroke="none"
-         style="white-space:pre"
-         id="tspan20879-0">R</tspan></tspan></tspan></text>
+   style="font-size:1482px;font-family:'URW Gothic', sans-serif;white-space:pre;fill:#eeeeee" />
        </g>
       </g>
       <g
@@ -449,22 +178,12 @@
    width="1525"
    height="1777"
    id="rect20890-6" />
-        <text
+        <path
+   d="m 15021.366,8942 h 109.668 v -810.654 h -109.668 z m 0,-908.466 h 109.668 v -186.732 h -109.668 z"
+   id="text20898-0"
+   style="font-size:1482px;font-family:'URW Gothic', sans-serif;white-space:pre;fill:#eeeeee"
    class="SVGTextShape"
-   id="text20898-0"><tspan
-     class="TextParagraph"
-     id="tspan20896-6"><tspan
-       class="TextPosition"
-       x="14928"
-       y="8942"
-       id="tspan20894-2"><tspan
-         font-family="'URW Gothic', sans-serif"
-         font-size="1482px"
-         font-weight="400"
-         fill="#eeeeee"
-         stroke="none"
-         style="white-space:pre"
-         id="tspan20892-6">i</tspan></tspan></tspan></text>
+   aria-label="i" />
        </g>
       </g>
       <g
@@ -482,22 +201,12 @@
    width="1525"
    height="1776"
    id="rect20903-7" />
-        <text
+        <path
+   d="m 15140.632,8943 h 598.728 v -99.294 H 15250.3 V 8439.12 h 472.758 v -99.294 H 15250.3 v -392.73 h 489.06 v -99.294 h -598.728 z"
+   id="text20911-9"
+   style="font-size:1482px;font-family:'URW Gothic', sans-serif;white-space:pre;fill:#eeeeee"
    class="SVGTextShape"
-   id="text20911-9"><tspan
-     class="TextParagraph"
-     id="tspan20909-2"><tspan
-       class="TextPosition"
-       x="15028"
-       y="8943"
-       id="tspan20907-0"><tspan
-         font-family="'URW Gothic', sans-serif"
-         font-size="1482px"
-         font-weight="400"
-         fill="#eeeeee"
-         stroke="none"
-         style="white-space:pre"
-         id="tspan20905-2">E</tspan></tspan></tspan></text>
+   aria-label="E" />
        </g>
       </g>
       <g
@@ -515,22 +224,12 @@
    width="1525"
    height="1777"
    id="rect20916-5" />
-        <text
+        <path
+   d="m 15907.632,8943 h 563.16 v -99.294 H 16017.3 v -995.904 h -109.668 z"
+   id="text20924-9"
+   style="font-size:1482px;font-family:'URW Gothic', sans-serif;white-space:pre;fill:#eeeeee"
    class="SVGTextShape"
-   id="text20924-9"><tspan
-     class="TextParagraph"
-     id="tspan20922-2"><tspan
-       class="TextPosition"
-       x="15795"
-       y="8943"
-       id="tspan20920-2"><tspan
-         font-family="'URW Gothic', sans-serif"
-         font-size="1482px"
-         font-weight="400"
-         fill="#eeeeee"
-         stroke="none"
-         style="white-space:pre"
-         id="tspan20918-8">L</tspan></tspan></tspan></text>
+   aria-label="L" />
        </g>
       </g>
       <g
@@ -590,23 +289,12 @@
    width="1525"
    height="1777"
    id="rect20943-4" />
-        <text
+        <path
+   d="m 13320.302,8941 h 115.596 l 228.228,-369.018 h 509.808 l 90.402,369.018 h 120.042 l -268.242,-1095.198 h -123.006 z m 404.586,-468.312 306.774,-502.398 118.56,502.398 z"
+   id="text20951-7"
+   style="font-style:italic;font-size:1482px;font-family:'URW Gothic', sans-serif;white-space:pre;fill:#eeeeee"
    class="SVGTextShape"
-   id="text20951-7"><tspan
-     class="TextParagraph"
-     id="tspan20949-8"><tspan
-       class="TextPosition"
-       x="13304"
-       y="8941"
-       id="tspan20947-4"><tspan
-         font-family="'URW Gothic', sans-serif"
-         font-size="1482px"
-         font-style="italic"
-         font-weight="400"
-         fill="#eeeeee"
-         stroke="none"
-         style="white-space:pre"
-         id="tspan20945-5">A</tspan></tspan></tspan></text>
+   aria-label="A" />
        </g>
       </g>
       <g


### PR DESCRIPTION
# Description

Prevents issues where the logo is not accurate when the viewer is missing the fonts on the local computer

## Issues/PRs references

follow-up to #901 

Test by viewing the new logo on a device with limited fonts, such as an android based device.

## Open Questions


## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
