### PR TITLE
feat(nrf): add basic support for nRF9160

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -89,6 +89,21 @@ chips:
       storage: supported
       wifi: not_available
 
+  nrf9160:
+    name: nRF9160
+    support:
+      gpio: supported
+      debug_output: supported
+      hwrng:
+        status: not_currently_supported
+        comments:
+          - only available through the CryptoCell
+      i2c_controller: supported
+      spi_main: supported
+      logging: supported
+      storage: supported
+      wifi: not_available
+
   rp2040:
     name: RP2040
     support:
@@ -228,6 +243,14 @@ boards:
     support:
       user_usb: supported
       ethernet_over_usb: supported
+
+  nrf9160dk:
+    name: nRF9160-DK
+    url: https://web.archive.org/web/20250311221943/https://www.nordicsemi.com/Products/Development-hardware/nrf9160-dk
+    chip: nrf9160
+    support:
+      user_usb: not_available
+      ethernet_over_usb: not_available
 
   rpi-pico:
     name: Raspberry Pi Pico

--- a/examples/blinky/laze.yml
+++ b/examples/blinky/laze.yml
@@ -6,6 +6,7 @@ apps:
       - esp
       - nrf52840dk
       - nrf5340dk
+      - nrf9160dk
       - particle-xenon
       - rp
       - st-nucleo-c031c6

--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -12,6 +12,9 @@ ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_13 });
 #[cfg(context = "nrf5340dk")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_28 });
 
+#[cfg(context = "nrf9160dk")]
+ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_02 });
+
 #[cfg(context = "particle-xenon")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: P1_12 });
 

--- a/examples/gpio/laze.yml
+++ b/examples/gpio/laze.yml
@@ -6,6 +6,7 @@ apps:
       - esp
       - nrf52840dk
       - nrf5340dk
+      - nrf9160dk
       - rp
       - st-nucleo-c031c6
       - st-nucleo-f401re

--- a/examples/gpio/src/pins.rs
+++ b/examples/gpio/src/pins.rs
@@ -19,6 +19,12 @@ ariel_os::hal::define_peripherals!(Peripherals {
     btn1: P0_23
 });
 
