### PR TITLE
refactor(debug-log): drop use of unstable `macro_metavar_expr` feature

### DIFF
--- a/src/ariel-os-debug-log/src/lib.rs
+++ b/src/ariel-os-debug-log/src/lib.rs
@@ -11,8 +11,6 @@
 //! feature; please refer to the documentation of those crates for details on the supported syntax.
 
 #![cfg_attr(not(test), no_std)]
-// Required for nested macros with repetitions in the inner macro.
-#![feature(macro_metavar_expr)]
 #![feature(doc_auto_cfg)]
 #![deny(missing_docs)]
 #![deny(clippy::pedantic)]
@@ -47,137 +45,130 @@ pub mod log {
     pub use log::{debug, error, info, trace, warn};
 }
 
+// NOTE: log macros are defined within private modules so that `doc_auto_cfg` does not produce
+// "feature flairs" on them.
+// The macros are still exported even though they are defined "within" private modules.
 #[cfg(feature = "defmt")]
-macro_rules! define_logging_macros {
-    () => {
-        /// Logs a message at the trace level.
-        #[macro_export]
-        macro_rules! trace {
-            ($$($$arg:tt)*) => {{
-                use $crate::defmt::hidden::defmt;
-                defmt::trace!($$($$arg)*);
-            }};
-        }
+mod log_macros {
+    /// Logs a message at the trace level.
+    #[macro_export]
+    macro_rules! trace {
+        ($($arg:tt)*) => {{
+            use $crate::defmt::hidden::defmt;
+            defmt::trace!($($arg)*);
+        }};
+    }
 
-        /// Logs a message at the debug level.
-        #[macro_export]
-        macro_rules! debug {
-            ($$($$arg:tt)*) => {{
-                use $crate::defmt::hidden::defmt;
-                defmt::debug!($$($$arg)*);
-            }};
-        }
+    /// Logs a message at the debug level.
+    #[macro_export]
+    macro_rules! debug {
+        ($($arg:tt)*) => {{
+            use $crate::defmt::hidden::defmt;
+            defmt::debug!($($arg)*);
+        }};
+    }
 
-        /// Logs a message at the info level.
-        #[macro_export]
-        macro_rules! info {
-            ($$($$arg:tt)*) => {{
-                use $crate::defmt::hidden::defmt;
-                defmt::info!($$($$arg)*);
-            }};
-        }
+    /// Logs a message at the info level.
+    #[macro_export]
+    macro_rules! info {
+        ($($arg:tt)*) => {{
+            use $crate::defmt::hidden::defmt;
+            defmt::info!($($arg)*);
+        }};
+    }
 
-        /// Logs a message at the warn level.
-        #[macro_export]
-        macro_rules! warn {
-            ($$($$arg:tt)*) => {{
-                use $crate::defmt::hidden::defmt;
-                defmt::warn!($$($$arg)*);
-            }};
-        }
+    /// Logs a message at the warn level.
+    #[macro_export]
+    macro_rules! warn {
+        ($($arg:tt)*) => {{
+            use $crate::defmt::hidden::defmt;
+            defmt::warn!($($arg)*);
+        }};
+    }
 
-        /// Logs a message at the error level.
-        #[macro_export]
-        macro_rules! error {
-            ($$($$arg:tt)*) => {{
-                use $crate::defmt::hidden::defmt;
-                defmt::error!($$($$arg)*);
-            }};
-        }
+    /// Logs a message at the error level.
+    #[macro_export]
+    macro_rules! error {
+        ($($arg:tt)*) => {{
+            use $crate::defmt::hidden::defmt;
+            defmt::error!($($arg)*);
+        }};
     }
 }
 
 #[cfg(feature = "log")]
-macro_rules! define_logging_macros {
-    () => {
-        /// Logs a message at the trace level.
-        #[macro_export]
-        macro_rules! trace {
-            ($$($$arg:tt)*) => {{
-                $crate::log::trace!($$($$arg)*);
-            }};
-        }
+mod log_macros {
+    /// Logs a message at the trace level.
+    #[macro_export]
+    macro_rules! trace {
+        ($($arg:tt)*) => {{
+            $crate::log::trace!($($arg)*);
+        }};
+    }
 
-        /// Logs a message at the debug level.
-        #[macro_export]
-        macro_rules! debug {
-            ($$($$arg:tt)*) => {{
-                $crate::log::debug!($$($$arg)*);
-            }};
-        }
+    /// Logs a message at the debug level.
+    #[macro_export]
+    macro_rules! debug {
+        ($($arg:tt)*) => {{
+            $crate::log::debug!($($arg)*);
+        }};
+    }
 
-        /// Logs a message at the info level.
-        #[macro_export]
-        macro_rules! info {
-            ($$($$arg:tt)*) => {{
-                $crate::log::info!($$($$arg)*);
-            }};
-        }
+    /// Logs a message at the info level.
+    #[macro_export]
+    macro_rules! info {
+        ($($arg:tt)*) => {{
+            $crate::log::info!($($arg)*);
+        }};
+    }
 
-        /// Logs a message at the warn level.
-        #[macro_export]
-        macro_rules! warn {
-            ($$($$arg:tt)*) => {{
-                $crate::log::warn!($$($$arg)*);
-            }};
-        }
+    /// Logs a message at the warn level.
+    #[macro_export]
+    macro_rules! warn {
+        ($($arg:tt)*) => {{
+            $crate::log::warn!($($arg)*);
+        }};
+    }
 
-        /// Logs a message at the error level.
-        #[macro_export]
-        macro_rules! error {
-            ($$($$arg:tt)*) => {{
-                $crate::log::error!($$($$arg)*);
-            }};
-        }
+    /// Logs a message at the error level.
+    #[macro_export]
+    macro_rules! error {
+        ($($arg:tt)*) => {{
+            $crate::log::error!($($arg)*);
+        }};
     }
 }
 
 // Define no-op macros in case no facade is enabled.
 #[cfg(not(any(feature = "defmt", feature = "log")))]
-macro_rules! define_logging_macros {
-    () => {
-        /// Logs a message at the trace level.
-        #[macro_export]
-        macro_rules! trace {
-            ($$($$arg:tt)*) => {};
-        }
+mod log_macros {
+    /// Logs a message at the trace level.
+    #[macro_export]
+    macro_rules! trace {
+        ($($arg:tt)*) => {};
+    }
 
-        /// Logs a message at the debug level.
-        #[macro_export]
-        macro_rules! debug {
-            ($$($$arg:tt)*) => {};
-        }
+    /// Logs a message at the debug level.
+    #[macro_export]
+    macro_rules! debug {
+        ($($arg:tt)*) => {};
+    }
 
-        /// Logs a message at the info level.
-        #[macro_export]
-        macro_rules! info {
-            ($$($$arg:tt)*) => {};
-        }
+    /// Logs a message at the info level.
+    #[macro_export]
+    macro_rules! info {
+        ($($arg:tt)*) => {};
+    }
 
-        /// Logs a message at the warn level.
-        #[macro_export]
-        macro_rules! warn {
-            ($$($$arg:tt)*) => {};
-        }
+    /// Logs a message at the warn level.
+    #[macro_export]
+    macro_rules! warn {
+        ($($arg:tt)*) => {};
+    }
 
-        /// Logs a message at the error level.
-        #[macro_export]
-        macro_rules! error {
-            ($$($$arg:tt)*) => {};
-        }
-    };
+    /// Logs a message at the error level.
+    #[macro_export]
+    macro_rules! error {
+        ($($arg:tt)*) => {};
+    }
 }
-
-// NOTE: these nested macros are used so `doc_auto_cfg` doesn't produce "feature flairs" on the
-// logging macros.
-define_logging_macros!();


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This removes the need for the `macro_metavar_expr` unstable feature, which was previously used to avoid "feature flairs" on log macros. This uses a module-based trick instead.

## Testing

Successfully tested the `log` example with `defmt` selected and with `log` selected (one at a time).

## How to review this PR

Check that docs of these log macros haven't changed, i.e., that they still don't have "feature flairs" on them (which would say `defmt` or `log` otherwise).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Needed by #951.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
