### PR TITLE
fix(task-macro): avoid the need for importing `UsbBuilderHook`

### DIFF
--- a/src/ariel-os-macros/src/task.rs
+++ b/src/ariel-os-macros/src/task.rs
@@ -185,9 +185,9 @@ mod task {
             }
         }
 
-        pub fn type_name(&self) -> &'static str {
+        pub fn type_path(&self) -> proc_macro2::TokenStream {
             match self {
-                Self::UsbBuilder => "UsbBuilderHook",
+                Self::UsbBuilder => quote::quote!{ usb::UsbBuilderHook },
             }
         }
 
@@ -244,7 +244,7 @@ mod task {
 
             let delegate_ident = kind.delegate_ident();
 
-            let type_name = format_ident!("{}", kind.type_name());
+            let type_path = kind.type_path();
             let delegate_hook_ident = format_ident!("{delegate_ident}");
             let delegate_hook_ref_ident = format_ident!("{delegate_ident}_REF");
 
@@ -254,7 +254,7 @@ mod task {
 
                 #[#ariel_os_crate::reexports::linkme::distributed_slice(#distributed_slice_type)]
                 #[linkme(crate=#ariel_os_crate::reexports::linkme)]
-                    static #delegate_hook_ref_ident: #type_name = &#delegate_hook_ident;
+                    static #delegate_hook_ref_ident: #ariel_os_crate::#type_path = &#delegate_hook_ident;
                 }
             }
         );


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Uses a full path to the `ariel-os` crate instead of expecting the `UsbBuilderHook` to be in scope.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
