### PR TITLE
chore(stm32): drop unneeded info from probe-rs chip names

### DIFF
--- a/book/src/adding-board-support.md
+++ b/book/src/adding-board-support.md
@@ -38,7 +38,7 @@ contexts:
     selects:
       - thumbv7em-none-eabi # actually eabihf, but ariel-os doesn't support hard float yet
     env:
-      PROBE_RS_CHIP: STM32F401RETx
+      PROBE_RS_CHIP: STM32F401RE
       PROBE_RS_PROTOCOL: swd
       RUSTFLAGS:
         - --cfg context=\"stm32f401retx\"

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -404,7 +404,7 @@ contexts:
     env:
       isr_stacksize_required_default: "1024"
       executor_stacksize_required_default: "3072"
-      PROBE_RS_CHIP: STM32C031C6Tx
+      PROBE_RS_CHIP: STM32C031C6
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.
         - CONFIG_SWI=USART2
@@ -416,7 +416,7 @@ contexts:
     provides:
       - has_swi
     env:
-      PROBE_RS_CHIP: STM32F401RETx
+      PROBE_RS_CHIP: STM32F401RE
       RUSTFLAGS:
         - --cfg capability=\"async-flash-driver\"
       CARGO_ENV:
@@ -433,7 +433,7 @@ contexts:
       - has_storage_support
       - has_swi
     env:
-      PROBE_RS_CHIP: STM32H755ZITx
+      PROBE_RS_CHIP: STM32H755ZI
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-dual-core\"
         - --cfg capability=\"hw/stm32-hash-rng\"
@@ -451,7 +451,7 @@ contexts:
       - has_storage_support
       - has_swi
     env:
-      PROBE_RS_CHIP: STM32WB55RGVx
+      PROBE_RS_CHIP: STM32WB55RG
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
         - --cfg capability=\"hw/stm32-usb-lp\"
@@ -467,7 +467,7 @@ contexts:
       - has_hwrng
       - has_swi
     env:
-      PROBE_RS_CHIP: STM32WBA55CGUx
+      PROBE_RS_CHIP: STM32WBA55CG
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
       CARGO_ENV:


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This drops the package type and temperature range from the `PROBE_RS_CHIP` values specified in STM32 laze contexts, which are passed to probe-rs as `--chip ${PROBE_RS_CHIP}`. This still works because probe-rs actually prefix-matches the chip names.

Removing these will allow to greatly simplify the laze contexts for STM32 MCUs and the `ariel-os-stm32-mapping` crate recently added in #928.

## Testing

Successfully tested on st-nucleo-c031c6, st-nucleo-h755zi-q, and st-nucleo-wb55.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
