### PR TITLE
chore: enable Clippy pedantic at workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,12 +160,9 @@ unexpected_cfgs = "allow"
 # Clippy lints are documented here: https://rust-lang.github.io/rust-clippy/master/index.html
 indexing_slicing = "deny"
 missing_safety_doc = { level = "warn" }
+pedantic = { level = "warn", priority = -1 }
 too_long_first_doc_paragraph = "warn"
 unused_result_ok = "deny"
-
-# TODO: remove these when we enable pedantic
-must_use_candidate = "warn"
-return_self_not_must_use = "warn"
 
 [workspace.lints.rustdoc]
 broken_intra_doc_links = "deny"

--- a/book/src/coding-conventions.md
+++ b/book/src/coding-conventions.md
@@ -88,7 +88,7 @@ To add a new workspace crate re-exported by `ariel-os`, follow these steps:
 
 1. Create the new crate's directory in `src/`.
 1. Run `cargo init --lib` in that directory.
-1. Add `#![deny(missing_docs)]` and `#![deny(clippy::pedantic)]` to the crate; some lints are already inherited from the workspace and do not need to be added to the new crate.
+1. Add `#![deny(missing_docs)]` to the crate; some lints are already inherited from the workspace and do not need to be added to the new crate.
 1. In the workspace's `Cargo.toml` `workspace.members` array, ensure the new entry preserves the lexicographic order of that array.
 1. In the workspace's `Cargo.toml` `dependencies` array, add a (properly sorted) entry.
 1. Re-export the crate from the `ariel-os` crate, inline it in the docs as done for the other crates, and feature-gate it if necessary.

--- a/src/ariel-os-alloc/src/lib.rs
+++ b/src/ariel-os-alloc/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 // required for tests:
 #![cfg_attr(test, no_main)]
 

--- a/src/ariel-os-bench/src/lib.rs
+++ b/src/ariel-os-bench/src/lib.rs
@@ -1,7 +1,6 @@
 //! Provides on-board benchmarking facilities.
 
 #![cfg_attr(not(test), no_std)]
