### PR TITLE
fix(laze): change order of `root`/`relroot` for Ariel Cargo config

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -30,7 +30,7 @@ contexts:
         - ${RUSTFLAGS_CONTEXTS}
       SCRIPTS: ${relroot}/scripts
       CARGO_ARGS:
-        - --config ${root}/${relroot}/ariel-os-cargo.toml
+        - --config ${relroot}/${root}/ariel-os-cargo.toml
       # While laze allows "export:" in rules and tasks to export laze
       # variables to a rule's recipe shell environment, this would require
       # those to be listed for *all* rules and tasks where they are needed.


### PR DESCRIPTION
# Description

... otherwise, OOT applications in a subdir do `build/import/foo/../../ariel-os-cargo.toml` instead of `../../build/import/foo/ariel-os-cargo.toml`.

This worked before for OOT applications in the root folder (like, our ariel-os-hello), as `${relroot}` is `./` in that case.

<!-- Please write a summary of your changes and why you made them.-->

I tested that the *current* `ariel-os-hello` but pointing to this PR's head still works.

## Issues/PRs references

Fixes #973.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
