### PR TITLE
feat: enable building on stable Rust

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -61,7 +61,7 @@ jobs:
       # faster generation.
       - name: Build rustdoc docs
         run: |
-          cargo doc \
+          RUSTDOCFLAGS='--cfg nightly' cargo doc \
               --no-deps \
               -p ariel-os \
               -p coapcore \
@@ -90,7 +90,7 @@ jobs:
                   usb-hid,
                   coapcore/_nightly_docs
                   "
-          RUSTDOCFLAGS='-D warnings --cfg context="esp32c6"' cargo doc \
+          RUSTDOCFLAGS='-D warnings --cfg context="esp32c6" --cfg nightly' cargo doc \
               --target=riscv32imac-unknown-none-elf \
               --no-deps \
               --features "
@@ -101,7 +101,7 @@ jobs:
                   spi,
                   " \
               -p ariel-os-esp
-          RUSTDOCFLAGS='-D warnings --cfg context="rp" --cfg context="rp2040"' cargo doc \
+          RUSTDOCFLAGS='-D warnings --cfg context="rp" --cfg context="rp2040" --cfg nightly' cargo doc \
               --no-deps \
               --features "
                   embassy-rp/rp2040,
@@ -110,7 +110,7 @@ jobs:
                   spi,
                   " \
               -p ariel-os-rp
-          RUSTDOCFLAGS='-D warnings --cfg context="nrf52840"' cargo doc \
+          RUSTDOCFLAGS='-D warnings --cfg context="nrf52840" --cfg nightly' cargo doc \
               --no-deps \
               --features "
                   embassy-nrf/nrf52840,
@@ -119,7 +119,7 @@ jobs:
                   spi,
                   " \
               -p ariel-os-nrf
-          RUSTDOCFLAGS='-D warnings --cfg context="stm32wb55rg"' cargo doc \
+          RUSTDOCFLAGS='-D warnings --cfg context="stm32wb55rg" --cfg nightly' cargo doc \
               --no-deps \
               --features "
                   embassy-stm32/stm32wb55rg,
@@ -140,8 +140,8 @@ jobs:
 
       - name: Check for unexpected cmdrun uses
         run: |
-            cd book
-            ./cmdrun-check.sh
+          cd book
+          ./cmdrun-check.sh
 
       - name: Build the book
         run: |
@@ -163,8 +163,8 @@ jobs:
         continue-on-error: true
         id: check
         run: |
-            hash="$(curl https://ariel-os.github.io/ariel-os/_hash | head -n 1)"
-            test "$hash" != "$(cat ./_site/_hash)"
+          hash="$(curl https://ariel-os.github.io/ariel-os/_hash | head -n 1)"
+          test "$hash" != "$(cat ./_site/_hash)"
 
       - name: Upload artifact (PR)
         if: github.event_name == 'pull_request' && steps.check.conclusion == 'success'

--- a/examples/http-server/laze.yml
+++ b/examples/http-server/laze.yml
@@ -7,6 +7,9 @@ apps:
     selects:
       - network
       - ?button-reading
+    conflicts:
+      # needs `feature(type_alias_impl_trait)`
+      - stable
 
 modules:
   - name: button-reading

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -25,6 +25,8 @@ contexts:
       - ?hw/device-identity
       - ?lto
       - ?semihosting
+      - ?nightly
+      - ?stable
     env:
       RUSTFLAGS:
         - ${RUSTFLAGS_CONTEXTS}
@@ -331,7 +333,6 @@ contexts:
     selects:
       - xtensa
     env:
-      CARGO_TOOLCHAIN: +esp
       RUSTC_TARGET: xtensa-esp32-none-elf
       CARGO_TARGET_PREFIX: CARGO_TARGET_XTENSA_ESP32_NONE_ELF
       CC: xtensa-esp32-elf-gcc
@@ -380,7 +381,6 @@ contexts:
       - sw/benchmark
     provides_unique: [c-function-abort]
     env:
-      CARGO_TOOLCHAIN: +esp
       RUSTC_TARGET: xtensa-esp32s3-none-elf
       PROBE_RS_CHIP: esp32s3
       PROBE_RS_PROTOCOL: jtag
