### PR TITLE
feat(stm32): add support for low-priority USB interrupts

### DIFF
--- a/src/ariel-os-stm32/src/usb.rs
+++ b/src/ariel-os-stm32/src/usb.rs
@@ -3,8 +3,18 @@ use embassy_stm32::{bind_interrupts, peripherals, usb, usb::Driver};
 bind_interrupts!(struct Irqs {
     #[cfg(capability = "hw/stm32-usb")]
     USB => usb::InterruptHandler<peripherals::USB>;
+    #[cfg(capability = "hw/stm32-usb-drd-fs")]
+    USB_DRD_FS => usb::InterruptHandler<peripherals::USB>;
+    #[cfg(capability = "hw/stm32-usb-fs")]
+    USB_FS => usb::InterruptHandler<peripherals::USB>;
     #[cfg(capability = "hw/stm32-usb-lp")]
     USB_LP => usb::InterruptHandler<peripherals::USB>;
+    #[cfg(capability = "hw/stm32-usb-lp-can1-rx0")]
+    USB_LP_CAN1_RX0 => usb::InterruptHandler<peripherals::USB>;
+    #[cfg(capability = "hw/stm32-usb-lp-can-rx0")]
+    USB_LP_CAN_RX0 => usb::InterruptHandler<peripherals::USB>;
+    #[cfg(capability = "hw/stm32-usb-ucpd1-2")]
+    USB_UCPD1_2 => usb::InterruptHandler<peripherals::USB>;
 });
 
 pub type UsbDriver = Driver<'static, peripherals::USB>;


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Introduces new laze capabilities for what I believe is every *low-priority* USB interrupts.
These were obtained by grepping the JSON files from [stm32-data-generated](https://github.com/embassy-rs/stm32-data-generated/tree/main/data/chips) for `interrupt": "[^"]*USB` and then manually checking in the JSON files that these interrupts were indeed used for the peripheral of name "USB" for the LP (low-priority) signal.

High-priority and wake-up interrupts are out of scope of this PR, which excludes the following matches:
- `USB_FS_WKUP`
- `USB_HP`
- `USB_HP_CAN1_TX`
- `USB_HP_CAN_TX`
- `USBWakeUp`

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Builds on #889.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
