### PR TITLE
refactor(boards)!: rename `nrf9160dk` to `nrf9160dk-nrf9160`

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -244,7 +244,7 @@ boards:
       user_usb: supported
       ethernet_over_usb: supported
 
-  nrf9160dk:
+  nrf9160dk-nrf9160:
     name: nRF9160-DK
     url: https://web.archive.org/web/20250311221943/https://www.nordicsemi.com/Products/Development-hardware/nrf9160-dk
     chip: nrf9160

--- a/examples/blinky/laze.yml
+++ b/examples/blinky/laze.yml
@@ -6,7 +6,7 @@ apps:
       - esp
       - nrf52840dk
       - nrf5340dk
-      - nrf9160dk
+      - nrf9160dk-nrf9160
       - particle-xenon
       - rp
       - st-nucleo-c031c6

--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -12,7 +12,7 @@ ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_13 });
 #[cfg(context = "nrf5340dk")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_28 });
 
-#[cfg(context = "nrf9160dk")]
+#[cfg(context = "nrf9160dk-nrf9160")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_02 });
 
 #[cfg(context = "particle-xenon")]

--- a/examples/gpio/laze.yml
+++ b/examples/gpio/laze.yml
@@ -6,7 +6,7 @@ apps:
       - esp
       - nrf52840dk
       - nrf5340dk
-      - nrf9160dk
+      - nrf9160dk-nrf9160
       - rp
       - st-nucleo-c031c6
       - st-nucleo-f401re

--- a/examples/gpio/src/pins.rs
+++ b/examples/gpio/src/pins.rs
@@ -19,7 +19,7 @@ ariel_os::hal::define_peripherals!(Peripherals {
     btn1: P0_23
 });
 
-#[cfg(context = "nrf9160dk")]
+#[cfg(context = "nrf9160dk-nrf9160")]
 ariel_os::hal::define_peripherals!(Peripherals {
     led1: P0_02,
     btn1: P0_06

--- a/examples/http-server/laze.yml
+++ b/examples/http-server/laze.yml
@@ -13,7 +13,7 @@ modules:
     context:
       - nrf52840dk
       - nrf5340dk
-      - nrf9160dk
+      - nrf9160dk-nrf9160
       - st-nucleo-wb55
     env:
       global:

--- a/examples/http-server/src/pins.rs
+++ b/examples/http-server/src/pins.rs
@@ -7,7 +7,7 @@ ariel_os::hal::define_peripherals!(Button { btn1: P0_11 });
 #[cfg(context = "nrf5340dk")]
 ariel_os::hal::define_peripherals!(Button { btn1: P0_23 });
 
-#[cfg(context = "nrf9160dk")]
+#[cfg(context = "nrf9160dk-nrf9160")]
 ariel_os::hal::define_peripherals!(Button { btn1: P0_06 });
 
 #[cfg(context = "st-nucleo-wb55")]

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1392,7 +1392,7 @@ builders:
         - CONFIG_SWI=USART2
 
   # TODO: there also is a companion nrf52840 on this board
-  - name: nrf9160dk
+  - name: nrf9160dk-nrf9160
     parent: nrf9160
 
   - name: st-nucleo-f401re

--- a/tests/coap-blinky/laze.yml
+++ b/tests/coap-blinky/laze.yml
@@ -9,7 +9,7 @@ apps:
       - esp
       - nrf52840dk
       - nrf5340dk
-      - nrf9160dk
+      - nrf9160dk-nrf9160
       - particle-xenon
       - rp
       - st-nucleo-f401re


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This renames that board as it is comprised of two target MCUs, and that laze builder only targets the onboard nRF9160 MCU, not the companion nRF52840.

## Testing

Running the following succeeds:

```sh
laze build -g -b nrf9160dk-nrf9160
```

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
