### PR TITLE
chore(laze): drop redundant `PROBE_RS_PROTOCOL` for STM32 MCUs

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -405,7 +405,6 @@ contexts:
       isr_stacksize_required_default: "1024"
       executor_stacksize_required_default: "3072"
       PROBE_RS_CHIP: STM32C031C6Tx
-      PROBE_RS_PROTOCOL: swd
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.
         - CONFIG_SWI=USART2
@@ -418,7 +417,6 @@ contexts:
       - has_swi
     env:
       PROBE_RS_CHIP: STM32F401RETx
-      PROBE_RS_PROTOCOL: swd
       RUSTFLAGS:
         - --cfg capability=\"async-flash-driver\"
       CARGO_ENV:
@@ -436,7 +434,6 @@ contexts:
       - has_swi
     env:
       PROBE_RS_CHIP: STM32H755ZITx
-      PROBE_RS_PROTOCOL: swd
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-dual-core\"
         - --cfg capability=\"hw/stm32-hash-rng\"
@@ -455,7 +452,6 @@ contexts:
       - has_swi
     env:
       PROBE_RS_CHIP: STM32WB55RGVx
-      PROBE_RS_PROTOCOL: swd
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
         - --cfg capability=\"hw/stm32-usb-lp\"
@@ -472,7 +468,6 @@ contexts:
       - has_swi
     env:
       PROBE_RS_CHIP: STM32WBA55CGUx
-      PROBE_RS_PROTOCOL: swd
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
       CARGO_ENV:


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This drops the redundant `PROBE_RS_PROTOCOL` variable from STM32 laze contexts, so that the value transitively inherited from the `ariel-os` context (`swd`) is used instead.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
