### PR TITLE
fix(examples): increase unpinned thread priority in threading-multicore

### DIFF
--- a/examples/threading-multicore/README.md
+++ b/examples/threading-multicore/README.md
@@ -10,6 +10,6 @@ In this directory, run
 
     laze build -b rpi-pico run
 
-The application will start two threads that each print their ID and the core that they are running on, before
-entering a busy loop.
-The thread that is started first in pinned to Core 1 using core affinities.
+The application will start two threads that each print their ID and the core
+that they are running on, before entering a busy loop.
+The thread that is started first is pinned to Core 1 using core affinities.

--- a/examples/threading-multicore/src/main.rs
+++ b/examples/threading-multicore/src/main.rs
@@ -8,11 +8,11 @@ use ariel_os::{
     thread::{CoreAffinity, CoreId},
 };
 
-#[ariel_os::thread(autostart, affinity = CoreAffinity::one(CoreId::new(1)))]
+#[ariel_os::thread(autostart, affinity = CoreAffinity::one(CoreId::new(1)), priority = 2)]
 fn thread0() {
     let core = ariel_os::thread::core_id();
     let tid = ariel_os::thread::current_tid().unwrap();
-    info!("Hello from {:?} on {:?}", tid, core);
+    info!("Hello from {:?} on {:?}, I am pinned to core 1", tid, core);
     loop {}
 }
 


### PR DESCRIPTION
# Description

Works around scheduler behavior when another higher-priority thread is active (e.g., executor thread).

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

Fixes #934.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
