### PR TITLE
chore(build): re-enable sccache

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -653,9 +653,6 @@ modules:
           - -Clink-arg=-Tdefmt.x
         ESPFLASH_LOG_FORMAT: "--log-format defmt"
         CARGO_ENV:
-          # For some reason, `sccache` makes the build not realize changes to
-          # `DEFMT_LOG`. Painful as it is, hard-disable `sccache` here.
-          - RUSTC_WRAPPER=""
           - DEFMT_LOG=info,${LOG}
 
   - name: log


### PR DESCRIPTION
# Description

`defmt 1.0` contains the fix needed for sccache getting changes to defmts log variable, so we don't need to disable it anymore:

Changelog:

https://github.com/knurling-rs/defmt/blob/main/CHANGELOG.md#defmt-v100-2025-04-01

PR that fixed this:

- https://github.com/knurling-rs/defmt/pull/938

## Issues/PRs references

Depends on #969.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
