### PR TITLE
feat(coap): use CBOR defmt debugging

### DIFF
--- a/examples/coap-client/src/main.rs
+++ b/examples/coap-client/src/main.rs
@@ -21,7 +21,7 @@ async fn run_client_operations() {
         .with_request_payload_slice(b"This is Ariel OS")
         .processing_response_payload_through(|p| {
             info!(
-                "Uppercase response is {}",
+                "Uppercase response is {:?}",
                 core::str::from_utf8(p).map_err(|_| "not Unicode?")
             );
         });

--- a/examples/device-metadata/src/main.rs
+++ b/examples/device-metadata/src/main.rs
@@ -9,7 +9,7 @@ async fn main() {
     info!("Available information:");
     info!("Board type: {}", ariel_os::buildinfo::BOARD);
     if let Ok(id) = ariel_os::identity::device_id_bytes() {
-        info!("Device ID: {=[u8]:02x}", id.as_ref());
+        info!("Device ID: {}", Hex(id));
     } else {
         info!("Device ID is unavailable.");
     }

--- a/examples/storage/src/main.rs
+++ b/examples/storage/src/main.rs
@@ -4,7 +4,7 @@
 
 use ariel_os::debug::{
     ExitCode, exit,
-    log::{defmt, info},
+    log::{Hex, defmt, info},
 };
 
 // Imports for using [`ariel_os::storage`]
@@ -72,8 +72,8 @@ async fn main() {
     {
         // no `defmt::Format` for arrayvec, so just print length
         info!(
-            "Attempting to retrieve string value as ArrayString: {:02x}",
-            string.as_bytes()
+            "Attempting to retrieve string value as ArrayString: {}",
+            Hex(string.as_bytes())
         );
     }
     info!("");
@@ -83,7 +83,7 @@ async fn main() {
         val_one: heapless::String::<64>::try_from("some value").unwrap(),
         val_two: 99,
     };
-    info!("Storing cfg object {} as struct", cfg);
+    info!("Storing cfg object {:?} as struct", cfg);
     storage::insert("my_config", cfg).await.unwrap();
 
     // Getting an object
@@ -98,33 +98,33 @@ async fn main() {
     let cfg_array: Option<arrayvec::ArrayVec<u8, 256>> = storage::get("my_config").await.unwrap();
     if let Some(cfg) = cfg_array.as_ref() {
         info!(
-            "Attempting to retrieve cfg as ArrayVec: {:02x}",
-            cfg.as_slice()
+            "Attempting to retrieve cfg as ArrayVec: {}",
+            Hex(cfg.as_slice())
         );
     }
 
     // Same for byte arrays
     let cfg_array: Option<[u8; 10]> = storage::get("my_config").await.unwrap();
     if let Some(cfg) = cfg_array.as_ref() {
-        info!("Attempting to retrieve cfg as array: {:02x}", cfg);
+        info!("Attempting to retrieve cfg as array: {}", Hex(cfg));
     }
     info!("");
 
     // raw bytes
     let bytes: [u8; 5] = [0, 1, 2, 3, 4];
-    info!("Storing raw bytes {:02x}", bytes);
+    info!("Storing raw bytes {}", Hex(bytes));
     storage::insert("some_raw_bytes", bytes).await.unwrap();
 
     let bytes: Option<[u8; 5]> = storage::get("some_raw_bytes").await.unwrap();
     if let Some(bytes) = bytes.as_ref() {
-        info!("got bytes as array: {:02x}", bytes);
+        info!("got bytes as array: {}", Hex(bytes));
     }
 
     let bytes: Option<heapless::Vec<u8, 256>> = storage::get("some_raw_bytes").await.unwrap();
     if let Some(bytes) = bytes.as_ref() {
         info!(
-            "Attempting to retrieve bytes as heapless vec arr: {:02x}",
-            bytes
+            "Attempting to retrieve bytes as heapless vec arr: {}",
+            Hex(bytes)
         );
     }
     info!("");

--- a/examples/threading-channel/src/main.rs
+++ b/examples/threading-channel/src/main.rs
@@ -9,17 +9,17 @@ static CHANNEL: Channel<u8> = Channel::new();
 #[ariel_os::thread(autostart)]
 fn thread0() {
     let my_id = ariel_os::thread::current_tid().unwrap();
-    info!("[Thread {}] Sending a message...", my_id);
+    info!("[Thread {:?}] Sending a message...", my_id);
     CHANNEL.send(&42);
 }
 
 #[ariel_os::thread(autostart, priority = 2)]
 fn thread1() {
     let my_id = ariel_os::thread::current_tid().unwrap();
-    info!("[Thread {}] Waiting to receive a message...", my_id);
+    info!("[Thread {:?}] Waiting to receive a message...", my_id);
     let recv = CHANNEL.recv();
     info!(
-        "[Thread {}] The answer to the Ultimate Question of Life, the Universe, and Everything is: {}.",
+        "[Thread {:?}] The answer to the Ultimate Question of Life, the Universe, and Everything is: {}.",
         my_id, recv
     );
     ariel_os::debug::exit(ExitCode::SUCCESS);

--- a/examples/threading-event/src/main.rs
+++ b/examples/threading-event/src/main.rs
@@ -9,13 +9,13 @@ static EVENT: Event = Event::new();
 fn waiter() {
     let my_id = ariel_os::thread::current_tid().unwrap();
     let my_prio = ariel_os::thread::get_priority(my_id).unwrap();
-    info!("[{}@{}] Waiting for event...", my_id, my_prio);
+    info!("[{:?}@{:?}] Waiting for event...", my_id, my_prio);
     EVENT.wait();
-    info!("[{}@{}] Done.", my_id, my_prio);
+    info!("[{:?}@{:?}] Done.", my_id, my_prio);
 
     if my_id == ThreadId::new(0) {
         info!(
-            "[{}@{}] All five threads should have reported \"Done.\". exiting.",
+            "[{:?}@{:?}] All five threads should have reported \"Done.\". exiting.",
             my_id, my_prio
         );
         ariel_os::debug::exit(ExitCode::SUCCESS);
@@ -46,8 +46,8 @@ fn thread3() {
 fn thread4() {
     let my_id = ariel_os::thread::current_tid().unwrap();
     let my_prio = ariel_os::thread::get_priority(my_id).unwrap();
-    info!("[{}@{}] Setting event...", my_id, my_prio);
+    info!("[{:?}@{:?}] Setting event...", my_id, my_prio);
     EVENT.set();
-    info!("[{}@{}] Event set.", my_id, my_prio);
+    info!("[{:?}@{:?}] Event set.", my_id, my_prio);
     waiter();
 }

--- a/examples/usb-serial/src/main.rs
+++ b/examples/usb-serial/src/main.rs
@@ -2,7 +2,12 @@
 #![no_main]
 #![feature(impl_trait_in_assoc_type)]
 
-use ariel_os::{cell::StaticCell, debug::log::info, reexports::embassy_usb, usb::UsbDriver};
+use ariel_os::{
+    cell::StaticCell,
+    debug::log::{Hex, info},
+    reexports::embassy_usb,
+    usb::UsbDriver,
+};
 use embassy_usb::{
     class::cdc_acm::{CdcAcmClass, State},
     driver::EndpointError,
@@ -69,7 +74,7 @@ async fn echo(class: &mut CdcAcmClass<'static, UsbDriver>) -> Result<(), Disconn
     loop {
         let n = class.read_packet(&mut buf).await?;
         let data = &buf[..n];
-        info!("data: {:x}", data);
+        info!("data: {}", Hex(data));
         class.write_packet(data).await?;
     }
 }

--- a/src/ariel-os-coap/src/stored.rs
+++ b/src/ariel-os-coap/src/stored.rs
@@ -1,6 +1,6 @@
 //! Credential and key configuration backed by ariel-os storage
 
-use ariel_os_debug::log::{debug, info};
+use ariel_os_debug::log::{Cbor, debug, info};
 use cbor_macro::cbo;
 use coapcore::seccfg::ServerSecurityConfig;
 
@@ -106,7 +106,7 @@ impl StoredPolicy {
             }
         };
 
-        info!("CoAP server identity: {=[u8]:02x}", credential); // :02x could be :cbor
+        info!("CoAP server identity: {}", Cbor(&credential));
 
         let credential =
             lakers::Credential::parse_ccs(&credential).expect("Processable by construction");

--- a/src/ariel-os-debug-log/src/lib.rs
+++ b/src/ariel-os-debug-log/src/lib.rs
@@ -48,6 +48,10 @@ pub mod log {
 // NOTE: log macros are defined within private modules so that `doc_auto_cfg` does not produce
 // "feature flairs" on them.
 // The macros are still exported even though they are defined "within" private modules.
+//
+// The `if true` conditionals ensure that the arguments are also valid under format_args!; this is
+// requires because a laze switch can just make the back-end switch over. The actual and the unused
+// formatting need to be in different branches to avoid trouble due to arguments being moved.
 #[cfg(feature = "defmt")]
 mod log_macros {
     /// Logs a message at the trace level.
@@ -55,7 +59,11 @@ mod log_macros {
     macro_rules! trace {
         ($($arg:tt)*) => {{
             use $crate::defmt::hidden::defmt;
-            defmt::trace!($($arg)*);
+            if true {
+                defmt::trace!($($arg)*);
+            } else {
+                drop(format_args!($($arg)*));
+            }
         }};
     }
 
@@ -64,7 +72,11 @@ mod log_macros {
     macro_rules! debug {
         ($($arg:tt)*) => {{
             use $crate::defmt::hidden::defmt;
-            defmt::debug!($($arg)*);
+            if true {
+                defmt::debug!($($arg)*);
+            } else {
+                drop(format_args!($($arg)*));
+            }
         }};
     }
 
@@ -73,7 +85,11 @@ mod log_macros {
     macro_rules! info {
         ($($arg:tt)*) => {{
             use $crate::defmt::hidden::defmt;
-            defmt::info!($($arg)*);
+            if true {
+                defmt::info!($($arg)*);
+            } else {
+                drop(format_args!($($arg)*));
+            }
         }};
     }
 
@@ -82,7 +98,11 @@ mod log_macros {
     macro_rules! warn {
         ($($arg:tt)*) => {{
             use $crate::defmt::hidden::defmt;
-            defmt::warn!($($arg)*);
+            if true {
+                defmt::warn!($($arg)*);
+            } else {
+                drop(format_args!($($arg)*));
+            }
         }};
     }
 
@@ -91,7 +111,11 @@ mod log_macros {
     macro_rules! error {
         ($($arg:tt)*) => {{
             use $crate::defmt::hidden::defmt;
-            defmt::error!($($arg)*);
+            if true {
+                defmt::error!($($arg)*);
+            } else {
+                drop(format_args!($($arg)*));
+            }
         }};
     }
 }
@@ -176,8 +200,8 @@ mod log_macros {
 /// A newtype around byte slices used for all of Ariel OS's logging facades that turns the bytes
 /// into some hex output.
 ///
-/// Its preferred output `00 11 22 33`, but log facades may also produce something like `[00, 11,
-/// 22, 33]` (eg. while that is cheaper on defmt).
+/// Its preferred output is `00 11 22 33`, but log facades may also produce something like `[00,
+/// 11, 22, 33]` (eg. while that is cheaper on defmt).
 ///
 /// Instead of writing some variation of `info!("Found bytes {:02x}", data)`, you can write
 /// `info!("Found bytes {}", Hex(data))`.
@@ -199,7 +223,7 @@ impl<T: AsRef<[u8]>> defmt::Format for Hex<T> {
 /// A newtype around byte slices used for all of Ariel OS's logging facades that prefers
 /// interpreting the data as CBOR.
 ///
-/// Its preferred outptu is CBOR Diagnostic Notation (EDN), but showing hex is also acceptable.
+/// Its preferred output is CBOR Diagnostic Notation (EDN), but showing hex is also acceptable.
 ///
 /// Instead of writing some variation of `info!("Found bytes {:cbor}", item)`, you can write
 /// `info!("Found bytes {}", Cbor(item))`.

--- a/src/ariel-os-debug-log/src/lib.rs
+++ b/src/ariel-os-debug-log/src/lib.rs
@@ -172,3 +172,52 @@ mod log_macros {
         ($($arg:tt)*) => {};
     }
 }
+
+/// A newtype around byte slices used for all of Ariel OS's logging facades that turns the bytes
+/// into some hex output.
+///
+/// Its preferred output `00 11 22 33`, but log facades may also produce something like `[00, 11,
+/// 22, 33]` (eg. while that is cheaper on defmt).
+///
+/// Instead of writing some variation of `info!("Found bytes {:02x}", data)`, you can write
+/// `info!("Found bytes {}", Hex(data))`.
+pub struct Hex<T: AsRef<[u8]>>(pub T);
+
+impl<T: AsRef<[u8]>> core::fmt::Display for Hex<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:02x?}", self.0.as_ref())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<T: AsRef<[u8]>> defmt::Format for Hex<T> {
+    fn format(&self, f: defmt::Formatter) {
+        ::defmt::write!(f, "{=[u8]:02x}", self.0.as_ref())
+    }
+}
+
+/// A newtype around byte slices used for all of Ariel OS's logging facades that prefers
+/// interpreting the data as CBOR.
+///
+/// Its preferred outptu is CBOR Diagnostic Notation (EDN), but showing hex is also acceptable.
+///
+/// Instead of writing some variation of `info!("Found bytes {:cbor}", item)`, you can write
+/// `info!("Found bytes {}", Cbor(item))`.
+///
+/// Note that using this wrapper is not necessary when using a
+/// [`cboritem::CborItem`](https://docs.rs/cboritem/latest/cboritem/struct.CborItem.html) as it
+/// already does something similar on its own.
+pub struct Cbor<T: AsRef<[u8]>>(pub T);
+
+impl<T: AsRef<[u8]>> core::fmt::Display for Cbor<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Hex(self.0.as_ref()).fmt(f)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<T: AsRef<[u8]>> defmt::Format for Cbor<T> {
+    fn format(&self, f: defmt::Formatter) {
+        ::defmt::write!(f, "{=[u8]:cbor}", self.0.as_ref())
+    }
+}

--- a/src/ariel-os-storage/src/lib.rs
+++ b/src/ariel-os-storage/src/lib.rs
@@ -65,7 +65,7 @@ fn flash_range_from_linker() -> Range<u32> {
 fn init_(p: &mut OptionalPeripherals) {
     use ariel_os_debug::log::info;
     let flash_range = flash_range_from_linker();
-    info!("storage: using flash range {:#x}", &flash_range);
+    info!("storage: using flash range {:?}", &flash_range);
 
     let flash = flash_init(p);
     let _ = STORAGE.init(Mutex::new(Storage::new(flash, flash_range)));

--- a/src/lib/coapcore/src/ace.rs
+++ b/src/lib/coapcore/src/ace.rs
@@ -9,6 +9,7 @@ use coap_message::Code as _;
 use defmt_or_log::trace;
 
 use crate::error::{CredentialError, CredentialErrorDetail};
+use crate::log_helpers::Cbor;
 
 use crate::helpers::COwn;
 
@@ -170,7 +171,7 @@ impl CoseEncrypt0<'_> {
         let mut aad_encoded = heapless::Vec::<u8, AADSIZE>::new();
         minicbor::encode(&aad, minicbor_adapters::WriteToHeapless(&mut aad_encoded))
             .map_err(|_| CredentialErrorDetail::ConstraintExceeded)?;
-        trace!("Serialized AAD: {:02x}", aad_encoded); // :02x could be :cbor
+        trace!("Serialized AAD: {}", Cbor(&aad_encoded));
 
         buffer.clear();
         // Copying around is not a constraint of this function (well that too but that could
@@ -427,7 +428,7 @@ pub(crate) fn process_acecbor_authz_info<GC: crate::GeneralClaims>(
     nonce2: [u8; OWN_NONCE_LEN],
     server_recipient_id: impl FnOnce(&[u8]) -> COwn,
 ) -> Result<(AceCborAuthzInfoResponse, liboscore::PrimitiveContext, GC), CredentialError> {
-    trace!("Processing authz_info {=[u8]:02x}", payload); // :02x could be :cbor
+    trace!("Processing authz_info {}", Cbor(payload));
 
     let decoded: UnprotectedAuthzInfoPost = minicbor::decode(payload)?;
     // FIXME: The `..` should be "all others are None"; se also comment on UnprotectedAuthzInfoPost

--- a/src/lib/coapcore/src/lib.rs
+++ b/src/lib/coapcore/src/lib.rs
@@ -63,6 +63,7 @@
 mod iana;
 
 mod helpers;
+mod log_helpers;
 
 pub mod time;
 

--- a/src/lib/coapcore/src/log_helpers.rs
+++ b/src/lib/coapcore/src/log_helpers.rs
@@ -1,0 +1,27 @@
+//! Helpers for using [`defmt_or_log`]
+
+/// A newtype around byte slices used for all of Ariel OS's logging facades that prefers
+/// interpreting the data as CBOR.
+///
+/// Its preferred output is CBOR Diagnostic Notation (EDN), but showing hex is also acceptable.
+///
+/// Instead of writing some variation of `info!("Found bytes {:cbor}", item)`, you can write
+/// `info!("Found bytes {}", Cbor(item))`.
+///
+/// Note that using this wrapper is not necessary when using a
+/// [`cboritem::CborItem`](https://docs.rs/cboritem/latest/cboritem/struct.CborItem.html) as it
+/// already does something similar on its own.
+pub struct Cbor<T: AsRef<[u8]>>(pub T);
+
+impl<T: AsRef<[u8]>> core::fmt::Display for Cbor<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:02x?}", self.0.as_ref())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<T: AsRef<[u8]>> defmt::Format for Cbor<T> {
+    fn format(&self, f: defmt::Formatter) {
+        ::defmt::write!(f, "{=[u8]:cbor}", self.0.as_ref())
+    }
+}

--- a/src/lib/coapcore/src/seccfg.rs
+++ b/src/lib/coapcore/src/seccfg.rs
@@ -9,6 +9,7 @@ use defmt_or_log::{debug, error, trace};
 use crate::ace::HeaderMap;
 use crate::error::{CredentialError, CredentialErrorDetail};
 use crate::generalclaims::{GeneralClaims, Unlimited};
+use crate::log_helpers::Cbor;
 use crate::time::TimeConstraint;
 
 pub(crate) const MAX_AUD_SIZE: usize = 8;
@@ -359,8 +360,8 @@ impl ServerSecurityConfig for ConfigBuilder {
         id_cred_x: lakers::IdCred,
     ) -> Option<(lakers::Credential, Self::GeneralClaims)> {
         trace!(
-            "Evaluating peer's credential {=[u8]:02x}", // :02x could be :cbor
-            id_cred_x.as_full_value()
+            "Evaluating peer's credential {}",
+            Cbor(id_cred_x.as_full_value())
         );
 
         #[expect(
@@ -368,7 +369,7 @@ impl ServerSecurityConfig for ConfigBuilder {
             reason = "Expected to be extended to actual loop soon"
         )]
         for (credential, scope) in &[self.known_edhoc_clients.as_ref()?] {
-            trace!("Comparing to {=[u8]:02x}", credential.bytes.as_slice()); // :02x could be :cbor
+            trace!("Comparing to {}", Cbor(credential.bytes.as_slice()));
             if id_cred_x.reference_only() {
                 // ad Ok: If our credential has no KID, it can't be recognized in this branch
                 if credential.by_kid() == Ok(id_cred_x) {

--- a/src/lib/coapcore/src/seccontext.rs
+++ b/src/lib/coapcore/src/seccontext.rs
@@ -15,6 +15,7 @@ use defmt_or_log::{Debug2Format, debug, error, trace};
 
 use crate::generalclaims::{self, GeneralClaims as _};
 use crate::helpers::COwn;
+use crate::log_helpers::Cbor;
 use crate::scope::Scope;
 use crate::seccfg::ServerSecurityConfig;
 
@@ -617,7 +618,7 @@ impl<
                 match crate::ace::process_edhoc_token(value.as_slice(), &self.authorities) {
                     Ok(ci_and_a) => cred_i_and_authorization = Some(ci_and_a),
                     Err(e) => {
-                        error!("Received unprocessable token {=[u8]:02x}, error: {}", value.as_slice(), Debug2Format(&e)); // :02x could be :cbor
+                        error!("Received unprocessable token {}, error: {}", Cbor(value.as_slice()), Debug2Format(&e));
                     }
                 }
             }

--- a/tests/i2c-controller/src/main.rs
+++ b/tests/i2c-controller/src/main.rs
@@ -35,7 +35,7 @@ pub static I2C_BUS: once_cell::sync::OnceCell<
 async fn main(peripherals: pins::Peripherals) {
     let mut i2c_config = hal::i2c::controller::Config::default();
     i2c_config.frequency = const { highest_freq_in(Kilohertz::kHz(100)..=Kilohertz::kHz(400)) };
-    debug!("Selected frequency: {}", i2c_config.frequency);
+    debug!("Selected frequency: {:?}", i2c_config.frequency);
 
     let i2c_bus = pins::SensorI2c::new(peripherals.i2c_sda, peripherals.i2c_scl, i2c_config);
 

--- a/tests/spi-loopback/src/main.rs
+++ b/tests/spi-loopback/src/main.rs
@@ -12,7 +12,7 @@ mod pins;
 use ariel_os::{
     debug::{
         ExitCode, exit,
-        log::{debug, info},
+        log::{Hex, debug, info},
     },
     gpio, hal,
     spi::{
@@ -31,7 +31,7 @@ pub static SPI_BUS: once_cell::sync::OnceCell<
 async fn main(peripherals: pins::Peripherals) {
     let mut spi_config = hal::spi::main::Config::default();
     spi_config.frequency = const { highest_freq_in(Kilohertz::kHz(1000)..=Kilohertz::kHz(2000)) };
-    debug!("Selected frequency: {}", spi_config.frequency);
+    debug!("Selected frequency: {:?}", spi_config.frequency);
     spi_config.mode = if !cfg!(context = "esp") {
         Mode::Mode3
     } else {
@@ -55,7 +55,7 @@ async fn main(peripherals: pins::Peripherals) {
     let mut in_ = [0u8; 8];
     spi_device.transfer(&mut in_, &out).await.unwrap();
 
-    info!("got 0x{:x}", &in_);
+    info!("got {}", Hex(in_));
 
     assert_eq!(out, in_);
 

--- a/tests/spi-main/src/main.rs
+++ b/tests/spi-main/src/main.rs
@@ -37,7 +37,7 @@ pub static SPI_BUS: once_cell::sync::OnceCell<
 async fn main(peripherals: pins::Peripherals) {
     let mut spi_config = hal::spi::main::Config::default();
     spi_config.frequency = const { highest_freq_in(Kilohertz::kHz(1000)..=Kilohertz::kHz(2000)) };
-    debug!("Selected frequency: {}", spi_config.frequency);
+    debug!("Selected frequency: {:?}", spi_config.frequency);
     spi_config.mode = if !cfg!(context = "esp") {
         Mode::Mode3
     } else {


### PR DESCRIPTION
# Description

With defmt updated, a lot of places where CBOR debugging was already planned are now unblocked.

<del>Draft: I'll look around whether there are more places where using this makes sense.</del>

Note that this is only usable for people who <del>have a manually updated prob-rs (https://github.com/probe-rs/probe-rs/pull/3206) until they merge and</del> installed probe-rs from their master branch or their next release; for everyone else, the debug output changes subtly from the previously manually set 2-digit hex output to the fallback comma-separated decimal integers.

## Issues/PRs references

Builds on #969
Depends on #972.

## Open Questions

* [x] When do I stop?

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.

[edit: probe-rs merged my PR]