### PR TITLE
 feat(stm32c0): complete support for I2C in controller mode

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -162,7 +162,7 @@ chips:
       debug_output: supported
       ethernet_over_usb: not_available
       hwrng: not_available
-      i2c_controller: needs_testing
+      i2c_controller: supported
       spi_main: needs_testing
       logging: supported
       storage:

--- a/src/ariel-os-stm32/src/i2c/controller/mod.rs
+++ b/src/ariel-os-stm32/src/i2c/controller/mod.rs
@@ -4,7 +4,7 @@ use ariel_os_embassy_common::{i2c::controller::Kilohertz, impl_async_i2c_for_dri
 use embassy_embedded_hal::adapter::{BlockingAsync, YieldingAsync};
 use embassy_stm32::{
     Peripheral, bind_interrupts,
-    i2c::{ErrorInterruptHandler, EventInterruptHandler, I2c as InnerI2c, SclPin, SdaPin},
+    i2c::{EventInterruptHandler, I2c as InnerI2c, SclPin, SdaPin},
     mode::Blocking,
     peripherals,
     time::Hertz,
@@ -120,7 +120,7 @@ impl From<Frequency> for Hertz {
 }
 
 macro_rules! define_i2c_drivers {
-    ($( $ev_interrupt:ident + $er_interrupt:ident => $peripheral:ident ),* $(,)?) => {
+    ($( $ev_interrupt:ident $( + $er_interrupt:ident )? => $peripheral:ident ),* $(,)?) => {
         $(
             /// Peripheral-specific I2C driver.
             // NOTE(hal): this is not required in this HAL, as the inner I2C type is
@@ -148,7 +148,7 @@ macro_rules! define_i2c_drivers {
                     bind_interrupts!(
                         struct Irqs {
                             $ev_interrupt => EventInterruptHandler<peripherals::$peripheral>;
-                            $er_interrupt => ErrorInterruptHandler<peripherals::$peripheral>;
+                            $( $er_interrupt => embassy_stm32::i2c::ErrorInterruptHandler<peripherals::$peripheral>; )?
                         }
                     );
 
@@ -214,7 +214,7 @@ fn from_error(err: embassy_stm32::i2c::Error) -> ariel_os_embassy_common::i2c::c
 // Define a driver per peripheral
 #[cfg(context = "stm32c031c6")]
 define_i2c_drivers!(
-   I2C1_EV + I2C1_ER => I2C1,
+   I2C1 => I2C1,
 );
 #[cfg(context = "stm32f401re")]
 define_i2c_drivers!(

--- a/src/ariel-os-stm32/src/i2c/mod.rs
+++ b/src/ariel-os-stm32/src/i2c/mod.rs
@@ -7,7 +7,7 @@ pub mod controller;
 pub fn init(peripherals: &mut crate::OptionalPeripherals) {
     // This macro has to be defined in this function so that the `peripherals` variables exists.
     macro_rules! take_all_i2c_peripherals {
-        ($peripherals:ident, $( $peripheral:ident ),*) => {
+        ($( $peripheral:ident ),*) => {
             $(
                 let _ = peripherals.$peripheral.take().unwrap();
             )*

--- a/tests/i2c-controller/laze.yml
+++ b/tests/i2c-controller/laze.yml
@@ -8,5 +8,6 @@ apps:
       - nrf9160
       - rp2040
       - rp235xa
+      - st-nucleo-c031c6
       - st-nucleo-h755zi-q
       - st-nucleo-wb55

--- a/tests/i2c-controller/src/pins.rs
+++ b/tests/i2c-controller/src/pins.rs
@@ -31,6 +31,14 @@ ariel_os::hal::define_peripherals!(Peripherals {
     i2c_scl: PIN_13,
 });
 
+#[cfg(context = "stm32c031c6")]
+pub type SensorI2c = i2c::controller::I2C1;
+#[cfg(context = "stm32c031c6")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    i2c_sda: PB9,
+    i2c_scl: PB8,
+});
+
 #[cfg(context = "stm32h755zi")]
 pub type SensorI2c = i2c::controller::I2C1;
 #[cfg(context = "stm32h755zi")]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This fixes and completes support for I2C in controller mode on STM32C0 which was bootstrapped in #838.

## Testing

Tested `tests/i2c-controller` successfully on st-nucleo-c031c6. 

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #961.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