@@ -581,8 +581,12 @@ modules:
           - --cfg context=\"cortex-m33f\"
 
   - name: xtensa
+    conflicts:
+      # no xtensa in stable Rust
+      - stable
     env:
       global:
+        CARGO_TOOLCHAIN: +esp
         RUSTFLAGS:
           - --cfg context=\"xtensa\"
         CFLAGS:
@@ -643,6 +647,25 @@ modules:
       global:
         FEATURES:
           - ariel-os/debug-console
+
+  - name: stable
+    help: build with stable Rust
+    conflicts:
+      - nightly
+    env:
+      global:
+        CARGO_TOOLCHAIN: +stable
+        RUSTFLAGS:
+          - --cfg stable
+
+  - name: nightly
+    help: build with nightly Rust
+    conflicts:
+      - stable
+    env:
+      global:
+        RUSTFLAGS:
+          - --cfg nightly
 
   # This module should be hard-selected when an application *requires* debug
   # logging.

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -511,6 +511,8 @@ modules:
           - --cfg armv8m
 
   - name: cortex-m
+    selects:
+      - ?emit-stack-sizes
     env:
       global:
         OBJCOPY: arm-none-eabi-objcopy
@@ -522,9 +524,7 @@ modules:
           - -Clink-arg=-Teheap.x
           - -Clink-arg=-Tdevice.x
           - -Clink-arg=-Tisr_stack.x
-          - -Clink-arg=-Tkeep-stack-sizes.x
           - --cfg context=\"cortex-m\"
-          - -Z emit-stack-sizes
 
   - name: cortex-m0
     selects:
@@ -647,6 +647,15 @@ modules:
       global:
         FEATURES:
           - ariel-os/debug-console
+
+  - name: emit-stack-sizes
+    conflicts:
+      - stable
+    env:
+      global:
+        RUSTFLAGS:
+          - -Clink-arg=-Tkeep-stack-sizes.x
+          - -Z emit-stack-sizes
 
   - name: stable
     help: build with stable Rust

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -734,6 +734,8 @@ modules:
 
   - name: build_std
     context: ariel-os
+    conflicts:
+      - stable
     env:
       global:
         CARGO_ARGS:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -325,8 +325,6 @@ contexts:
         - -Clink-arg=-Tlinkall.x
         # this might be needed for backtraces. it is needed for probe-rs.
         - -C force-frame-pointers
-      CARGO_ARGS:
-        - -Zbuild-std=core,alloc
 
   - name: esp32
     parent: esp
@@ -591,6 +589,8 @@ modules:
           - --cfg context=\"xtensa\"
         CFLAGS:
           - -mlongcalls
+        CARGO_ARGS:
+          - -Zbuild-std=core,alloc
         CARGO_PRESHELL:
           # ~/export-esp.sh is the common location, but espup install can
           # override it with its --export-file argument, which is done in CI;

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1263,8 +1263,9 @@ modules:
       - probe-rs
     tasks:
       test:
+        workdir: ${appdir}
         cmd:
-          - ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} -Z unstable-options -C${appdir} test ${FEATURES}
+          - ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} test ${FEATURES}
         build: false
 
     env:

--- a/src/ariel-os-debug-log/src/lib.rs
+++ b/src/ariel-os-debug-log/src/lib.rs
@@ -11,7 +11,7 @@
 //! feature; please refer to the documentation of those crates for details on the supported syntax.
 
 #![cfg_attr(not(test), no_std)]
-#![feature(doc_auto_cfg)]
+#![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
 #![deny(clippy::pedantic)]
 

--- a/src/ariel-os-embassy-common/src/lib.rs
+++ b/src/ariel-os-embassy-common/src/lib.rs
@@ -1,7 +1,7 @@
 //! HAL-agnostic types shared between HALs.
 
 #![no_std]
-#![feature(doc_auto_cfg)]
+#![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![deny(clippy::pedantic)]
 #![deny(missing_docs)]
 

