### PR TITLE
refactor(coap): move stack size into module

### DIFF
--- a/examples/coap-client/laze.yml
+++ b/examples/coap-client/laze.yml
@@ -1,8 +1,4 @@
 apps:
   - name: example-coap-client
-    env:
-      global:
-        executor_stacksize_required:
-          - "32768"
     selects:
       - coap-client

--- a/examples/coap-server/laze.yml
+++ b/examples/coap-server/laze.yml
@@ -1,9 +1,5 @@
 apps:
   - name: example-coap-server
-    env:
-      global:
-        executor_stacksize_required:
-          - "32768"
     selects:
       - coap-server
       - ?coap-server-config-demokeys

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -947,6 +947,8 @@ modules:
       global:
         FEATURES:
           - ariel-os/coap
+        executor_stacksize_required:
+          - "32768"
 
   - name: coap-server
     help: Support for applications to set up CoAP server handlers.

--- a/tests/coap-blinky/laze.yml
+++ b/tests/coap-blinky/laze.yml
@@ -1,9 +1,5 @@
 apps:
   - name: coap-blinky
-    env:
-      global:
-        CARGO_ENV:
-          - CONFIG_ISR_STACKSIZE=32768
     selects:
       - coap-server
       - ?coap-server-config-demokeys

--- a/tests/coap/laze.yml
+++ b/tests/coap/laze.yml
@@ -1,9 +1,5 @@
 apps:
   - name: test-coap
-    env:
-      global:
-        CARGO_ENV:
-          - CONFIG_ISR_STACKSIZE=32768
     selects:
       - coap-server
       - ?coap-server-config-demokeys


### PR DESCRIPTION
# Description

The individual examples don't do anything on their own that makes the stack size exceed the default. This also eases writing own applications.

(Also, some of those were still on an older idiom to set that size; happened to not cause trouble with the run-tested boards).

## Testing

The CoAP tests and exampels still build, --verbose shows the stack size in the cargo environment, and they don't crash on requests. (the clien example of course still errs out)

(Tested on st-nucleo-wb55 with on `{examples,tests}/*coap*`)

## Issues/PRs references

This helps the CoAP tutorial.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.