### PR TITLE
fix: ensure defmt log statements also work with log

### DIFF
--- a/examples/coap-client/src/main.rs
+++ b/examples/coap-client/src/main.rs
@@ -21,7 +21,7 @@ async fn run_client_operations() {
         .with_request_payload_slice(b"This is Ariel OS")
         .processing_response_payload_through(|p| {
             info!(
-                "Uppercase response is {}",
+                "Uppercase response is {:?}",
                 core::str::from_utf8(p).map_err(|_| "not Unicode?")
             );
         });

--- a/examples/device-metadata/src/main.rs
+++ b/examples/device-metadata/src/main.rs
@@ -9,7 +9,7 @@ async fn main() {
     info!("Available information:");
     info!("Board type: {}", ariel_os::buildinfo::BOARD);
     if let Ok(id) = ariel_os::identity::device_id_bytes() {
-        info!("Device ID: {=[u8]:02x}", id.as_ref());
+        info!("Device ID: {}", Hex(id));
     } else {
         info!("Device ID is unavailable.");
     }

--- a/examples/storage/src/main.rs
+++ b/examples/storage/src/main.rs
@@ -4,7 +4,7 @@
 
 use ariel_os::debug::{
     ExitCode, exit,
-    log::{defmt, info},
+    log::{Hex, defmt, info},
 };
 
 // Imports for using [`ariel_os::storage`]
@@ -72,8 +72,8 @@ async fn main() {
     {
         // no `defmt::Format` for arrayvec, so just print length
         info!(
-            "Attempting to retrieve string value as ArrayString: {:02x}",
-            string.as_bytes()
+            "Attempting to retrieve string value as ArrayString: {}",
+            Hex(string.as_bytes())
         );
     }
     info!("");
@@ -83,7 +83,7 @@ async fn main() {
         val_one: heapless::String::<64>::try_from("some value").unwrap(),
         val_two: 99,
     };
-    info!("Storing cfg object {} as struct", cfg);
+    info!("Storing cfg object {:?} as struct", cfg);
     storage::insert("my_config", cfg).await.unwrap();
 
     // Getting an object
@@ -98,33 +98,33 @@ async fn main() {
     let cfg_array: Option<arrayvec::ArrayVec<u8, 256>> = storage::get("my_config").await.unwrap();
     if let Some(cfg) = cfg_array.as_ref() {
         info!(
-            "Attempting to retrieve cfg as ArrayVec: {:02x}",
-            cfg.as_slice()
+            "Attempting to retrieve cfg as ArrayVec: {}",
+            Hex(cfg.as_slice())
         );
     }
 
     // Same for byte arrays
     let cfg_array: Option<[u8; 10]> = storage::get("my_config").await.unwrap();
     if let Some(cfg) = cfg_array.as_ref() {
-        info!("Attempting to retrieve cfg as array: {:02x}", cfg);
+        info!("Attempting to retrieve cfg as array: {}", Hex(cfg));
     }
     info!("");
 
     // raw bytes
     let bytes: [u8; 5] = [0, 1, 2, 3, 4];
-    info!("Storing raw bytes {:02x}", bytes);
+    info!("Storing raw bytes {}", Hex(bytes));
     storage::insert("some_raw_bytes", bytes).await.unwrap();
 
     let bytes: Option<[u8; 5]> = storage::get("some_raw_bytes").await.unwrap();
     if let Some(bytes) = bytes.as_ref() {
-        info!("got bytes as array: {:02x}", bytes);
+        info!("got bytes as array: {}", Hex(bytes));
     }
 
     let bytes: Option<heapless::Vec<u8, 256>> = storage::get("some_raw_bytes").await.unwrap();
     if let Some(bytes) = bytes.as_ref() {
         info!(
-            "Attempting to retrieve bytes as heapless vec arr: {:02x}",
-            bytes
+            "Attempting to retrieve bytes as heapless vec arr: {}",
+            Hex(bytes)
         );
     }
     info!("");

--- a/examples/threading-channel/src/main.rs
+++ b/examples/threading-channel/src/main.rs
@@ -9,17 +9,17 @@ static CHANNEL: Channel<u8> = Channel::new();
 #[ariel_os::thread(autostart)]
 fn thread0() {
     let my_id = ariel_os::thread::current_tid().unwrap();
-    info!("[Thread {}] Sending a message...", my_id);
+    info!("[Thread {:?}] Sending a message...", my_id);
     CHANNEL.send(&42);
 }
 
 #[ariel_os::thread(autostart, priority = 2)]
 fn thread1() {
     let my_id = ariel_os::thread::current_tid().unwrap();
-    info!("[Thread {}] Waiting to receive a message...", my_id);
+    info!("[Thread {:?}] Waiting to receive a message...", my_id);
     let recv = CHANNEL.recv();
     info!(
-        "[Thread {}] The answer to the Ultimate Question of Life, the Universe, and Everything is: {}.",
+        "[Thread {:?}] The answer to the Ultimate Question of Life, the Universe, and Everything is: {}.",
         my_id, recv
     );
     ariel_os::debug::exit(ExitCode::SUCCESS);

--- a/examples/threading-event/src/main.rs
+++ b/examples/threading-event/src/main.rs
@@ -9,13 +9,13 @@ static EVENT: Event = Event::new();
 fn waiter() {
     let my_id = ariel_os::thread::current_tid().unwrap();
     let my_prio = ariel_os::thread::get_priority(my_id).unwrap();
-    info!("[{}@{}] Waiting for event...", my_id, my_prio);
+    info!("[{:?}@{:?}] Waiting for event...", my_id, my_prio);
     EVENT.wait();
-    info!("[{}@{}] Done.", my_id, my_prio);
+    info!("[{:?}@{:?}] Done.", my_id, my_prio);
 
     if my_id == ThreadId::new(0) {
         info!(
-            "[{}@{}] All five threads should have reported \"Done.\". exiting.",
+            "[{:?}@{:?}] All five threads should have reported \"Done.\". exiting.",
             my_id, my_prio
         );
         ariel_os::debug::exit(ExitCode::SUCCESS);
@@ -46,8 +46,8 @@ fn thread3() {
 fn thread4() {
     let my_id = ariel_os::thread::current_tid().unwrap();
     let my_prio = ariel_os::thread::get_priority(my_id).unwrap();
-    info!("[{}@{}] Setting event...", my_id, my_prio);
+    info!("[{:?}@{:?}] Setting event...", my_id, my_prio);
     EVENT.set();
-    info!("[{}@{}] Event set.", my_id, my_prio);
+    info!("[{:?}@{:?}] Event set.", my_id, my_prio);
     waiter();
 }

--- a/examples/usb-serial/src/main.rs
+++ b/examples/usb-serial/src/main.rs
@@ -2,7 +2,12 @@
 #![no_main]
 #![feature(impl_trait_in_assoc_type)]
 
-use ariel_os::{cell::StaticCell, debug::log::info, reexports::embassy_usb, usb::UsbDriver};
+use ariel_os::{
+    cell::StaticCell,
+    debug::log::{Hex, info},
+    reexports::embassy_usb,
+    usb::UsbDriver,
+};
 use embassy_usb::{
     class::cdc_acm::{CdcAcmClass, State},
     driver::EndpointError,
@@ -69,7 +74,7 @@ async fn echo(class: &mut CdcAcmClass<'static, UsbDriver>) -> Result<(), Disconn
     loop {
         let n = class.read_packet(&mut buf).await?;
         let data = &buf[..n];
-        info!("data: {:x}", data);
+        info!("data: {}", Hex(data));
         class.write_packet(data).await?;
     }
 }

--- a/src/ariel-os-debug-log/src/lib.rs
+++ b/src/ariel-os-debug-log/src/lib.rs
@@ -48,6 +48,10 @@ pub mod log {
 // NOTE: log macros are defined within private modules so that `doc_auto_cfg` does not produce
 // "feature flairs" on them.
 // The macros are still exported even though they are defined "within" private modules.
+//
+// The `if true` conditionals ensure that the arguments are also valid under format_args!; this is
+// requires because a laze switch can just make the back-end switch over. The actual and the unused
+// formatting need to be in different branches to avoid trouble due to arguments being moved.
 #[cfg(feature = "defmt")]
 mod log_macros {
     /// Logs a message at the trace level.
@@ -55,7 +59,11 @@ mod log_macros {
     macro_rules! trace {
         ($($arg:tt)*) => {{
             use $crate::defmt::hidden::defmt;
-            defmt::trace!($($arg)*);
+            if true {
+                defmt::trace!($($arg)*);
+            } else {
+                drop(format_args!($($arg)*));
+            }
         }};
     }
 
@@ -64,7 +72,11 @@ mod log_macros {
     macro_rules! debug {
         ($($arg:tt)*) => {{
             use $crate::defmt::hidden::defmt;
-            defmt::debug!($($arg)*);
+            if true {
+                defmt::debug!($($arg)*);
+            } else {
+                drop(format_args!($($arg)*));
+            }
         }};
     }
 
@@ -73,7 +85,11 @@ mod log_macros {
     macro_rules! info {
         ($($arg:tt)*) => {{
             use $crate::defmt::hidden::defmt;
-            defmt::info!($($arg)*);
+            if true {
+                defmt::info!($($arg)*);
+            } else {
+                drop(format_args!($($arg)*));
+            }
         }};
     }
 
@@ -82,7 +98,11 @@ mod log_macros {
     macro_rules! warn {
         ($($arg:tt)*) => {{
             use $crate::defmt::hidden::defmt;
-            defmt::warn!($($arg)*);
+            if true {
+                defmt::warn!($($arg)*);
+            } else {
+                drop(format_args!($($arg)*));
+            }
         }};
     }
 
@@ -91,7 +111,11 @@ mod log_macros {
     macro_rules! error {
         ($($arg:tt)*) => {{
             use $crate::defmt::hidden::defmt;
-            defmt::error!($($arg)*);
+            if true {
+                defmt::error!($($arg)*);
+            } else {
+                drop(format_args!($($arg)*));
+            }
         }};
     }
 }
@@ -176,8 +200,8 @@ mod log_macros {
 /// A newtype around byte slices used for all of Ariel OS's logging facades that turns the bytes
 /// into some hex output.
 ///
-/// Its preferred output `00 11 22 33`, but log facades may also produce something like `[00, 11,
-/// 22, 33]` (eg. while that is cheaper on defmt).
+/// Its preferred output is `00 11 22 33`, but log facades may also produce something like `[00,
+/// 11, 22, 33]` (eg. while that is cheaper on defmt).
 ///
 /// Instead of writing some variation of `info!("Found bytes {:02x}", data)`, you can write
 /// `info!("Found bytes {}", Hex(data))`.
@@ -199,7 +223,7 @@ impl<T: AsRef<[u8]>> defmt::Format for Hex<T> {
 /// A newtype around byte slices used for all of Ariel OS's logging facades that prefers
 /// interpreting the data as CBOR.
 ///
-/// Its preferred outptu is CBOR Diagnostic Notation (EDN), but showing hex is also acceptable.
+/// Its preferred output is CBOR Diagnostic Notation (EDN), but showing hex is also acceptable.
 ///
 /// Instead of writing some variation of `info!("Found bytes {:cbor}", item)`, you can write
 /// `info!("Found bytes {}", Cbor(item))`.

--- a/src/ariel-os-debug-log/src/lib.rs
+++ b/src/ariel-os-debug-log/src/lib.rs
@@ -172,3 +172,52 @@ mod log_macros {
         ($($arg:tt)*) => {};
     }
 }
+
+/// A newtype around byte slices used for all of Ariel OS's logging facades that turns the bytes
+/// into some hex output.
+///
+/// Its preferred output `00 11 22 33`, but log facades may also produce something like `[00, 11,
+/// 22, 33]` (eg. while that is cheaper on defmt).
+///
+/// Instead of writing some variation of `info!("Found bytes {:02x}", data)`, you can write
+/// `info!("Found bytes {}", Hex(data))`.
+pub struct Hex<T: AsRef<[u8]>>(pub T);
+
+impl<T: AsRef<[u8]>> core::fmt::Display for Hex<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:02x?}", self.0.as_ref())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<T: AsRef<[u8]>> defmt::Format for Hex<T> {
+    fn format(&self, f: defmt::Formatter) {
+        ::defmt::write!(f, "{=[u8]:02x}", self.0.as_ref())
+    }
+}
+
+/// A newtype around byte slices used for all of Ariel OS's logging facades that prefers
+/// interpreting the data as CBOR.
+///
+/// Its preferred outptu is CBOR Diagnostic Notation (EDN), but showing hex is also acceptable.
+///
+/// Instead of writing some variation of `info!("Found bytes {:cbor}", item)`, you can write
+/// `info!("Found bytes {}", Cbor(item))`.
+///
+/// Note that using this wrapper is not necessary when using a
+/// [`cboritem::CborItem`](https://docs.rs/cboritem/latest/cboritem/struct.CborItem.html) as it
+/// already does something similar on its own.
+pub struct Cbor<T: AsRef<[u8]>>(pub T);
+
+impl<T: AsRef<[u8]>> core::fmt::Display for Cbor<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Hex(self.0.as_ref()).fmt(f)
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl<T: AsRef<[u8]>> defmt::Format for Cbor<T> {
+    fn format(&self, f: defmt::Formatter) {
+        ::defmt::write!(f, "{=[u8]:cbor}", self.0.as_ref())
+    }
+}

--- a/src/ariel-os-storage/src/lib.rs
+++ b/src/ariel-os-storage/src/lib.rs
@@ -65,7 +65,7 @@ fn flash_range_from_linker() -> Range<u32> {
 fn init_(p: &mut OptionalPeripherals) {
     use ariel_os_debug::log::info;
     let flash_range = flash_range_from_linker();
-    info!("storage: using flash range {:#x}", &flash_range);
+    info!("storage: using flash range {:?}", &flash_range);
 
     let flash = flash_init(p);
     let _ = STORAGE.init(Mutex::new(Storage::new(flash, flash_range)));

--- a/tests/i2c-controller/src/main.rs
+++ b/tests/i2c-controller/src/main.rs
@@ -35,7 +35,7 @@ pub static I2C_BUS: once_cell::sync::OnceCell<
 async fn main(peripherals: pins::Peripherals) {
     let mut i2c_config = hal::i2c::controller::Config::default();
     i2c_config.frequency = const { highest_freq_in(Kilohertz::kHz(100)..=Kilohertz::kHz(400)) };
-    debug!("Selected frequency: {}", i2c_config.frequency);
+    debug!("Selected frequency: {:?}", i2c_config.frequency);
 
     let i2c_bus = pins::SensorI2c::new(peripherals.i2c_sda, peripherals.i2c_scl, i2c_config);
 

--- a/tests/spi-loopback/src/main.rs
+++ b/tests/spi-loopback/src/main.rs
@@ -12,7 +12,7 @@ mod pins;
 use ariel_os::{
     debug::{
         ExitCode, exit,
-        log::{debug, info},
+        log::{Hex, debug, info},
     },
     gpio, hal,
     spi::{
@@ -31,7 +31,7 @@ pub static SPI_BUS: once_cell::sync::OnceCell<
 async fn main(peripherals: pins::Peripherals) {
     let mut spi_config = hal::spi::main::Config::default();
     spi_config.frequency = const { highest_freq_in(Kilohertz::kHz(1000)..=Kilohertz::kHz(2000)) };
-    debug!("Selected frequency: {}", spi_config.frequency);
+    debug!("Selected frequency: {:?}", spi_config.frequency);
     spi_config.mode = if !cfg!(context = "esp") {
         Mode::Mode3
     } else {
@@ -55,7 +55,7 @@ async fn main(peripherals: pins::Peripherals) {
     let mut in_ = [0u8; 8];
     spi_device.transfer(&mut in_, &out).await.unwrap();
 
-    info!("got 0x{:x}", &in_);
+    info!("got {}", Hex(in_));
 
     assert_eq!(out, in_);
 

--- a/tests/spi-main/src/main.rs
+++ b/tests/spi-main/src/main.rs
@@ -37,7 +37,7 @@ pub static SPI_BUS: once_cell::sync::OnceCell<
 async fn main(peripherals: pins::Peripherals) {
     let mut spi_config = hal::spi::main::Config::default();
     spi_config.frequency = const { highest_freq_in(Kilohertz::kHz(1000)..=Kilohertz::kHz(2000)) };
-    debug!("Selected frequency: {}", spi_config.frequency);
+    debug!("Selected frequency: {:?}", spi_config.frequency);
     spi_config.mode = if !cfg!(context = "esp") {
         Mode::Mode3
     } else {


### PR DESCRIPTION
# Description

This adds checks to defmt builds to avoid defmt-isms (such as formatting a range or slice with {:x}, or formatting results in {}) don't creep up unchecked, and adds the tools to smooth over inconsistencies between the languages.

## Testing

```
laze build -g -b st-nucleo-wb55 -D LOG=debug -s log -d defmt
```

previously failed. Once this PR is through, not only should that not fail any more, but any case that does break should just as well break the developer's build that doesn't select log over defmt.

## Issues/PRs references

Contributes to #625 (doesn't fix it completely, that'd require checking also the currently unused log levels, and doing the same exercise also in the other direction; both is harder in that it'll require extra checking to see whether that doesn't introduce needless defmt interning).

## Testing

A good test is `laze build -b st-nucleo-wb55 -C examples/device-metadata -s log run`, which should still show the device ID in a way similar to defmt (possibly prettier, but that's not implemented right now to keep things simple).

## Open Questions

* <del>What do we do with the harder parts? Right now, the fixes just throw away a bit of formatting details. We can start having our custom wrappers a la `info!("The data is {}", HexSlice(&my_slice))`, but that makes at least defmt a small bit less efficient than its own version `info!("The data is {:02x}", my_slice)` is, and at some point we should be sure that this is a trade-off (not just in runtime but also mental-load and build complexity) we really want to make for not going full defmt.</del> (resolved by doing this, like embassy does)

  (Not that going full-defmt doesn't come with its own problems that we haven't even explored -- like, doing the full formatting for a device that does want to output to serial even when it has all the defmt strings is not trivial.)

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