+#[cfg(context = "nrf9160dk")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    led1: P0_02,
+    btn1: P0_06
+});
+
 #[cfg(context = "rp")]
 ariel_os::hal::define_peripherals!(Peripherals {
     led1: PIN_1,

--- a/examples/http-server/laze.yml
+++ b/examples/http-server/laze.yml
@@ -13,6 +13,7 @@ modules:
     context:
       - nrf52840dk
       - nrf5340dk
+      - nrf9160dk
       - st-nucleo-wb55
     env:
       global:

--- a/examples/http-server/src/pins.rs
+++ b/examples/http-server/src/pins.rs
@@ -7,6 +7,9 @@ ariel_os::hal::define_peripherals!(Button { btn1: P0_11 });
 #[cfg(context = "nrf5340dk")]
 ariel_os::hal::define_peripherals!(Button { btn1: P0_23 });
 
+#[cfg(context = "nrf9160dk")]
+ariel_os::hal::define_peripherals!(Button { btn1: P0_06 });
+
 #[cfg(context = "st-nucleo-wb55")]
 ariel_os::hal::define_peripherals!(Button { btn1: PC4 });
 

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -240,6 +240,16 @@ contexts:
     env:
       PROBE_RS_CHIP: nrf5340_xxAA
 
+  - name: nrf91
+    parent: nrf
+
+  - name: nrf9160
+    parent: nrf91
+    selects:
+      - cortex-m33f
+    env:
+      PROBE_RS_CHIP: nRF9160_xxAA
+
   - name: rp
     help: Raspberry Pi Pico (2) MCU support (based on embassy-rp)
     parent: ariel-os
@@ -1393,6 +1403,10 @@ builders:
 
   - name: st-nucleo-c031c6
     parent: stm32c031c6tx
+
+  # TODO: there also is a companion nrf52840 on this board
+  - name: nrf9160dk
+    parent: nrf9160
 
   - name: st-nucleo-f401re
     parent: stm32f401retx

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -245,6 +245,8 @@ contexts:
 
   - name: nrf9160
     parent: nrf91
+    provides:
+      - has_storage_support
     selects:
       - cortex-m33f
     env:

--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -48,6 +48,9 @@ embassy-nrf = { workspace = true, features = [
   "nrf5340-app-s",
 ] }
 
+[target.'cfg(context = "nrf9160")'.dependencies]
+embassy-nrf = { workspace = true, features = ["nrf9160-s"] }
+
 [build-dependencies]
 ld-memory = { workspace = true, features = ["build-rs"] }
 

--- a/src/ariel-os-nrf/build.rs
+++ b/src/ariel-os-nrf/build.rs
@@ -14,6 +14,8 @@ fn main() {
         (256, 1024)
     } else if is_in_current_contexts(&["nrf5340"]) {
         (512, 1024)
+    } else if is_in_current_contexts(&["nrf9160"]) {
+        (256, 1024)
     } else {
         panic!("nrf52: please set MCU feature");
     };
@@ -22,6 +24,8 @@ fn main() {
         "NRF52_FLASH"
     } else if is_in_current_contexts(&["nrf5340"]) {
         "NRF5340_FLASH"
+    } else if is_in_current_contexts(&["nrf9160"]) {
+        "NRF9160_FLASH"
     } else {
         unreachable!();
     };

--- a/src/ariel-os-nrf/src/i2c/controller/mod.rs
+++ b/src/ariel-os-nrf/src/i2c/controller/mod.rs
@@ -41,19 +41,24 @@ impl Default for Config {
 
 /// I2C bus frequency.
 // NOTE(hal): the datasheets only mention these frequencies.
-#[cfg(any(context = "nrf52833", context = "nrf52840", context = "nrf5340"))]
+#[cfg(any(
+    context = "nrf52833",
+    context = "nrf52840",
+    context = "nrf5340",
+    context = "nrf9160"
+))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Frequency {
     /// Standard mode.
     _100k,
     /// 250 kHz.
-    #[cfg(any(context = "nrf52833", context = "nrf5340"))]
+    #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf9160"))]
     _250k,
     /// Fast mode.
     _400k,
     // FIXME(embassy): the upstream Embassy crate does not support this frequency
-    // #[cfg(context = "nrf5340")]
+    // #[cfg(context = "nrf5340", context = "nrf9160")]
     // _1M,
 }
 
@@ -74,9 +79,9 @@ impl Frequency {
         match self {
             #[cfg(context = "nrf52840")]
             Self::_100k => Some(Self::_400k),
-            #[cfg(any(context = "nrf52833", context = "nrf5340"))]
+            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf9160"))]
             Self::_100k => Some(Self::_250k),
-            #[cfg(any(context = "nrf52833", context = "nrf5340"))]
+            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf9160"))]
             Self::_250k => Some(Self::_400k),
             Self::_400k => None,
         }
@@ -86,11 +91,11 @@ impl Frequency {
     pub const fn prev(self) -> Option<Self> {
         match self {
             Self::_100k => None,
-            #[cfg(any(context = "nrf52833", context = "nrf5340"))]
+            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf9160"))]
             Self::_250k => Some(Self::_100k),
             #[cfg(context = "nrf52840")]
             Self::_400k => Some(Self::_100k),
-            #[cfg(any(context = "nrf52833", context = "nrf5340"))]
+            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf9160"))]
             Self::_400k => Some(Self::_250k),
         }
     }
@@ -99,7 +104,7 @@ impl Frequency {
     pub const fn khz(self) -> u32 {
         match self {
             Self::_100k => 100,
-            #[cfg(any(context = "nrf52833", context = "nrf5340"))]
+            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf9160"))]
             Self::_250k => 250,
             Self::_400k => 400,
         }
@@ -112,7 +117,7 @@ impl From<Frequency> for embassy_nrf::twim::Frequency {
     fn from(freq: Frequency) -> Self {
         match freq {
             Frequency::_100k => embassy_nrf::twim::Frequency::K100,
-            #[cfg(any(context = "nrf52833", context = "nrf5340"))]
+            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf9160"))]
             Frequency::_250k => embassy_nrf::twim::Frequency::K250,
             Frequency::_400k => embassy_nrf::twim::Frequency::K400,
         }
@@ -215,6 +220,11 @@ define_i2c_drivers!(
     TWISPI1 => TWISPI1,
 );
 #[cfg(context = "nrf5340")]
+define_i2c_drivers!(
+    SERIAL0 => SERIAL0,
+    SERIAL1 => SERIAL1,
+);
+#[cfg(context = "nrf9160")]
 define_i2c_drivers!(
     SERIAL0 => SERIAL0,
     SERIAL1 => SERIAL1,

--- a/src/ariel-os-nrf/src/i2c/mod.rs
+++ b/src/ariel-os-nrf/src/i2c/mod.rs
@@ -16,6 +16,9 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
         } else if #[cfg(context = "nrf5340")] {
             let _ = peripherals.SERIAL0.take().unwrap();
             let _ = peripherals.SERIAL1.take().unwrap();
+        } else if #[cfg(context = "nrf9160")] {
+            let _ = peripherals.SERIAL0.take().unwrap();
+            let _ = peripherals.SERIAL1.take().unwrap();
         } else {
             compile_error!("this nRF chip is not supported");
         }

--- a/src/ariel-os-nrf/src/identity.rs
+++ b/src/ariel-os-nrf/src/identity.rs
@@ -6,9 +6,9 @@ impl ariel_os_embassy_common::identity::DeviceId for DeviceId {
         reason = "making this fallible would be a breaking API change for Ariel OS"
     )]
     fn get() -> Result<Self, core::convert::Infallible> {
-        #[cfg(not(context = "nrf5340"))]
+        #[cfg(not(any(context = "nrf5340", context = "nrf9160")))]
         let ficr = embassy_nrf::pac::FICR;
-        #[cfg(context = "nrf5340")]
+        #[cfg(any(context = "nrf5340", context = "nrf9160"))]
         let ficr = embassy_nrf::pac::FICR.info();
 
         let low = ficr.deviceid(0).read();

--- a/src/ariel-os-nrf/src/lib.rs
+++ b/src/ariel-os-nrf/src/lib.rs
@@ -45,7 +45,7 @@ pub use embassy_executor::InterruptExecutor as Executor;
 ariel_os_embassy_common::executor_swi!(EGU0_SWI0);
 
 #[cfg(feature = "executor-interrupt")]
-#[cfg(context = "nrf5340")]
+#[cfg(any(context = "nrf5340", context = "nrf9160"))]
 ariel_os_embassy_common::executor_swi!(EGU0);
 
 use embassy_nrf::config::Config;

--- a/src/ariel-os-nrf/src/spi/main/mod.rs
+++ b/src/ariel-os-nrf/src/spi/main/mod.rs
@@ -237,3 +237,9 @@ define_spi_drivers!(
     SERIAL2 => SERIAL2,
     SERIAL3 => SERIAL3,
 );
+// FIXME: arbitrary selected peripherals
+#[cfg(context = "nrf9160")]
+define_spi_drivers!(
+    SERIAL2 => SERIAL2,
+    SERIAL3 => SERIAL3,
+);

--- a/src/ariel-os-nrf/src/spi/mod.rs
+++ b/src/ariel-os-nrf/src/spi/mod.rs
@@ -33,6 +33,9 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
         } else if #[cfg(context = "nrf5340")] {
             let _ = peripherals.SERIAL2.take().unwrap();
             let _ = peripherals.SERIAL3.take().unwrap();
+        } else if #[cfg(context = "nrf9160")] {
+            let _ = peripherals.SERIAL2.take().unwrap();
+            let _ = peripherals.SERIAL3.take().unwrap();
         } else {
             compile_error!("this nRF chip is not supported");
         }

--- a/src/ariel-os-storage/build.rs
+++ b/src/ariel-os-storage/build.rs
@@ -8,7 +8,7 @@ fn main() {
     // Trying to restrict the storage size to the subset of homogeneous flash would not work as it
     // could be pushed out of it by a large enough binary.
     let (storage_size_total, flash_page_size) =
-        if is_in_current_contexts(&["nrf52", "nrf5340", "rp", "stm32wb55rgvx"]) {
+        if is_in_current_contexts(&["nrf52", "nrf5340", "nrf9160", "rp", "stm32wb55rgvx"]) {
             (8 * KIBIBYTES, 4 * KIBIBYTES)
         } else if is_in_current_contexts(&["stm32h755zitx"]) {
             (256 * KIBIBYTES, 128 * KIBIBYTES)

--- a/tests/coap-blinky/laze.yml
+++ b/tests/coap-blinky/laze.yml
@@ -9,6 +9,7 @@ apps:
       - esp
       - nrf52840dk
       - nrf5340dk
+      - nrf9160dk
       - particle-xenon
       - rp
       - st-nucleo-f401re

--- a/tests/gpio-interrupt-nrf/src/main.rs
+++ b/tests/gpio-interrupt-nrf/src/main.rs
@@ -38,6 +38,19 @@ ariel_os::hal::define_peripherals!(ButtonPeripherals {
     btn_8: P0_10,
 });
 
+#[cfg(context = "nrf9160")]
+ariel_os::hal::define_peripherals!(ButtonPeripherals {
+    btn_0: P0_00,
+    btn_1: P0_01,
+    btn_2: P0_02,
+    btn_3: P0_03,
+    btn_4: P0_04,
+    btn_5: P0_05,
+    btn_6: P0_06,
+    btn_7: P0_07,
+    btn_8: P0_08,
+});
+
 #[ariel_os::task(autostart, peripherals)]
 async fn main(peripherals: ButtonPeripherals) {
     let _btn_0 = Input::builder(peripherals.btn_0, Pull::Up)

--- a/tests/gpio/src/pins.rs
+++ b/tests/gpio/src/pins.rs
@@ -16,6 +16,14 @@ ariel_os::hal::define_peripherals!(Peripherals {
     pin_3: P0_05,
 });
 
+#[cfg(context = "nrf91")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    pin_0: P0_00,
+    pin_1: P0_01,
+    pin_2: P0_02,
+    pin_3: P0_03,
+});
+
 #[cfg(context = "rp")]
 ariel_os::hal::define_peripherals!(Peripherals {
     pin_0: PIN_0,

--- a/tests/i2c-controller/laze.yml
+++ b/tests/i2c-controller/laze.yml
@@ -5,6 +5,7 @@ apps:
       - esp
       - nrf52840
       - nrf5340
+      - nrf9160
       - rp2040
       - rp235xa
       - st-nucleo-h755zi-q

--- a/tests/i2c-controller/src/pins.rs
+++ b/tests/i2c-controller/src/pins.rs
@@ -10,7 +10,7 @@ ariel_os::hal::define_peripherals!(Peripherals {
 
 #[cfg(any(context = "nrf52833", context = "nrf52840"))]
 pub type SensorI2c = i2c::controller::TWISPI0;
-#[cfg(context = "nrf5340")]
+#[cfg(any(context = "nrf5340", context = "nrf9160"))]
 pub type SensorI2c = i2c::controller::SERIAL0;
 #[cfg(all(context = "nrf", not(context = "bbc-microbit-v2")))]
 ariel_os::hal::define_peripherals!(Peripherals {

--- a/tests/spi-loopback/laze.yml
+++ b/tests/spi-loopback/laze.yml
@@ -5,6 +5,7 @@ apps:
       - esp
       - nrf52840
       - nrf5340
+      - nrf9160
       - rp2040
       - rp235xa
       - st-nucleo-c031c6

--- a/tests/spi-loopback/src/pins.rs
+++ b/tests/spi-loopback/src/pins.rs
@@ -32,7 +32,7 @@ ariel_os::hal::define_peripherals!(Peripherals {
 });
 
 // Side SPI of Arduino v3 connector
-#[cfg(context = "nrf5340")]
+#[cfg(any(context = "nrf5340", context = "nrf9160"))]
 pub type SensorSpi = spi::main::SERIAL2;
 #[cfg(context = "nrf5340")]
 ariel_os::hal::define_peripherals!(Peripherals {
@@ -40,6 +40,13 @@ ariel_os::hal::define_peripherals!(Peripherals {
     spi_miso: P1_14,
     spi_mosi: P1_13,
     spi_cs: P1_12,
+});
+#[cfg(context = "nrf9160")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    spi_sck: P0_13,
+    spi_miso: P0_12,
+    spi_mosi: P0_11,
+    spi_cs: P0_10,
 });
 
 #[cfg(context = "rp")]

--- a/tests/spi-main/laze.yml
+++ b/tests/spi-main/laze.yml
@@ -4,6 +4,7 @@ apps:
       - esp
       - nrf52840
       - nrf5340
+      - nrf9160
       - rp2040
       - st-nucleo-h755zi-q
       - st-nucleo-wb55

--- a/tests/spi-main/src/pins.rs
+++ b/tests/spi-main/src/pins.rs
@@ -22,7 +22,7 @@ ariel_os::hal::define_peripherals!(Peripherals {
 });
 
 // Side SPI of Arduino v3 connector
-#[cfg(context = "nrf5340")]
+#[cfg(any(context = "nrf5340", context = "nrf9160"))]
 pub type SensorSpi = spi::main::SERIAL2;
 #[cfg(context = "nrf5340")]
 ariel_os::hal::define_peripherals!(Peripherals {
@@ -30,6 +30,13 @@ ariel_os::hal::define_peripherals!(Peripherals {
     spi_miso: P1_14,
     spi_mosi: P1_13,
     spi_cs: P1_12,
+});
+#[cfg(context = "nrf9160")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    spi_sck: P0_13,
+    spi_miso: P0_12,
+    spi_mosi: P0_11,
+    spi_cs: P0_10,
 });
 
 #[cfg(context = "rp")]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This adds basic (i.e., only ports features common to other boards, not what makes that board fancy) support for the nRF9160 MCU and its development kit.

## Testing

Successfully tested in hardware the following:

- `examples/blinky`
- `examples/gpio`
- `examples/power`
- `examples/storage`
- `examples/threading-channel`
- `examples/theading-mutex`
- `tests/gpio-interrupt-nrf`
- `tests/i2c-controller`
- `tests/threading-mutex`
- `tests/spi-loopback`
- `tests/spi-main`
- `tests/threading-dynamic-prios`

## TODO

- [x] Make other examples and tests compile (`laze build --global -b nrf9160dk` succeeds)
- [x] Add support for I2C and SPI
- [x] Add support for persistent storage
- [x] Test these features in hardware
- [x] Update the support matrix

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Closes #840.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
