### PR TITLE
feat(boards): add support for the Raspberry Pi Pico 2 W

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -122,7 +122,7 @@ chips:
       gpio: supported
       debug_output: supported
       hwrng: supported
-      i2c_controller: needs_testing
+      i2c_controller: supported
       spi_main: supported
       logging: supported
       storage: supported
@@ -275,6 +275,15 @@ boards:
     chip: rp235xa
     support:
       user_usb: supported
+      ethernet_over_usb: supported
+
+  rpi-pico2-w:
+    name: Raspberry Pi Pico 2 W
+    url: https://web.archive.org/web/20250130144056/https://www.raspberrypi.com/products/raspberry-pi-pico-2/
+    chip: rp235xa
+    support:
+      user_usb: supported
+      wifi: supported
       ethernet_over_usb: supported
 
   espressif-esp32-c6-devkitc-1:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1379,6 +1379,12 @@ builders:
     provides:
       - has_usb_device_port
 
+  - name: rpi-pico2-w
+    parent: rp235xa
+    provides:
+      - has_usb_device_port
+      - has_wifi_cyw43
+
   - name: ai-c3
     parent: esp-c3-01m
 

--- a/src/ariel-os-rp/src/cyw43.rs
+++ b/src/ariel-os-rp/src/cyw43.rs
@@ -1,4 +1,7 @@
-#[cfg_attr(context = "rpi-pico-w", path = "cyw43/rpi-pico-w.rs")]
+#[cfg_attr(
+    any(context = "rpi-pico-w", context = "rpi-pico2-w"),
+    path = "cyw43/rpi-pico-w.rs"
+)]
 mod rpi_pico_w;
 
 use ariel_os_debug::log::info;

--- a/tests/spi-main/laze.yml
+++ b/tests/spi-main/laze.yml
@@ -6,5 +6,6 @@ apps:
       - nrf5340
       - nrf9160
       - rp2040
+      - rp235xa
       - st-nucleo-h755zi-q
       - st-nucleo-wb55


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Support for the Raspberry Pi Pico 2 (non-W) was added in #435, this adds support for the W variant, which features the same CYW43/Infineon chip as the Pico (1) W, wired the same way, which allows us to simply reuse what we already have for that one.

## Testing

Successfully tested:

- `tests/i2c-controller/`
- `tests/spi-main`
- `examples/http-client` using Wi-Fi

## TODO

- [x] Specify pins in the GPIO example (nothing to do)
- [x] Test Wi-Fi support in hardware
- [x] Test other features in hardware
- [x] Update the support matrix

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Closes #940.
Depends on #848.
Depends on #944.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
