### PR TITLE
feat(boards): add support for the Nordic Thingy:91 X

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -89,6 +89,21 @@ chips:
       storage: supported
       wifi: not_available
 
+  nrf9151:
+    name: nRF9151
+    support:
+      gpio: supported
+      debug_output: supported
+      hwrng:
+        status: not_currently_supported
+        comments:
+          - only available through the CryptoCell
+      i2c_controller: supported
+      spi_main: supported
+      logging: supported
+      storage: supported
+      wifi: not_available
+
   nrf9160:
     name: nRF9160
     support:
@@ -227,6 +242,15 @@ boards:
     support:
       user_usb: not_available
       ethernet_over_usb: not_available
+
+  nordic-thingy-91-x-nrf9151:
+    name: Nordic Thingy:91 X
+    url: https://web.archive.org/web/20250329185651/https://www.nordicsemi.com/Products/Development-hardware/Nordic-Thingy-91-X
+    chip: nrf9151
+    support:
+      user_usb: not_available
+      ethernet_over_usb: not_available
+      wifi: not_currently_supported
 
   nrf52840dk:
     name: nRF52840-DK

--- a/examples/blinky/laze.yml
+++ b/examples/blinky/laze.yml
@@ -4,6 +4,7 @@ apps:
       # list of contexts that have an entry in `pins.rs`
       - bbc-microbit-v2
       - esp
+      - nordic-thingy-91-x-nrf9151
       - nrf52840dk
       - nrf5340dk
       - nrf9160dk

--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -6,6 +6,9 @@ ariel_os::hal::define_peripherals!(LedPeripherals {
     led: P0_21,
 });
 
+#[cfg(context = "nordic-thingy-91-x-nrf9151")]
+ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_29 });
+
 #[cfg(context = "nrf52840dk")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_13 });
 

--- a/examples/gpio/laze.yml
+++ b/examples/gpio/laze.yml
@@ -4,6 +4,7 @@ apps:
       # list of contexts that have an entry in `pins.rs`
       - bbc-microbit-v2
       - esp
+      - nordic-thingy-91-x-nrf9151
       - nrf52840dk
       - nrf5340dk
       - nrf9160dk

--- a/examples/gpio/src/pins.rs
+++ b/examples/gpio/src/pins.rs
@@ -13,6 +13,12 @@ ariel_os::hal::define_peripherals!(Peripherals {
     btn1: P0_14
 });
 
