### PR TITLE
docs(book): Add macOS to getting started

### DIFF
--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -3,20 +3,25 @@
 This guide is intended to get you started in about 5 minutes.
 It explains how to compile and run the `hello-word` example to verify your setup, and how to bootstrap a new application.
 
-> Currently only GNU/Linux is supported in this guide.
-
 ## Installing the build prerequisites
 
 1. Install the needed build dependencies.
-   On Ubuntu, the following is sufficient:
+
+    **Ubuntu (GNU/Linux)**
 
    <!-- gcc and curl are only required for espup, but it doesn't hurt to install those here. -->
 
     ```sh
-    apt install git rustup ninja-build pkg-config libudev-dev clang gcc-arm-none-eabi gcc-riscv64-unknown-elf gcc curl
+    apt install git ninja-build pkg-config libudev-dev clang gcc-arm-none-eabi gcc-riscv64-unknown-elf gcc curl
     ```
 
-1. Install the Rust installer [rustup](https://rustup.rs/) using the website's instructions or through your distribution package manager.
+    **macOS (Apple Silicon)**
+
+    ```sh
+    brew install git ninja pkg-config llvm gcc curl
+    ```
+
+1. Install the Rust installer [rustup](https://rustup.rs/) using the website's instructions.
 
 1. Only for using ESP devices, install [espup](https://github.com/esp-rs/espup) and related tools:
 


### PR DESCRIPTION
# Description
This PR adds instructions for getting started with Ariel-OS on macOS. I built the `hello-world` example for all available boards and found that `gcc-arm-none-eabi` and `gcc-riscv64-unknown-elf` were not required, so I removed them from the macOS install command. 

Additionally, I made minor adjustments to the `rustup` installation commands since it was listed twice—once in step 1 and again in step 2. I also believe the recommended installation method is via the official website.


<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references
#906 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->