-#![deny(clippy::pedantic)]
 #![deny(missing_docs)]
 
 cfg_if::cfg_if! {

--- a/src/ariel-os-buildinfo/src/lib.rs
+++ b/src/ariel-os-buildinfo/src/lib.rs
@@ -1,7 +1,6 @@
 //! Exposes information about the build.
 #![no_std]
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 
 /// The board name.
 ///

--- a/src/ariel-os-coap/build.rs
+++ b/src/ariel-os-coap/build.rs
@@ -51,8 +51,8 @@ impl Permission {
 impl SinglePermission {
     /// The `Tperm` unsigned integer representation of the REST-specific AIF model described in
     /// RFC9237.
-    fn mask(&self) -> u32 {
-        1 << (*self as u8 - 1)
+    fn mask(self) -> u32 {
+        1 << (self as u8 - 1)
     }
 }
 
@@ -130,9 +130,10 @@ fn main() {
                 .expect("writing to String is infallible");
             }
             (None, Some(KnownSource::Unauthenticated)) => {
-                if unauthenticated_scope.is_some() {
-                    panic!("Only a single `from: unauthenticated` record is usable.");
-                }
+                assert!(
+                    unauthenticated_scope.is_none(),
+                    "Only a single `from: unauthenticated` record is usable.",
+                );
 
                 unauthenticated_scope = Some(format!("Some({scope})"));
             }

--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -7,7 +7,6 @@
 //! implementations.
 #![no_std]
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 
 // Moving work from https://github.com/embassy-rs/embassy/pull/2519 in here for the time being
 mod udp_nal;

--- a/src/ariel-os-debug-log/src/lib.rs
+++ b/src/ariel-os-debug-log/src/lib.rs
@@ -13,7 +13,6 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 
 #[featurecomb::comb]
 mod _featurecomb {}

--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -3,7 +3,6 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(test, no_main)]
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 
 #[cfg(all(feature = "rtt-target", feature = "esp-println"))]
 compile_error!(

--- a/src/ariel-os-embassy-common/src/lib.rs
+++ b/src/ariel-os-embassy-common/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![cfg_attr(nightly, feature(doc_auto_cfg))]
-#![deny(clippy::pedantic)]
 #![deny(missing_docs)]
 
 pub mod gpio;

--- a/src/ariel-os-embassy/src/asynch.rs
+++ b/src/ariel-os-embassy/src/asynch.rs
@@ -4,7 +4,6 @@
 //! some [Embassy](https://github.com/embassy-rs/embassy) types.
 
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 
 use core::cell::OnceCell;
 

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![cfg_attr(nightly, feature(doc_auto_cfg))]
-#![deny(clippy::pedantic)]
 
 pub mod gpio;
 

--- a/src/ariel-os-esp/src/lib.rs
+++ b/src/ariel-os-esp/src/lib.rs
@@ -3,7 +3,6 @@
 #![no_std]
 #![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 
 #[cfg(all(feature = "threading", feature = "wifi"))]
 mod preempt;

--- a/src/ariel-os-hal/src/lib.rs
+++ b/src/ariel-os-hal/src/lib.rs
@@ -23,7 +23,6 @@
 //! application.
 
 #![no_std]
-#![deny(clippy::pedantic)]
 
 #[doc(hidden)]
 pub mod define_peripherals;

--- a/src/ariel-os-identity/src/lib.rs
+++ b/src/ariel-os-identity/src/lib.rs
@@ -26,7 +26,6 @@
 //! derived from the main identity, but have different properties.
 #![no_std]
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 // required for tests:
 #![cfg_attr(test, no_main)]
 

--- a/src/ariel-os-macros/src/lib.rs
+++ b/src/ariel-os-macros/src/lib.rs
@@ -1,5 +1,3 @@
-#![deny(clippy::pedantic)]
-
 mod utils;
 
 use proc_macro::TokenStream;

--- a/src/ariel-os-nrf/build.rs
+++ b/src/ariel-os-nrf/build.rs
@@ -6,7 +6,7 @@ fn main() {
         return;
     }
 
-    let (ram, rom) = if is_in_current_contexts(&["nrf52832"]) {
+    let (ram, flash) = if is_in_current_contexts(&["nrf52832"]) {
         (64, 256)
     } else if is_in_current_contexts(&["nrf52833"]) {
         (128, 512)
@@ -34,9 +34,9 @@ fn main() {
 
     // generate linker script
     let memory = Memory::new()
-        .add_section(MemorySection::new("RAM", 0x20000000, ram * 1024))
+        .add_section(MemorySection::new("RAM", 0x2000_0000, ram * 1024))
         .add_section(
-            MemorySection::new("FLASH", 0x0, rom * 1024)
+            MemorySection::new("FLASH", 0x0, flash * 1024)
                 .pagesize(4096)
                 .from_env_with_prefix(slot_prefix),
         );

--- a/src/ariel-os-nrf/src/lib.rs
+++ b/src/ariel-os-nrf/src/lib.rs
@@ -3,7 +3,6 @@
 #![no_std]
 #![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 
 pub mod gpio;
 

--- a/src/ariel-os-power/src/lib.rs
+++ b/src/ariel-os-power/src/lib.rs
@@ -1,6 +1,5 @@
 //! Provides power management functionality.
 
-#![deny(clippy::pedantic)]
 #![deny(missing_docs)]
 #![no_std]
 

--- a/src/ariel-os-random/src/lib.rs
+++ b/src/ariel-os-random/src/lib.rs
@@ -23,7 +23,6 @@
 //! [`rand_pcg::Pcg32`] is decided yet for the fast one. Neither the algorithm nor the size of
 //! [`FastRng`] or [`CryptoRng`] is guaranteed.
 #![no_std]
-#![deny(clippy::pedantic)]
 
 use core::{cell::RefCell, marker::PhantomData};
 

--- a/src/ariel-os-rp/src/lib.rs
+++ b/src/ariel-os-rp/src/lib.rs
@@ -3,7 +3,6 @@
 #![no_std]
 #![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 
 pub mod gpio;
 

--- a/src/ariel-os-runqueue/src/lib.rs
+++ b/src/ariel-os-runqueue/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
+#![expect(clippy::cast_possible_truncation)]
 
 mod runqueue;
 pub use runqueue::{RunQueue, RunqueueId, ThreadId};

--- a/src/ariel-os-runqueue/src/runqueue.rs
+++ b/src/ariel-os-runqueue/src/runqueue.rs
@@ -48,10 +48,10 @@ impl From<ThreadId> for usize {
 /// Runqueue for `N_QUEUES`, supporting `N_THREADS` total.
 ///
 /// Assumptions:
-/// - runqueue numbers (corresponding priorities) are 0..N_QUEUES (exclusive)
+/// - runqueue numbers (corresponding priorities) are `0..N_QUEUES` (exclusive)
 /// - higher runqueue number ([`RunqueueId`]) means higher priority
 /// - runqueue numbers fit in usize bits (supporting max 32 priority levels)
-/// - [`ThreadId`]s range from 0..N_THREADS
+/// - [`ThreadId`]s range from `0..N_THREADS`
 /// - `N_THREADS` is <255 (as u8 is used to store them, but 0xFF is used as
 ///   special value)
 ///
@@ -278,6 +278,7 @@ mod clist {
             self.tail[rq as usize] == Self::sentinel()
         }
 
+        #[expect(clippy::missing_panics_doc, reason = "internal")]
         pub fn push(&mut self, n: u8, rq: u8) {
             assert!(n < Self::sentinel());
             if self.next_idxs[n as usize] != Self::sentinel() {

--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -3,7 +3,6 @@
 #![no_std]
 #![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 
 pub mod gpio;
 

--- a/src/ariel-os-storage/src/lib.rs
+++ b/src/ariel-os-storage/src/lib.rs
@@ -5,7 +5,6 @@
 
 #![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 // TODO: overhaul errors
 #![expect(clippy::missing_errors_doc)]
 

--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -24,7 +24,6 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(target_arch = "xtensa", feature(asm_experimental_arch))]
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 // Disable indexing lints for now, possible panics are documented or rely on internally-enforced
 // invariants
 #![allow(clippy::indexing_slicing)]

--- a/src/ariel-os-threads/src/sync/event.rs
+++ b/src/ariel-os-threads/src/sync/event.rs
@@ -1,7 +1,6 @@
 //! This module provides an event that can be waited for.
 
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 
 use core::cell::UnsafeCell;
 

--- a/src/ariel-os-threads/src/sync/mutex.rs
+++ b/src/ariel-os-threads/src/sync/mutex.rs
@@ -1,5 +1,4 @@
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 
 use core::{
     cell::UnsafeCell,

--- a/src/lib/coapcore/src/lib.rs
+++ b/src/lib/coapcore/src/lib.rs
@@ -57,7 +57,6 @@
 #![no_std]
 #![cfg_attr(feature = "_nightly_docs", feature(doc_auto_cfg))]
 #![deny(missing_docs)]
-#![deny(clippy::pedantic)]
 #![allow(clippy::too_many_lines)]
 
 mod iana;


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This fixes the few remaining warnings of Clippy pedantic, and sets Clippy's `pedantic` lint group to `warn` at workspace level, so that it issues warnings when developing locally but fails CI (because we make these warnings errors in CI with `-- --deny warnings`).
The attributes denying `clippy::pedantic` in each crates are removed, as they are now unnecessary.

I checked that every crate from `src/` is properly inheriting lints from the workspace.

## How to review this PR

- This PR is better reviewed commit by commit.
- CI runs Clippy, failing on warnings; it can however be useful to check locally that the pedantic lints are still properly triggered, for instance by commenting out one of the `#[must_use]` attribute:

    https://github.com/ariel-os/ariel-os/blob/6d67089b91f9dcbcc0a8c51416191d4cb2c9d161/src/ariel-os-embassy/src/gpio.rs#L35-L38

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Supersedes #279.
The required refactoring for individual HAL crates has been done in #949, #1031, #1032, and #1033.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