+#[cfg(context = "nordic-thingy-91-x-nrf9151")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    led1: P0_29,
+    btn1: P0_26
+});
+
 #[cfg(context = "nrf5340dk")]
 ariel_os::hal::define_peripherals!(Peripherals {
     led1: P0_28,

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -242,14 +242,23 @@ contexts:
 
   - name: nrf91
     parent: nrf
+    selects:
+      - cortex-m33f
 
   - name: nrf9160
     parent: nrf91
     provides:
       - has_storage_support
-    selects:
-      - cortex-m33f
     env:
+      PROBE_RS_CHIP: nRF9160_xxAA
+
+  - name: nrf9151
+    parent: nrf91
+    provides:
+      - has_storage_support
+    env:
+      # FIXME: probe-rs does not support the nRF9151_xxAA yet, because there is
+      # no CMSIS-Pack available
       PROBE_RS_CHIP: nRF9160_xxAA
 
   - name: rp
@@ -1394,6 +1403,10 @@ builders:
   # TODO: there also is a companion nrf52840 on this board
   - name: nrf9160dk
     parent: nrf9160
+
+  # TODO: there also is a companion nrf5340 on this board
+  - name: nordic-thingy-91-x-nrf9151
+    parent: nrf9151
 
   - name: st-nucleo-f401re
     parent: stm32f401re

--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -48,6 +48,9 @@ embassy-nrf = { workspace = true, features = [
   "nrf5340-app-s",
 ] }
 
+[target.'cfg(context = "nrf9151")'.dependencies]
+embassy-nrf = { workspace = true, features = ["nrf9151-s"] }
+
 [target.'cfg(context = "nrf9160")'.dependencies]
 embassy-nrf = { workspace = true, features = ["nrf9160-s"] }
 

--- a/src/ariel-os-nrf/build.rs
+++ b/src/ariel-os-nrf/build.rs
@@ -14,7 +14,7 @@ fn main() {
         (256, 1024)
     } else if is_in_current_contexts(&["nrf5340"]) {
         (512, 1024)
-    } else if is_in_current_contexts(&["nrf9160"]) {
+    } else if is_in_current_contexts(&["nrf9151", "nrf9160"]) {
         (256, 1024)
     } else {
         panic!("nrf52: please set MCU feature");
@@ -24,6 +24,8 @@ fn main() {
         "NRF52_FLASH"
     } else if is_in_current_contexts(&["nrf5340"]) {
         "NRF5340_FLASH"
+    } else if is_in_current_contexts(&["nrf9151"]) {
+        "NRF9151_FLASH"
     } else if is_in_current_contexts(&["nrf9160"]) {
         "NRF9160_FLASH"
     } else {

--- a/src/ariel-os-nrf/src/i2c/controller/mod.rs
+++ b/src/ariel-os-nrf/src/i2c/controller/mod.rs
@@ -45,7 +45,7 @@ impl Default for Config {
     context = "nrf52833",
     context = "nrf52840",
     context = "nrf5340",
-    context = "nrf9160"
+    context = "nrf91"
 ))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -53,12 +53,12 @@ pub enum Frequency {
     /// Standard mode.
     _100k,
     /// 250 kHz.
-    #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf9160"))]
+    #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf91"))]
     _250k,
     /// Fast mode.
     _400k,
     // FIXME(embassy): the upstream Embassy crate does not support this frequency
-    // #[cfg(context = "nrf5340", context = "nrf9160")]
+    // #[cfg(context = "nrf5340", context = "nrf91")]
     // _1M,
 }
 
@@ -79,9 +79,9 @@ impl Frequency {
         match self {
             #[cfg(context = "nrf52840")]
             Self::_100k => Some(Self::_400k),
-            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf9160"))]
+            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf91"))]
             Self::_100k => Some(Self::_250k),
-            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf9160"))]
+            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf91"))]
             Self::_250k => Some(Self::_400k),
             Self::_400k => None,
         }
@@ -91,11 +91,11 @@ impl Frequency {
     pub const fn prev(self) -> Option<Self> {
         match self {
             Self::_100k => None,
-            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf9160"))]
+            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf91"))]
             Self::_250k => Some(Self::_100k),
             #[cfg(context = "nrf52840")]
             Self::_400k => Some(Self::_100k),
-            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf9160"))]
+            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf91"))]
             Self::_400k => Some(Self::_250k),
         }
     }
@@ -104,7 +104,7 @@ impl Frequency {
     pub const fn khz(self) -> u32 {
         match self {
             Self::_100k => 100,
-            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf9160"))]
+            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf91"))]
             Self::_250k => 250,
             Self::_400k => 400,
         }
@@ -117,7 +117,7 @@ impl From<Frequency> for embassy_nrf::twim::Frequency {
     fn from(freq: Frequency) -> Self {
         match freq {
             Frequency::_100k => embassy_nrf::twim::Frequency::K100,
-            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf9160"))]
+            #[cfg(any(context = "nrf52833", context = "nrf5340", context = "nrf91"))]
             Frequency::_250k => embassy_nrf::twim::Frequency::K250,
             Frequency::_400k => embassy_nrf::twim::Frequency::K400,
         }
@@ -224,7 +224,7 @@ define_i2c_drivers!(
     SERIAL0 => SERIAL0,
     SERIAL1 => SERIAL1,
 );
-#[cfg(context = "nrf9160")]
+#[cfg(context = "nrf91")]
 define_i2c_drivers!(
     SERIAL0 => SERIAL0,
     SERIAL1 => SERIAL1,

--- a/src/ariel-os-nrf/src/i2c/mod.rs
+++ b/src/ariel-os-nrf/src/i2c/mod.rs
@@ -16,7 +16,7 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
         } else if #[cfg(context = "nrf5340")] {
             let _ = peripherals.SERIAL0.take().unwrap();
             let _ = peripherals.SERIAL1.take().unwrap();
-        } else if #[cfg(context = "nrf9160")] {
+        } else if #[cfg(context = "nrf91")] {
             let _ = peripherals.SERIAL0.take().unwrap();
             let _ = peripherals.SERIAL1.take().unwrap();
         } else {

--- a/src/ariel-os-nrf/src/identity.rs
+++ b/src/ariel-os-nrf/src/identity.rs
@@ -6,9 +6,9 @@ impl ariel_os_embassy_common::identity::DeviceId for DeviceId {
         reason = "making this fallible would be a breaking API change for Ariel OS"
     )]
     fn get() -> Result<Self, core::convert::Infallible> {
-        #[cfg(not(any(context = "nrf5340", context = "nrf9160")))]
+        #[cfg(not(any(context = "nrf5340", context = "nrf91")))]
         let ficr = embassy_nrf::pac::FICR;
-        #[cfg(any(context = "nrf5340", context = "nrf9160"))]
+        #[cfg(any(context = "nrf5340", context = "nrf91"))]
         let ficr = embassy_nrf::pac::FICR.info();
 
         let low = ficr.deviceid(0).read();

--- a/src/ariel-os-nrf/src/lib.rs
+++ b/src/ariel-os-nrf/src/lib.rs
@@ -45,7 +45,7 @@ pub use embassy_executor::InterruptExecutor as Executor;
 ariel_os_embassy_common::executor_swi!(EGU0_SWI0);
 
 #[cfg(feature = "executor-interrupt")]
-#[cfg(any(context = "nrf5340", context = "nrf9160"))]
+#[cfg(any(context = "nrf5340", context = "nrf91"))]
 ariel_os_embassy_common::executor_swi!(EGU0);
 
 use embassy_nrf::config::Config;

--- a/src/ariel-os-nrf/src/spi/main/mod.rs
+++ b/src/ariel-os-nrf/src/spi/main/mod.rs
@@ -238,7 +238,7 @@ define_spi_drivers!(
     SERIAL3 => SERIAL3,
 );
 // FIXME: arbitrary selected peripherals
-#[cfg(context = "nrf9160")]
+#[cfg(context = "nrf91")]
 define_spi_drivers!(
     SERIAL2 => SERIAL2,
     SERIAL3 => SERIAL3,

--- a/src/ariel-os-nrf/src/spi/mod.rs
+++ b/src/ariel-os-nrf/src/spi/mod.rs
@@ -33,7 +33,7 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
         } else if #[cfg(context = "nrf5340")] {
             let _ = peripherals.SERIAL2.take().unwrap();
             let _ = peripherals.SERIAL3.take().unwrap();
-        } else if #[cfg(context = "nrf9160")] {
+        } else if #[cfg(context = "nrf91")] {
             let _ = peripherals.SERIAL2.take().unwrap();
             let _ = peripherals.SERIAL3.take().unwrap();
         } else {

--- a/src/ariel-os-storage/build.rs
+++ b/src/ariel-os-storage/build.rs
@@ -8,7 +8,7 @@ fn main() {
     // Trying to restrict the storage size to the subset of homogeneous flash would not work as it
     // could be pushed out of it by a large enough binary.
     let (storage_size_total, flash_page_size) =
-        if is_in_current_contexts(&["nrf52", "nrf5340", "nrf9160", "rp", "stm32wb55rg"]) {
+        if is_in_current_contexts(&["nrf52", "nrf5340", "nrf91", "rp", "stm32wb55rg"]) {
             (8 * KIBIBYTES, 4 * KIBIBYTES)
         } else if is_in_current_contexts(&["stm32h755zi"]) {
             (256 * KIBIBYTES, 128 * KIBIBYTES)

--- a/tests/gpio-interrupt-nrf/src/main.rs
+++ b/tests/gpio-interrupt-nrf/src/main.rs
@@ -38,7 +38,7 @@ ariel_os::hal::define_peripherals!(ButtonPeripherals {
     btn_8: P0_10,
 });
 
-#[cfg(context = "nrf9160")]
+#[cfg(context = "nrf91")]
 ariel_os::hal::define_peripherals!(ButtonPeripherals {
     btn_0: P0_00,
     btn_1: P0_01,

--- a/tests/i2c-controller/laze.yml
+++ b/tests/i2c-controller/laze.yml
@@ -3,6 +3,7 @@ apps:
     context:
       - bbc-microbit-v2
       - esp
+      - nordic-thingy-91-x-nrf9151
       - nrf52840
       - nrf5340
       - nrf9160

--- a/tests/i2c-controller/src/main.rs
+++ b/tests/i2c-controller/src/main.rs
@@ -23,10 +23,22 @@ use ariel_os::{
 use embassy_sync::mutex::Mutex;
 use embedded_hal_async::i2c::I2c as _;
 
+#[cfg(not(context = "nordic-thingy-91-x-nrf9151"))]
 const TARGET_I2C_ADDR: u8 = 0x19;
+#[cfg(context = "nordic-thingy-91-x-nrf9151")]
+// Alternate address
+const TARGET_I2C_ADDR: u8 = 0x1d;
 
 // WHO_AM_I register of the sensor
+#[cfg(not(context = "nordic-thingy-91-x-nrf9151"))]
 const WHO_AM_I_REG_ADDR: u8 = 0x0f;
+#[cfg(context = "nordic-thingy-91-x-nrf9151")]
+const WHO_AM_I_REG_ADDR: u8 = 0x02;
+
+#[cfg(not(context = "nordic-thingy-91-x-nrf9151"))]
+const DEVICE_ID: u8 = 0x33;
+#[cfg(context = "nordic-thingy-91-x-nrf9151")]
+const DEVICE_ID: u8 = 0xf7;
 
 pub static I2C_BUS: once_cell::sync::OnceCell<
     Mutex<embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex, hal::i2c::controller::I2c>,
@@ -52,7 +64,7 @@ async fn main(peripherals: pins::Peripherals) {
 
     let who_am_i = id[0];
     info!("WHO_AM_I_COMMAND register value: 0x{:x}", who_am_i);
-    assert_eq!(who_am_i, 0x33);
+    assert_eq!(who_am_i, DEVICE_ID);
 
     info!("Test passed!");
 

--- a/tests/i2c-controller/src/pins.rs
+++ b/tests/i2c-controller/src/pins.rs
@@ -10,9 +10,12 @@ ariel_os::hal::define_peripherals!(Peripherals {
 
 #[cfg(any(context = "nrf52833", context = "nrf52840"))]
 pub type SensorI2c = i2c::controller::TWISPI0;
-#[cfg(any(context = "nrf5340", context = "nrf9160"))]
+#[cfg(any(context = "nrf5340", context = "nrf91"))]
 pub type SensorI2c = i2c::controller::SERIAL0;
-#[cfg(all(context = "nrf", not(context = "bbc-microbit-v2")))]
+#[cfg(all(
+    context = "nrf",
+    not(any(context = "bbc-microbit-v2", context = "nordic-thingy-91-x-nrf9151"))
+))]
 ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: P0_00,
     i2c_scl: P0_01,
@@ -20,6 +23,11 @@ ariel_os::hal::define_peripherals!(Peripherals {
 #[cfg(context = "bbc-microbit-v2")]
 ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: P0_16,
+    i2c_scl: P0_08,
+});
+#[cfg(context = "nordic-thingy-91-x-nrf9151")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    i2c_sda: P0_09,
     i2c_scl: P0_08,
 });
 

--- a/tests/spi-main/laze.yml
+++ b/tests/spi-main/laze.yml
@@ -2,6 +2,7 @@ apps:
   - name: spi-main
     context:
       - esp
+      - nordic-thingy-91-x-nrf9151
       - nrf52840
       - nrf5340
       - nrf9160

--- a/tests/spi-main/src/pins.rs
+++ b/tests/spi-main/src/pins.rs
@@ -10,6 +10,14 @@ ariel_os::hal::define_peripherals!(Peripherals {
     spi_cs: GPIO3,
 });
 
+#[cfg(context = "nordic-thingy-91-x-nrf9151")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    spi_sck: P0_13,
+    spi_miso: P0_15,
+    spi_mosi: P0_14,
+    spi_cs: P0_10,
+});
+
 // Side SPI of Arduino v3 connector
 #[cfg(context = "nrf52840")]
 pub type SensorSpi = spi::main::SPI3;
@@ -22,7 +30,7 @@ ariel_os::hal::define_peripherals!(Peripherals {
 });
 
 // Side SPI of Arduino v3 connector
-#[cfg(any(context = "nrf5340", context = "nrf9160"))]
+#[cfg(any(context = "nrf5340", context = "nrf91"))]
 pub type SensorSpi = spi::main::SERIAL2;
 #[cfg(context = "nrf5340")]
 ariel_os::hal::define_peripherals!(Peripherals {


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This adds support for the nRF9151 MCU and the Nordic Thingy:91 X board.

This is not a duplicate of #929, which is for the older, non-X variant.

## Testing

Successfully tested in hardware:

- `examples/gpio`
- `examples/storage`
- `examples/threading`
- `tests/i2c-controller` (using an on-board sensor)
- `tests/spi-main` (using an on-board sensor)

There is no user USB support on the nRF9151, and we don't yet support other network links, so couldn't test networking.

Additionally, `laze build -g -b nordic-thingy-91-x-nrf9151` completes successfully.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
