### PR TITLE
fix(coap): remove needless use of ReportingHandlerBuilder

### DIFF
--- a/examples/coap-server/src/main.rs
+++ b/examples/coap-server/src/main.rs
@@ -5,9 +5,7 @@
 
 #[ariel_os::task(autostart)]
 async fn coap_run() {
-    use coap_handler_implementations::{
-        new_dispatcher, HandlerBuilder, ReportingHandlerBuilder, SimpleRendered,
-    };
+    use coap_handler_implementations::{new_dispatcher, HandlerBuilder, SimpleRendered};
 
     let handler = new_dispatcher()
         // We offer a single resource: /hello, which responds just with a text string.

--- a/tests/coap-blinky/src/main.rs
+++ b/tests/coap-blinky/src/main.rs
@@ -10,7 +10,7 @@ use ariel_os::gpio::{Level, Output};
 
 #[ariel_os::task(autostart, peripherals)]
 async fn coap_run(peripherals: pins::LedPeripherals) {
-    use coap_handler_implementations::{new_dispatcher, HandlerBuilder, ReportingHandlerBuilder};
+    use coap_handler_implementations::{new_dispatcher, HandlerBuilder};
 
     let led = Output::new(peripherals.led, Level::Low);
 


### PR DESCRIPTION
# Description

Removes needless `use` items.

The need for those went away when `.with_wkc()` was moved into ariel_os::coap.

## Open Questions

* Why didn't linting catch those? Maybe things are not so strict for examples.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.
