### PR TITLE
refactor(esp): make Clippy pedantic happy

### DIFF
--- a/src/ariel-os-esp/src/gpio.rs
+++ b/src/ariel-os-esp/src/gpio.rs
@@ -40,6 +40,7 @@ pub mod input {
         pull: ariel_os_embassy_common::gpio::Pull,
         _schmitt_trigger: bool, // Not supported by hardware
     ) -> Result<IntEnabledInput<'static>, InterruptError> {
+        #[expect(clippy::used_underscore_binding, reason = "just propagating")]
         match new(pin, pull, _schmitt_trigger) {
             Ok(input) => Ok(input),
             Err(err) => match err {
@@ -111,16 +112,14 @@ impl From<DriveStrength> for esp_hal::gpio::DriveStrength {
 
 impl ariel_os_embassy_common::gpio::FromDriveStrength for DriveStrength {
     fn from(drive_strength: ariel_os_embassy_common::gpio::DriveStrength<Self>) -> Self {
-        use ariel_os_embassy_common::gpio::DriveStrength::*;
-
         // ESPs are able to output up to 40 mA, so we somewhat normalize this.
         match drive_strength {
-            Hal(drive_strength) => drive_strength,
-            Lowest => Self::_5mA,
-            Standard => Self::_10mA,
-            Medium => Self::_10mA,
-            High => Self::_20mA,
-            Highest => Self::_40mA,
+            ariel_os_embassy_common::gpio::DriveStrength::Hal(drive_strength) => drive_strength,
+            ariel_os_embassy_common::gpio::DriveStrength::Lowest => Self::_5mA,
+            ariel_os_embassy_common::gpio::DriveStrength::Standard
+            | ariel_os_embassy_common::gpio::DriveStrength::Medium => Self::_10mA,
+            ariel_os_embassy_common::gpio::DriveStrength::High => Self::_20mA,
+            ariel_os_embassy_common::gpio::DriveStrength::Highest => Self::_40mA,
         }
     }
 }

--- a/src/ariel-os-esp/src/lib.rs
+++ b/src/ariel-os-esp/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(impl_trait_in_assoc_type)]
 #![feature(type_alias_impl_trait)]
 #![deny(missing_docs)]
+#![deny(clippy::pedantic)]
 
 #[cfg(all(feature = "threading", feature = "wifi"))]
 mod preempt;

--- a/src/ariel-os-esp/src/spi/main/mod.rs
+++ b/src/ariel-os-esp/src/spi/main/mod.rs
@@ -87,18 +87,18 @@ macro_rules! define_spi_drivers {
                     mosi_pin: impl Peripheral<P: PeripheralOutput> + 'static,
                     config: Config,
                 ) -> Spi {
-                    let mut spi_config = esp_hal::spi::master::Config::default();
-                    spi_config.frequency = config.frequency.into();
-                    spi_config.mode = crate::spi::from_mode(config.mode);
-                    spi_config.read_bit_order = crate::spi::from_bit_order(config.bit_order);
-                    spi_config.write_bit_order = crate::spi::from_bit_order(config.bit_order);
-
                     // Make this struct a compile-time-enforced singleton: having multiple statics
                     // defined with the same name would result in a compile-time error.
                     paste::paste! {
                         #[allow(dead_code)]
                         static [<PREVENT_MULTIPLE_ $peripheral>]: () = ();
                     }
+
+                    let mut spi_config = esp_hal::spi::master::Config::default();
+                    spi_config.frequency = config.frequency.into();
+                    spi_config.mode = crate::spi::from_mode(config.mode);
+                    spi_config.read_bit_order = crate::spi::from_bit_order(config.bit_order);
+                    spi_config.write_bit_order = crate::spi::from_bit_order(config.bit_order);
 
                     // FIXME(safety): enforce that the init code indeed has run
                     // SAFETY: this struct being a singleton prevents us from stealing the

--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -101,8 +101,8 @@ fn startup() -> ! {
     #[cfg(feature = "alloc")]
     // SAFETY: *this* is the only place alloc should be initialized.
     unsafe {
-        ariel_os_alloc::init()
-    };
+        ariel_os_alloc::init();
+    }
 
     #[cfg(test)]
     debug!("ariel_os_rt::startup() cfg(test)");


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Enables the pedantic group in `ariel-os-esp` and refactors to make Clippy happy.

Similar PRs for the other HALs should follow.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Works towards #948.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
