### PR TITLE
refactor: remove unneeded `UsbBuilderHook` imports

### DIFF
--- a/examples/usb-keyboard/src/main.rs
+++ b/examples/usb-keyboard/src/main.rs
@@ -10,7 +10,7 @@ use ariel_os::{
     debug::log::*,
     reexports::{embassy_usb, usbd_hid},
     time::{Duration, Timer},
-    usb::{UsbBuilderHook, UsbDriver},
+    usb::UsbDriver,
 };
 use embassy_usb::class::hid::{self, HidReaderWriter};
 use usbd_hid::descriptor::{KeyboardReport, SerializedDescriptor};

--- a/examples/usb-serial/src/main.rs
+++ b/examples/usb-serial/src/main.rs
@@ -3,12 +3,7 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 
-use ariel_os::{
-    cell::StaticCell,
-    debug::log::info,
-    reexports::embassy_usb,
-    usb::{UsbBuilderHook, UsbDriver},
-};
+use ariel_os::{cell::StaticCell, debug::log::info, reexports::embassy_usb, usb::UsbDriver};
 use embassy_usb::{
     class::cdc_acm::{CdcAcmClass, State},
     driver::EndpointError,

--- a/src/ariel-os-macros/src/task.rs
+++ b/src/ariel-os-macros/src/task.rs
@@ -24,8 +24,6 @@
 /// # Examples
 ///
 /// ```ignore
-/// use ariel_os::usb::UsbBuilderHook;
-///
 /// #[ariel_os::task(autostart, peripherals, usb_builder_hook)]
 /// async fn task(peripherals: /* your peripheral type */) {}
 /// ```

--- a/src/ariel-os-macros/tests/ui/task/missing_autostart_param_for_hook.rs
+++ b/src/ariel-os-macros/tests/ui/task/missing_autostart_param_for_hook.rs
@@ -2,10 +2,6 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 
-// As the macro will fail, this import will not get used
-#[allow(unused_imports)]
-use ariel_os::usb::UsbBuilderHook;
-
 // FAIL: using hooks require the task to be autostart
 #[ariel_os::task(usb_builder_hook)]
 async fn main() {}

--- a/src/ariel-os-macros/tests/ui/task/missing_autostart_param_for_hook.stderr
+++ b/src/ariel-os-macros/tests/ui/task/missing_autostart_param_for_hook.stderr
@@ -1,7 +1,7 @@
 error: custom attribute panicked
-  --> tests/ui/task/missing_autostart_param_for_hook.rs:10:1
-   |
-10 | #[ariel_os::task(usb_builder_hook)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: message: the task must be `autostart` to instantiate hooks
+ --> tests/ui/task/missing_autostart_param_for_hook.rs:6:1
+  |
+6 | #[ariel_os::task(usb_builder_hook)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: the task must be `autostart` to instantiate hooks

--- a/src/ariel-os-macros/tests/ui/task/misspelled_hook_name.rs
+++ b/src/ariel-os-macros/tests/ui/task/misspelled_hook_name.rs
@@ -2,10 +2,6 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(used_with_arg)]
 
-// As the macro will fail, this import will not get used
-#[allow(unused_imports)]
-use ariel_os::usb::UsbBuilderHook;
-
 // FAIL: misspelled hook name
 #[ariel_os::task(autostart, usb_builder_hooook)]
 async fn main() {}

--- a/src/ariel-os-macros/tests/ui/task/misspelled_hook_name.stderr
+++ b/src/ariel-os-macros/tests/ui/task/misspelled_hook_name.stderr
@@ -1,5 +1,5 @@
 error: unsupported parameter (`autostart`, `peripherals`, `pool_size`, and hooks `usb_builder_hook` are supported)
-  --> tests/ui/task/misspelled_hook_name.rs:10:29
-   |
-10 | #[ariel_os::task(autostart, usb_builder_hooook)]
-   |                             ^^^^^^^^^^^^^^^^^^
+ --> tests/ui/task/misspelled_hook_name.rs:6:29
+  |
+6 | #[ariel_os::task(autostart, usb_builder_hooook)]
+  |                             ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Following #918, this removes the imports of `UsbBuilderHook` as they are no longer needed.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
