### PR TITLE
perf(storage): block on storage init to spare RAM

### DIFF
--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -190,8 +190,10 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     // Clock startup and entropy collection may lend themselves to parallelization, provided that
     // doesn't impact runtime RAM or flash use.
 
+    // Block on this Future to reduce the size of this startup task, which is statically
+    // allocated.
     #[cfg(feature = "storage")]
-    ariel_os_storage::init(&mut peripherals).await;
+    embassy_futures::block_on(ariel_os_storage::init(&mut peripherals));
 
     #[cfg(all(feature = "usb", context = "nrf"))]
     hal::usb::init();

--- a/src/ariel-os-storage/src/lib.rs
+++ b/src/ariel-os-storage/src/lib.rs
@@ -87,7 +87,7 @@ pub async fn init(p: &mut OptionalPeripherals) {
     // interferes with flash write operations.
     // https://github.com/knurling-rs/defmt/pull/683
     #[cfg(context = "rp")]
-    embassy_time::Timer::after_millis(10).await;
+    embassy_time::block_for(embassy_time::Duration::from_millis(10));
 
     // Use a marker to ensure that this storage is initialized.
     match get::<u8>(MARKER_KEY).await {


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This reduces the size of the startup task ~~on non-RP MCUs~~, which is statically allocated and therefore ends up in the `bss` section, while only running at startup.

The following table summaries the change in `bss` size of the `storage` example:

| Board              | Old `bss` size | New `bss` size | Change       |
| --------           | -------------: | -------------: | -----------: |
| nrf52833dk         | 5140           | 4220           | -920 (17 %)  |
| nrf52840dk         | 5140           | 4220           | -920 (17 %)  |
| nrf5340dk          | 5124           | 4204           | -920 (17 %)  |
| rpi-pico-w         | 6012           | 4780           | -1232 (20 %) |
| st-nucleo-h755zi-q | 5752           | 4832           | -920 (16 %)  |
| st-nucleo-wb55     | 5288           | 4368           | -920 (17 %)  |

The `.text` size also decreases by a few hundred bytes.

I didn't observe any performance difference at startup, but I also didn't measure it properly.

## Testing

Successfully tested in hardware on the boards listed in the table.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Part of #924.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
