### PR TITLE
refactor(laze): expose `cortex-m*` modules as `cfg` flags

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -481,31 +481,55 @@ modules:
     selects:
       - cortex-m
       - thumbv6m-none-eabi
+    env:
+      global:
+        RUSTFLAGS:
+          - --cfg context=\"cortex-m0\"
 
   - name: cortex-m0-plus
     selects:
       - cortex-m
       - thumbv6m-none-eabi
+    env:
+      global:
+        RUSTFLAGS:
+          - --cfg context=\"cortex-m0-plus\"
 
   - name: cortex-m4
     selects:
       - cortex-m
       - thumbv7em-none-eabi
+    env:
+      global:
+        RUSTFLAGS:
+          - --cfg context=\"cortex-m4\"
 
   - name: cortex-m4f
     selects:
       - cortex-m
       - thumbv7em-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
+    env:
+      global:
+        RUSTFLAGS:
+          - --cfg context=\"cortex-m4f\"
 
   - name: cortex-m7f
     selects:
       - cortex-m
       - thumbv7em-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
+    env:
+      global:
+        RUSTFLAGS:
+          - --cfg context=\"cortex-m7f\"
 
   - name: cortex-m33f
     selects:
       - cortex-m
       - thumbv8m.main-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
+    env:
+      global:
+        RUSTFLAGS:
+          - --cfg context=\"cortex-m33f\"
 
   - name: xtensa
     env:

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -22,9 +22,12 @@ rustflags = "0.1"
 cortex-m = { workspace = true }
 cortex-m-rt = { workspace = true }
 
+# No CAS instructions on Cortex-M0+.
+[target.'cfg(context = "cortex-m0-plus")'.dependencies]
+portable-atomic = { workspace = true, features = ["critical-section"] }
+
 [target.'cfg(context = "rp")'.dependencies]
 embassy-rp = { workspace = true, optional = true }
-portable-atomic = { workspace = true, features = ["critical-section"] }
 
 [target.'cfg(context = "esp")'.dependencies]
 esp-hal = { workspace = true, default-features = false }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This exposes `cortex-m*` modules introduced in #882 as `cfg` flags, and use this in `ariel-os-rt` to enable `critical-section`-emulated CAS operations on Cortex-M0+.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
