### PR TITLE
refactor(stm32): move the SWI selection to the boards, from the MCUs

### DIFF
--- a/book/src/adding-board-support.md
+++ b/book/src/adding-board-support.md
@@ -8,6 +8,10 @@ Feel free to report anything that is unclear or missing!
 > This guide requires working on your own copy of Ariel OS.
 > You may want to fork the repository to easily upstream your changes later.
 
+> Unless documented in the User Guide, please expect the module and context names that are defined in the `laze-project.yml` file to change.
+> We're still figuring out a proper naming scheme.
+> You've been warned.
+
 ## Adding Support for a Board
 
 The more similar a board is to one that is already supported, the easier.
@@ -36,6 +40,11 @@ builders:
   # ...
   - name: st-nucleo-f401re
     parent: stm32f401re
+    provides:
+      - has_swi
+    env:
+      CARGO_ENV:
+        - CONFIG_SWI=USART2
 ```
 
 ## Adding Support for an MCU from a Supported MCU family

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -396,8 +396,6 @@ contexts:
     parent: stm32
     selects:
       - cortex-m0-plus
-    provides:
-      - has_swi
     disables:
       # TODO: embedded-test currently hard-codes 16k for its thread
       - embedded-test
@@ -405,23 +403,15 @@ contexts:
       isr_stacksize_required_default: "1024"
       executor_stacksize_required_default: "3072"
       PROBE_RS_CHIP: STM32C031C6
-      CARGO_ENV:
-        # This ISR is unused on a naked board. Configured here for testing.
-        - CONFIG_SWI=USART2
 
   - name: stm32f401re
     parent: stm32
     selects:
       - cortex-m4f
-    provides:
-      - has_swi
     env:
       PROBE_RS_CHIP: STM32F401RE
       RUSTFLAGS:
         - --cfg capability=\"async-flash-driver\"
-      CARGO_ENV:
-        # This ISR is unused on a naked board. Configured here for testing.
-        - CONFIG_SWI=USART2
 
   - name: stm32h755zi
     parent: stm32
@@ -431,16 +421,12 @@ contexts:
     provides:
       - has_hwrng
       - has_storage_support
-      - has_swi
     env:
       PROBE_RS_CHIP: STM32H755ZI
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-dual-core\"
         - --cfg capability=\"hw/stm32-hash-rng\"
         - --cfg capability=\"hw/stm32-usb-synopsis\"
-      CARGO_ENV:
-        # This ISR is unused on a naked board. Configured here for testing.
-        - CONFIG_SWI=UART5
 
   - name: stm32wb55rg
     parent: stm32
@@ -449,15 +435,11 @@ contexts:
     provides:
       - has_hwrng
       - has_storage_support
-      - has_swi
     env:
       PROBE_RS_CHIP: STM32WB55RG
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
         - --cfg capability=\"hw/stm32-usb-lp\"
-      CARGO_ENV:
-        # This ISR is unused on a naked board. Configured here for testing.
-        - CONFIG_SWI=LPUART1
 
   - name: stm32wba55cg
     parent: stm32
@@ -465,14 +447,10 @@ contexts:
       - cortex-m33f
     provides:
       - has_hwrng
-      - has_swi
     env:
       PROBE_RS_CHIP: STM32WBA55CG
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
-      CARGO_ENV:
-        # This ISR is unused on a naked board. Configured here for testing.
-        - CONFIG_SWI=LPUART1
 
 modules:
   - name: thumbv6m-none-eabi
@@ -1406,6 +1384,12 @@ builders:
 
   - name: st-nucleo-c031c6
     parent: stm32c031c6
+    provides:
+      - has_swi
+    env:
+      CARGO_ENV:
+        # This ISR is unused on a naked board. Configured here for testing.
+        - CONFIG_SWI=USART2
 
   # TODO: there also is a companion nrf52840 on this board
   - name: nrf9160dk
@@ -1413,19 +1397,41 @@ builders:
 
   - name: st-nucleo-f401re
     parent: stm32f401re
+    provides:
+      - has_swi
+    env:
+      CARGO_ENV:
+        # This ISR is unused on a naked board. Configured here for testing.
+        - CONFIG_SWI=USART2
 
   - name: st-nucleo-h755zi-q
     parent: stm32h755zi
     provides:
+      - has_swi
       - has_usb_device_port
+    env:
+      CARGO_ENV:
+        # This ISR is unused on a naked board. Configured here for testing.
+        - CONFIG_SWI=UART5
 
   - name: st-nucleo-wb55
     parent: stm32wb55rg
     provides:
+      - has_swi
       - has_usb_device_port
+    env:
+      CARGO_ENV:
+        # This ISR is unused on a naked board. Configured here for testing.
+        - CONFIG_SWI=LPUART1
 
   - name: st-nucleo-wba55
     parent: stm32wba55cg
+    provides:
+      - has_swi
+    env:
+      CARGO_ENV:
+        # This ISR is unused on a naked board. Configured here for testing.
+        - CONFIG_SWI=LPUART1
 
 apps:
   # define a dummy host application so the host tasks work


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This moves the definitions of `CONFIG_SWI` to the board laze contexts where they belong, as already documented in the book.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #959.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
