### PR TITLE
feat(stm32): introduce laze capabilities for all HWRNG interrupts

### DIFF
--- a/src/ariel-os-stm32/src/hwrng.rs
+++ b/src/ariel-os-stm32/src/hwrng.rs
@@ -4,14 +4,19 @@ use embassy_stm32::{bind_interrupts, peripherals, rng};
 #[cfg(not(any(capability = "hw/stm32-hash-rng", capability = "hw/stm32-rng")))]
 compile_error!("no stm32 RNG capability enabled");
 
-#[cfg(capability = "hw/stm32-hash-rng")]
 bind_interrupts!(struct Irqs {
+    #[cfg(capability = "hw/stm32-aes-rng")]
+    AES_RNG => rng::InterruptHandler<peripherals::RNG>;
+    #[cfg(capability = "hw/stm32-aes-rng-lpuart1")]
+    AES_RNG_LPUART1 => rng::InterruptHandler<peripherals::RNG>;
+    #[cfg(capability = "hw/stm32-hash-rng")]
     HASH_RNG => rng::InterruptHandler<peripherals::RNG>;
-});
-
-#[cfg(capability = "hw/stm32-rng")]
-bind_interrupts!(struct Irqs {
+    #[cfg(capability = "hw/stm32-rng")]
     RNG => rng::InterruptHandler<peripherals::RNG>;
+    #[cfg(capability = "hw/stm32-rng-cryp")]
+    RNG_CRYP => rng::InterruptHandler<peripherals::RNG>;
+    #[cfg(capability = "hw/stm32-rng-lpuart1")]
+    RNG_LPUART1 => rng::InterruptHandler<peripherals::RNG>;
 });
 
 pub fn construct_rng(peripherals: &mut crate::OptionalPeripherals) {


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This introduces laze capabilities for what I believe is the entirety of the currently existing STM32 HWRNG/TRNG interrupts. These were obtained by grepping the JSON files from [stm32-data-generated](https://github.com/embassy-rs/stm32-data-generated/tree/main/data/chips) for `interrupt": "[^"]*RNG` and then manually checking in the JSON files that these interrupts were indeed used for the peripheral of name "RNG".

The new interrupts are for STM32 MCUs we do not currently support, but this is preliminary work to make it easier to support all of them later.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Similar to #889.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
