### PR TITLE
fix(rp): mark `link_section` as `unsafe`

### DIFF
--- a/src/ariel-os-rp/src/picotool.rs
+++ b/src/ariel-os-rp/src/picotool.rs
@@ -1,10 +1,14 @@
 use embassy_rp::block::ImageDef;
-#[link_section = ".start_block"]
+// Safety:
+// This is where tooling expects this.
+#[unsafe(link_section = ".start_block")]
 #[used]
 pub static IMAGE_DEF: ImageDef = ImageDef::secure_exe();
 
 // Program metadata for `picotool info`
-#[link_section = ".bi_entries"]
+// Safety:
+// `.bl_entry` is where picotool expects this.
+#[unsafe(link_section = ".bi_entries")]
 #[used]
 pub static PICOTOOL_ENTRIES: [embassy_rp::binary_info::EntryAddr; 4] = [
     embassy_rp::binary_info::rp_program_name!(c"Ariel OS"),


### PR DESCRIPTION
# Description

Fixes build on rpi-pico2 that was [broken](https://github.com/ariel-os/ariel-os/actions/runs/14141849571/job/39624309023#step:15:1095) by #584.
<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
