### PR TITLE
docs(porting-guide): drop an extraneous `CONFIG_SWI`

### DIFF
--- a/book/src/adding-board-support.md
+++ b/book/src/adding-board-support.md
@@ -76,8 +76,6 @@ contexts:
       - cortex-m4f
     env:
       PROBE_RS_CHIP: STM32F401RE
-      CARGO_ENV:
-        - CONFIG_SWI=USART2
 ```
 
 ## Adding Support for an Embassy HAL/MCU family


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Drops an extraneous `CONFIG_SWI` in the porting guide, following #960.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