--- a/src/ariel-os-embassy/src/delegate.rs
+++ b/src/ariel-os-embassy/src/delegate.rs
@@ -1,5 +1,7 @@
 //! Delegate or lend an object to another task.
 
+use core::marker::PhantomData;
+
 use embassy_executor::Spawner;
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 use portable_atomic::{AtomicBool, Ordering};
@@ -41,9 +43,10 @@ pub struct Delegate<T> {
     send: Signal<CriticalSectionRawMutex, SameExecutorCell<*mut T>>,
     reply: Signal<CriticalSectionRawMutex, ()>,
     was_exercised: AtomicBool,
+    _not_send: PhantomData<*const ()>,
 }
 
-impl<T> !Send for Delegate<T> {}
+unsafe impl<T> Sync for Delegate<T> {}
 
 impl<T> Delegate<T> {
     /// Creates a new [`Delegate`].
@@ -53,6 +56,7 @@ impl<T> Delegate<T> {
             send: Signal::new(),
             reply: Signal::new(),
             was_exercised: AtomicBool::new(false),
+            _not_send: PhantomData,
         }
     }
 

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -1,7 +1,7 @@
 //! This module provides an opinionated integration of `embassy`.
 
 #![no_std]
-#![feature(doc_auto_cfg)]
+#![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![feature(negative_impls)]
 #![deny(clippy::pedantic)]
 

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![cfg_attr(nightly, feature(doc_auto_cfg))]
-#![feature(negative_impls)]
 #![deny(clippy::pedantic)]
 
 pub mod gpio;

--- a/src/ariel-os-esp/src/lib.rs
+++ b/src/ariel-os-esp/src/lib.rs
@@ -1,7 +1,7 @@
 //! Items specific to the Espressif ESP MCUs.
 
 #![no_std]
-#![feature(doc_auto_cfg)]
+#![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
 
 #[cfg(all(feature = "threading", feature = "wifi"))]

--- a/src/ariel-os-nrf/src/lib.rs
+++ b/src/ariel-os-nrf/src/lib.rs
@@ -1,7 +1,7 @@
 //! Items specific to the Nordic Semiconductor nRF MCUs.
 
 #![no_std]
-#![feature(doc_auto_cfg)]
+#![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
 
 pub mod gpio;

--- a/src/ariel-os-rp/src/lib.rs
+++ b/src/ariel-os-rp/src/lib.rs
@@ -1,7 +1,7 @@
 //! Items specific to the Raspberry Pi RP MCUs.
 
 #![no_std]
-#![feature(doc_auto_cfg)]
+#![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
 
 pub mod gpio;

--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -1,7 +1,7 @@
 //! Items specific to the STMicroelectronics STM32 MCUs.
 
 #![no_std]
-#![feature(doc_auto_cfg)]
+#![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
 
 pub mod gpio;

--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -22,7 +22,6 @@
 //! - [`thread_flags`]: thread-flag implementation for signaling between threads
 
 #![cfg_attr(not(test), no_std)]
-#![feature(negative_impls)]
 #![cfg_attr(target_arch = "xtensa", feature(asm_experimental_arch))]
 #![deny(missing_docs)]
 #![deny(clippy::pedantic)]

--- a/src/ariel-os/src/lib.rs
+++ b/src/ariel-os/src/lib.rs
@@ -20,7 +20,7 @@
 //!  to configure the operating system.
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![no_std]
-#![feature(doc_auto_cfg)]
+#![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
 
 #[cfg(feature = "bench")]


### PR DESCRIPTION
# Description

This PR adds stable Rust support. It is ~~WIP~~ a first iteration.

<!-- Please write a summary of your changes and why you made them.-->

- nightly is still default
- CI only builds nightly
- `examples/http-server` is using `type_alias_impl_trait` and thus conflicts `stable`.

## Issues/PRs references

unstable tracking list in #298.

Depends on #950.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

- [x] Do we wait for the embassy-executor(-macros) release? => no, that is already merged in #982 
- [x] how to choose toolchain with espup? currently does `+esp` => xtensa always nightly

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
