### PR TITLE
feat(rt): drop use of used(linker)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3651,18 +3651,18 @@ checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
 
 [[package]]
 name = "linkme"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566336154b9e58a4f055f6dd4cbab62c7dc0826ce3c0a04e63b2d2ecd784cdae"
+checksum = "22d227772b5999ddc0690e733f734f95ca05387e329c4084fe65678c51198ffe"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbe595006d355eaf9ae11db92707d4338cd2384d16866131cc1afdbdd35d8d9"
+checksum = "71a98813fa0073a317ed6a8055dcd4722a49d9b862af828ee68449adb799b6be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ esp-wifi-sys = { version = "0.7.1", default-features = false }
 esp-storage = { version = "0.4.0" }
 xtensa-lx-rt = { version = "0.18.0", default-features = false }
 
-linkme = { version = "0.3.31", features = ["used_linker"] }
+linkme = { version = "0.3.32" }
 
 ariel-os = { path = "src/ariel-os", default-features = false }
 ariel-os-alloc = { path = "src/ariel-os-alloc", default-features = false }

--- a/book/src/testing.md
+++ b/book/src/testing.md
@@ -90,7 +90,6 @@ apps:
 # This goes to the top of the file
 #![no_main]
 #![no_std]
-#![feature(used_with_arg)]
 #![feature(impl_trait_in_assoc_type)]
 ```
 

--- a/examples/alloc/src/main.rs
+++ b/examples/alloc/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 extern crate alloc;
 

--- a/examples/benchmark/src/main.rs
+++ b/examples/benchmark/src/main.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![no_std]
-#![feature(used_with_arg)]
 
 use ariel_os::debug::log::*;
 

--- a/examples/blinky/src/main.rs
+++ b/examples/blinky/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 mod pins;
 

--- a/examples/coap-client/src/main.rs
+++ b/examples/coap-client/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 use ariel_os::debug::log::info;
 

--- a/examples/coap-server/src/main.rs
+++ b/examples/coap-server/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 #[ariel_os::task(autostart)]
 async fn coap_run() {

--- a/examples/device-metadata/src/main.rs
+++ b/examples/device-metadata/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 use ariel_os::debug::{ExitCode, exit, log::*};
 

--- a/examples/gpio/src/main.rs
+++ b/examples/gpio/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 mod pins;
 

--- a/examples/hello-world-threading/src/main.rs
+++ b/examples/hello-world-threading/src/main.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![no_std]
-#![feature(used_with_arg)]
 
 use ariel_os::debug::{ExitCode, exit, log::*};
 

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 use ariel_os::debug::{ExitCode, exit, log::*};
 

--- a/examples/http-client/src/main.rs
+++ b/examples/http-client/src/main.rs
@@ -2,7 +2,6 @@
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(type_alias_impl_trait)]
-#![feature(used_with_arg)]
 
 use ariel_os::{
     config,

--- a/examples/http-server/src/main.rs
+++ b/examples/http-server/src/main.rs
@@ -2,7 +2,6 @@
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(type_alias_impl_trait)]
-#![feature(used_with_arg)]
 
 mod pins;
 mod routes;

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 use ariel_os::debug::log::*;
 

--- a/examples/power/src/main.rs
+++ b/examples/power/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 use ariel_os::{
     debug::log::info,

--- a/examples/random/src/main.rs
+++ b/examples/random/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 use ariel_os::debug::log::*;
 use rand::Rng as _;

--- a/examples/storage/src/main.rs
+++ b/examples/storage/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 use ariel_os::debug::{
     ExitCode, exit,

--- a/examples/tcp-echo/src/main.rs
+++ b/examples/tcp-echo/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 use ariel_os::{debug::log::*, net, reexports::embassy_net, time::Duration};
 use embassy_net::tcp::TcpSocket;

--- a/examples/testing/tests/test.rs
+++ b/examples/testing/tests/test.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 #[cfg(test)]
 #[embedded_test::tests]

--- a/examples/thread-async-interop/src/main.rs
+++ b/examples/thread-async-interop/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 

--- a/examples/threading-channel/src/main.rs
+++ b/examples/threading-channel/src/main.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![no_std]
-#![feature(used_with_arg)]
 
 use ariel_os::debug::{ExitCode, log::*};
 use ariel_os::thread::sync::Channel;

--- a/examples/threading-event/src/main.rs
+++ b/examples/threading-event/src/main.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![no_std]
-#![feature(used_with_arg)]
 
 use ariel_os::debug::{ExitCode, log::*};
 use ariel_os::thread::{ThreadId, sync::Event};

--- a/examples/threading-multicore/src/main.rs
+++ b/examples/threading-multicore/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(type_alias_impl_trait)]
-#![feature(used_with_arg)]
 
 use ariel_os::{
     debug::log::*,

--- a/examples/threading/src/main.rs
+++ b/examples/threading/src/main.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![no_std]
-#![feature(used_with_arg)]
 
 use ariel_os::debug::log::*;
 

--- a/examples/udp-echo/src/main.rs
+++ b/examples/udp-echo/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 use ariel_os::{debug::log::*, net, reexports::embassy_net};
 use embassy_net::udp::{PacketMetadata, UdpSocket};

--- a/examples/usb-keyboard/src/main.rs
+++ b/examples/usb-keyboard/src/main.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 mod pins;
 

--- a/examples/usb-serial/src/main.rs
+++ b/examples/usb-serial/src/main.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 use ariel_os::{cell::StaticCell, debug::log::info, reexports::embassy_usb, usb::UsbDriver};
 use embassy_usb::{

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -616,6 +616,8 @@ modules:
         RUSTFLAGS:
           - --cfg context=\"riscv\"
           - -Clink-arg=-Tisr_stack.x
+          - -Clink-arg=-Tlinkme-region-alias.x
+          - -Clink-arg=-Tlinkme.x
 
   - name: rp-link-arg
     help: helper module that ensures link-rp.x is added behind cortex-m ld scripts

--- a/src/ariel-os-alloc/src/lib.rs
+++ b/src/ariel-os-alloc/src/lib.rs
@@ -6,7 +6,6 @@
 // required for tests:
 #![cfg_attr(test, no_main)]
 #![cfg_attr(test, feature(impl_trait_in_assoc_type))]
-#![cfg_attr(test, feature(used_with_arg))]
 
 // With embedded-test enabled, this crate gets built *twice*, once regularly
 // as the system alloc it is supposed to be, and once as test application.

--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -9,7 +9,7 @@
 #![deny(missing_docs)]
 #![deny(clippy::pedantic)]
 // for #[ariel_os_macros::task(autostart)]
-#![feature(impl_trait_in_assoc_type, used_with_arg)]
+#![feature(impl_trait_in_assoc_type)]
 
 // Moving work from https://github.com/embassy-rs/embassy/pull/2519 in here for the time being
 mod udp_nal;

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 #![feature(doc_auto_cfg)]
 #![feature(negative_impls)]
 #![deny(clippy::pedantic)]

--- a/src/ariel-os-identity/src/lib.rs
+++ b/src/ariel-os-identity/src/lib.rs
@@ -30,7 +30,6 @@
 // required for tests:
 #![cfg_attr(test, no_main)]
 #![cfg_attr(test, feature(impl_trait_in_assoc_type))]
-#![cfg_attr(test, feature(used_with_arg))]
 
 pub use ariel_os_embassy_common::identity::Eui48;
 

--- a/src/ariel-os-macros/tests/ui/spawner/async_fn.rs
+++ b/src/ariel-os-macros/tests/ui/spawner/async_fn.rs
@@ -1,5 +1,4 @@
 #![no_main]
-#![feature(used_with_arg)]
 
 // As the macro will fail, this import will not get used
 #[allow(unused_imports)]

--- a/src/ariel-os-macros/tests/ui/spawner/async_fn.stderr
+++ b/src/ariel-os-macros/tests/ui/spawner/async_fn.stderr
@@ -1,7 +1,7 @@
 error: custom attribute panicked
- --> tests/ui/spawner/async_fn.rs:9:1
+ --> tests/ui/spawner/async_fn.rs:8:1
   |
-9 | #[ariel_os::spawner(autostart)]
+8 | #[ariel_os::spawner(autostart)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: spawner functions cannot be async, consider using `task` instead

--- a/src/ariel-os-macros/tests/ui/spawner/missing_peripherals_param.rs
+++ b/src/ariel-os-macros/tests/ui/spawner/missing_peripherals_param.rs
@@ -1,5 +1,4 @@
 #![no_main]
-#![feature(used_with_arg)]
 
 // As the macro will fail, this import will not get used
 #[allow(unused_imports)]

--- a/src/ariel-os-macros/tests/ui/spawner/missing_peripherals_param.stderr
+++ b/src/ariel-os-macros/tests/ui/spawner/missing_peripherals_param.stderr
@@ -1,13 +1,13 @@
 error: `peripherals` macro parameter missing here ...
- --> tests/ui/spawner/missing_peripherals_param.rs:9:1
+ --> tests/ui/spawner/missing_peripherals_param.rs:8:1
   |
-9 | #[ariel_os::spawner(autostart)]
+8 | #[ariel_os::spawner(autostart)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `ariel_os::spawner` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: ... because this function has a second parameter
-  --> tests/ui/spawner/missing_peripherals_param.rs:10:9
-   |
-10 | fn main(_spawner: Spawner, _peripherals: Peripherals) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> tests/ui/spawner/missing_peripherals_param.rs:9:9
+  |
+9 | fn main(_spawner: Spawner, _peripherals: Peripherals) {}
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/ariel-os-macros/tests/ui/spawner/no_autostart_param.rs
+++ b/src/ariel-os-macros/tests/ui/spawner/no_autostart_param.rs
@@ -1,5 +1,4 @@
 #![no_main]
-#![feature(used_with_arg)]
 
 // As the macro will fail, this import will not get used
 #[allow(unused_imports)]

--- a/src/ariel-os-macros/tests/ui/spawner/no_autostart_param.stderr
+++ b/src/ariel-os-macros/tests/ui/spawner/no_autostart_param.stderr
@@ -1,7 +1,7 @@
 error: custom attribute panicked
- --> tests/ui/spawner/no_autostart_param.rs:9:1
+ --> tests/ui/spawner/no_autostart_param.rs:8:1
   |
-9 | #[ariel_os::spawner]
+8 | #[ariel_os::spawner]
   | ^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: the `autostart` parameter must be provided

--- a/src/ariel-os-macros/tests/ui/task/forbidden_pool_size_on_autostart_task.rs
+++ b/src/ariel-os-macros/tests/ui/task/forbidden_pool_size_on_autostart_task.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 // FAIL: the `pool_size` parameter cannot be used on autostart task
 #[ariel_os::task(autostart, pool_size = 4)]

--- a/src/ariel-os-macros/tests/ui/task/forbidden_pool_size_on_autostart_task.stderr
+++ b/src/ariel-os-macros/tests/ui/task/forbidden_pool_size_on_autostart_task.stderr
@@ -1,7 +1,7 @@
 error: custom attribute panicked
- --> tests/ui/task/forbidden_pool_size_on_autostart_task.rs:6:1
+ --> tests/ui/task/forbidden_pool_size_on_autostart_task.rs:5:1
   |
-6 | #[ariel_os::task(autostart, pool_size = 4)]
+5 | #[ariel_os::task(autostart, pool_size = 4)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: pool size cannot be set on an `autostart` task

--- a/src/ariel-os-macros/tests/ui/task/incorrect_fn_peripheral_param_type.rs
+++ b/src/ariel-os-macros/tests/ui/task/incorrect_fn_peripheral_param_type.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 // FAIL: the function is expected to take a type having a `take_peripherals()` method as first
 // parameter

--- a/src/ariel-os-macros/tests/ui/task/incorrect_fn_peripheral_param_type.stderr
+++ b/src/ariel-os-macros/tests/ui/task/incorrect_fn_peripheral_param_type.stderr
@@ -1,7 +1,7 @@
 error[E0599]: no method named `take_peripherals` found for mutable reference `&mut OptionalPeripherals` in the current scope
- --> tests/ui/task/incorrect_fn_peripheral_param_type.rs:7:1
+ --> tests/ui/task/incorrect_fn_peripheral_param_type.rs:6:1
   |
-7 | #[ariel_os::task(autostart, peripherals)]
+6 | #[ariel_os::task(autostart, peripherals)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `&mut OptionalPeripherals`
   |
   = note: this error originates in the attribute macro `ariel_os::task` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/ariel-os-macros/tests/ui/task/missing_autostart_param_for_hook.rs
+++ b/src/ariel-os-macros/tests/ui/task/missing_autostart_param_for_hook.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 // FAIL: using hooks require the task to be autostart
 #[ariel_os::task(usb_builder_hook)]

--- a/src/ariel-os-macros/tests/ui/task/missing_autostart_param_for_hook.stderr
+++ b/src/ariel-os-macros/tests/ui/task/missing_autostart_param_for_hook.stderr
@@ -1,7 +1,7 @@
 error: custom attribute panicked
- --> tests/ui/task/missing_autostart_param_for_hook.rs:6:1
+ --> tests/ui/task/missing_autostart_param_for_hook.rs:5:1
   |
-6 | #[ariel_os::task(usb_builder_hook)]
+5 | #[ariel_os::task(usb_builder_hook)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: the task must be `autostart` to instantiate hooks

--- a/src/ariel-os-macros/tests/ui/task/missing_autostart_param_for_peripherals.rs
+++ b/src/ariel-os-macros/tests/ui/task/missing_autostart_param_for_peripherals.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 // FAIL: the `autostart` parameter must be present when requesting peripherals
 #[ariel_os::task(peripherals)]

--- a/src/ariel-os-macros/tests/ui/task/missing_autostart_param_for_peripherals.stderr
+++ b/src/ariel-os-macros/tests/ui/task/missing_autostart_param_for_peripherals.stderr
@@ -1,7 +1,7 @@
 error: custom attribute panicked
- --> tests/ui/task/missing_autostart_param_for_peripherals.rs:6:1
+ --> tests/ui/task/missing_autostart_param_for_peripherals.rs:5:1
   |
-6 | #[ariel_os::task(peripherals)]
+5 | #[ariel_os::task(peripherals)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: the task must be `autostart` to receive peripherals

--- a/src/ariel-os-macros/tests/ui/task/missing_peripherals_param.rs
+++ b/src/ariel-os-macros/tests/ui/task/missing_peripherals_param.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 // FAIL: the `peripherals` parameter is required in this case
 #[ariel_os::task(autostart)]

--- a/src/ariel-os-macros/tests/ui/task/missing_peripherals_param.stderr
+++ b/src/ariel-os-macros/tests/ui/task/missing_peripherals_param.stderr
@@ -1,7 +1,7 @@
 error: custom attribute panicked
- --> tests/ui/task/missing_peripherals_param.rs:6:1
+ --> tests/ui/task/missing_peripherals_param.rs:5:1
   |
-6 | #[ariel_os::task(autostart)]
+5 | #[ariel_os::task(autostart)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: to provide this function with peripherals, use the `peripherals` macro parameter

--- a/src/ariel-os-macros/tests/ui/task/misspelled_hook_name.rs
+++ b/src/ariel-os-macros/tests/ui/task/misspelled_hook_name.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 // FAIL: misspelled hook name
 #[ariel_os::task(autostart, usb_builder_hooook)]

--- a/src/ariel-os-macros/tests/ui/task/misspelled_hook_name.stderr
+++ b/src/ariel-os-macros/tests/ui/task/misspelled_hook_name.stderr
@@ -1,5 +1,5 @@
 error: unsupported parameter (`autostart`, `peripherals`, `pool_size`, and hooks `usb_builder_hook` are supported)
- --> tests/ui/task/misspelled_hook_name.rs:6:29
+ --> tests/ui/task/misspelled_hook_name.rs:5:29
   |
-6 | #[ariel_os::task(autostart, usb_builder_hooook)]
+5 | #[ariel_os::task(autostart, usb_builder_hooook)]
   |                             ^^^^^^^^^^^^^^^^^^

--- a/src/ariel-os-macros/tests/ui/task/non_async_fn.rs
+++ b/src/ariel-os-macros/tests/ui/task/non_async_fn.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 // FAIL: the function must be async
 #[ariel_os::task]

--- a/src/ariel-os-macros/tests/ui/task/non_async_fn.stderr
+++ b/src/ariel-os-macros/tests/ui/task/non_async_fn.stderr
@@ -1,7 +1,7 @@
 error: custom attribute panicked
- --> tests/ui/task/non_async_fn.rs:6:1
+ --> tests/ui/task/non_async_fn.rs:5:1
   |
-6 | #[ariel_os::task]
+5 | #[ariel_os::task]
   | ^^^^^^^^^^^^^^^^^
   |
   = help: message: the function must be async

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -41,6 +41,17 @@ fn main() {
         println!("cargo:rerun-if-changed=isr_stack.ld.in");
     }
 
+    if context("riscv") {
+        let region_alias = if context("esp32c3") {
+            "REGION_ALIAS(FLASH, DROM)"
+        } else if context("esp32c6") {
+            "REGION_ALIAS(FLASH, ROM)"
+        } else {
+            panic!("unexpected riscv platform");
+        };
+        std::fs::write(out.join("linkme-region-alias.x"), region_alias).unwrap();
+    }
+
     std::fs::copy("linkme.x", out.join("linkme.x")).unwrap();
     std::fs::copy("eheap.x", out.join("eheap.x")).unwrap();
     std::fs::copy("keep-stack-sizes.x", out.join("keep-stack-sizes.x")).unwrap();

--- a/src/ariel-os-rt/linkme.x
+++ b/src/ariel-os-rt/linkme.x
@@ -1,12 +1,12 @@
 SECTIONS {
-  linkme_INIT_FUNCS : { *(linkme_INIT_FUNCS) } > FLASH
-  linkm2_INIT_FUNCS : { *(linkm2_INIT_FUNCS) } > FLASH
-  linkme_EMBASSY_TASKS : { *(linkme_EMBASSY_TASKS) } > FLASH
-  linkm2_EMBASSY_TASKS : { *(linkm2_EMBASSY_TASKS) } > FLASH
-  linkme_USB_BUILDER_HOOKS : { *(linkme_USB_BUILDER_HOOKS) } > FLASH
-  linkm2_USB_BUILDER_HOOKS : { *(linkm2_USB_BUILDER_HOOKS) } > FLASH
-  linkme_THREAD_FNS : { *(linkme_THREAD_FNS) } > FLASH
-  linkm2_THREAD_FNS : { *(linkm2_THREAD_FNS) } > FLASH
+  linkme_INIT_FUNCS : { KEEP(*(linkme_INIT_FUNCS)) } > FLASH
+  linkm2_INIT_FUNCS : { KEEP(*(linkm2_INIT_FUNCS)) } > FLASH
+  linkme_EMBASSY_TASKS : { KEEP(*(linkme_EMBASSY_TASKS)) } > FLASH
+  linkm2_EMBASSY_TASKS : { KEEP(*(linkm2_EMBASSY_TASKS)) } > FLASH
+  linkme_USB_BUILDER_HOOKS : { KEEP(*(linkme_USB_BUILDER_HOOKS)) } > FLASH
+  linkm2_USB_BUILDER_HOOKS : { KEEP(*(linkm2_USB_BUILDER_HOOKS)) } > FLASH
+  linkme_THREAD_FNS : { KEEP(*(linkme_THREAD_FNS)) } > FLASH
+  linkm2_THREAD_FNS : { KEEP(*(linkm2_THREAD_FNS)) } > FLASH
 }
 
 INSERT AFTER .rodata

--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -4,10 +4,6 @@
 #![allow(incomplete_features)]
 // - const_generics
 
-// features
-// linkme
-#![feature(used_with_arg)]
-
 #[cfg(feature = "threading")]
 mod threading;
 

--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -22,7 +22,6 @@
 //! - [`thread_flags`]: thread-flag implementation for signaling between threads
 
 #![cfg_attr(not(test), no_std)]
-#![feature(used_with_arg)]
 #![feature(negative_impls)]
 #![cfg_attr(target_arch = "xtensa", feature(asm_experimental_arch))]
 #![deny(missing_docs)]

--- a/tests/benchmarks/bench_sched_flags/src/main.rs
+++ b/tests/benchmarks/bench_sched_flags/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(type_alias_impl_trait)]
-#![feature(used_with_arg)]
 
 use ariel_os::{
     debug::log::*,

--- a/tests/benchmarks/bench_sched_yield/src/main.rs
+++ b/tests/benchmarks/bench_sched_yield/src/main.rs
@@ -1,6 +1,5 @@
 #![no_main]
 #![no_std]
-#![feature(used_with_arg)]
 
 use ariel_os::{debug::println, thread};
 

--- a/tests/coap-blinky/src/main.rs
+++ b/tests/coap-blinky/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 #[path = "../../../examples/blinky/src/pins.rs"]
 mod pins;

--- a/tests/coap/src/main.rs
+++ b/tests/coap/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 #[ariel_os::task(autostart)]
 async fn coap_run() {

--- a/tests/gpio-interrupt-nrf/src/main.rs
+++ b/tests/gpio-interrupt-nrf/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 use ariel_os::{
     debug::{ExitCode, exit, log::info},

--- a/tests/gpio-interrupt-stm32/src/main.rs
+++ b/tests/gpio-interrupt-stm32/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 use ariel_os::{
     debug::{ExitCode, exit, log::info},

--- a/tests/gpio/src/test.rs
+++ b/tests/gpio/src/test.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(used_with_arg)]
 
 mod pins;
 

--- a/tests/i2c-controller/src/main.rs
+++ b/tests/i2c-controller/src/main.rs
@@ -7,7 +7,6 @@
 #![no_main]
 #![no_std]
 #![feature(type_alias_impl_trait)]
-#![feature(used_with_arg)]
 #![feature(impl_trait_in_assoc_type)]
 
 mod pins;

--- a/tests/spi-loopback/src/main.rs
+++ b/tests/spi-loopback/src/main.rs
@@ -5,7 +5,6 @@
 #![no_main]
 #![no_std]
 #![feature(type_alias_impl_trait)]
-#![feature(used_with_arg)]
 #![feature(impl_trait_in_assoc_type)]
 
 mod pins;

--- a/tests/spi-main/src/main.rs
+++ b/tests/spi-main/src/main.rs
@@ -7,7 +7,6 @@
 #![no_main]
 #![no_std]
 #![feature(type_alias_impl_trait)]
-#![feature(used_with_arg)]
 #![feature(impl_trait_in_assoc_type)]
 
 mod pins;

--- a/tests/threading-dynamic-prios/src/main.rs
+++ b/tests/threading-dynamic-prios/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(type_alias_impl_trait)]
-#![feature(used_with_arg)]
 
 use portable_atomic::{AtomicUsize, Ordering};
 

--- a/tests/threading-lock/src/main.rs
+++ b/tests/threading-lock/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(type_alias_impl_trait)]
-#![feature(used_with_arg)]
 
 use ariel_os::{
     debug::{ExitCode, exit},

--- a/tests/threading-mutex/src/main.rs
+++ b/tests/threading-mutex/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 #![no_std]
 #![feature(type_alias_impl_trait)]
-#![feature(used_with_arg)]
 
 use ariel_os::thread::{self, RunqueueId, ThreadId, sync::Mutex, thread_flags};
 use portable_atomic::{AtomicUsize, Ordering};


### PR DESCRIPTION
# Description

It seems adding `KEEP` to the listed sections in `linkme.x` is sufficient to keep the linker from garbage collecting our distributed slices, which would make the `used_with_arg` unstable feature unnecessary.

This one should be carefully tested, linkme errors produces non-working binaries...

## Issues/PRs references

#298 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
