### PR TITLE
docs(examples): rename examples with confusing laze module names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2616,6 +2616,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-storage"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+ "arrayvec",
+ "heapless 0.8.0",
+ "serde",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4953,17 +4964,6 @@ checksum = "dc520f60f6653a32479a95b9180b33908f0cbbdf106609465ee7dea98f4f5b37"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
-]
-
-[[package]]
-name = "storage"
-version = "0.0.0"
-dependencies = [
- "ariel-os",
- "ariel-os-boards",
- "arrayvec",
- "heapless 0.8.0",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,6 +2644,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-usb-serial"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5461,14 +5469,6 @@ dependencies = [
  "ariel-os-boards",
  "embassy-sync 0.6.2",
  "static_cell",
-]
-
-[[package]]
-name = "usb-serial"
-version = "0.0.0"
-dependencies = [
- "ariel-os",
- "ariel-os-boards",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,6 +2627,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-threading"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5204,14 +5212,6 @@ dependencies = [
  "ariel-os",
  "ariel-os-boards",
  "embassy-sync 0.6.2",
-]
-
-[[package]]
-name = "threading"
-version = "0.0.0"
-dependencies = [
- "ariel-os",
- "ariel-os-boards",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,6 +2627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-testing"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+ "embedded-test",
+]
+
+[[package]]
 name = "example-threading"
 version = "0.0.0"
 dependencies = [
@@ -5145,15 +5154,6 @@ dependencies = [
  "embedded-nal-coap",
  "heapless 0.8.0",
  "scroll-ring",
-]
-
-[[package]]
-name = "testing"
-version = "0.0.0"
-dependencies = [
- "ariel-os",
- "ariel-os-boards",
- "embedded-test",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,14 +636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "benchmark"
-version = "0.0.0"
-dependencies = [
- "ariel-os",
- "ariel-os-boards",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,6 +2549,14 @@ dependencies = [
 
 [[package]]
 name = "example-alloc"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+]
+
+[[package]]
+name = "example-benchmark"
 version = "0.0.0"
 dependencies = [
  "ariel-os",

--- a/examples/benchmark/Cargo.toml
+++ b/examples/benchmark/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "benchmark"
+name = "example-benchmark"
 license.workspace = true
 edition.workspace = true
 

--- a/examples/benchmark/laze.yml
+++ b/examples/benchmark/laze.yml
@@ -1,5 +1,5 @@
 apps:
-  - name: benchmark
+  - name: example-benchmark
     selects:
       - sw/benchmark
       - sw/threading

--- a/examples/storage/Cargo.toml
+++ b/examples/storage/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "storage"
+name = "example-storage"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/storage/laze.yml
+++ b/examples/storage/laze.yml
@@ -1,4 +1,4 @@
 apps:
-  - name: storage
+  - name: example-storage
     selects:
       - sw/storage

--- a/examples/testing/Cargo.toml
+++ b/examples/testing/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "testing"
+name = "example-testing"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/examples/testing/laze.yml
+++ b/examples/testing/laze.yml
@@ -1,5 +1,5 @@
 apps:
-  - name: testing
+  - name: example-testing
     selects:
       - defmt
       - embedded-test-only

--- a/examples/threading/Cargo.toml
+++ b/examples/threading/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "threading"
+name = "example-threading"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/threading/laze.yml
+++ b/examples/threading/laze.yml
@@ -1,4 +1,4 @@
 apps:
-  - name: threading
+  - name: example-threading
     selects:
       - sw/threading

--- a/examples/usb-serial/Cargo.toml
+++ b/examples/usb-serial/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "usb-serial"
+name = "example-usb-serial"
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/examples/usb-serial/laze.yml
+++ b/examples/usb-serial/laze.yml
@@ -1,4 +1,4 @@
 apps:
-  - name: usb-serial
+  - name: example-usb-serial
     selects:
       - usb


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This renames the examples the most likely to cause confusion because their laze module name is close to another documented laze module (e.g., `storage` and `sw/storage`).

## How to review this PR

This PR is better reviewed commit by commit.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
