### PR TITLE
 fix(boards): fix the context `rpi-pico-w` inherits from 

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1362,7 +1362,7 @@ builders:
       - has_usb_device_port
 
   - name: rpi-pico-w
-    parent: rpi-pico
+    parent: rp2040
     provides:
       - has_usb_device_port
       - has_wifi_cyw43


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The `rpi-pico-w` should inherit from `rp2040` directly instead of inheriting from `rpi-pico` because the capabilities of the `rpi-pico-w` are not a superset of those of the `rpi-pico`. For instance the GPIO25 is not connected to the onboard LED, which made the `blinky` example not work.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #848.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
