### PR TITLE
 feat(stm32c0): complete support for SPI in main mode

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -163,7 +163,7 @@ chips:
       ethernet_over_usb: not_available
       hwrng: not_available
       i2c_controller: supported
-      spi_main: needs_testing
+      spi_main: supported
       logging: supported
       storage:
         status: not_currently_supported

--- a/tests/spi-loopback/src/pins.rs
+++ b/tests/spi-loopback/src/pins.rs
@@ -67,7 +67,7 @@ ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: PA5,
     spi_miso: PA6,
     spi_mosi: PA7,
-    spi_cs: PA4,
+    spi_cs: PB0,
 });
 
 // Side SPI of Arduino v3 connector

--- a/tests/spi-main/laze.yml
+++ b/tests/spi-main/laze.yml
@@ -7,5 +7,6 @@ apps:
       - nrf9160
       - rp2040
       - rp235xa
+      - st-nucleo-c031c6
       - st-nucleo-h755zi-q
       - st-nucleo-wb55

--- a/tests/spi-main/src/pins.rs
+++ b/tests/spi-main/src/pins.rs
@@ -50,6 +50,17 @@ ariel_os::hal::define_peripherals!(Peripherals {
 });
 
 // Side SPI of Arduino v3 connector
+#[cfg(context = "stm32c031c6")]
+pub type SensorSpi = spi::main::SPI1;
+#[cfg(context = "stm32c031c6")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    spi_sck: PA5,
+    spi_miso: PA6,
+    spi_mosi: PA7,
+    spi_cs: PB0,
+});
+
+// Side SPI of Arduino v3 connector
 #[cfg(context = "stm32h755zi")]
 pub type SensorSpi = spi::main::SPI1;
 #[cfg(context = "stm32h755zi")]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This tests and completes support for SPI main on STM32C0.

## Testing

Tested `tests/spi-loopback` and `tests/spi-main` successfully on st-nucleo-c031c6. 

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #962.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
