### PR TITLE
feat(rt): add initial stack measuring & painting

### DIFF
--- a/examples/hello-world-threading/src/main.rs
+++ b/examples/hello-world-threading/src/main.rs
@@ -3,9 +3,48 @@
 
 use ariel_os::debug::{ExitCode, exit, log::*};
 
+use ariel_os::rt::stack::*;
+
 #[ariel_os::thread(autostart)]
 fn main() {
-    info!("Hello World!");
+    let limits = Stack::get();
+    let free_min = limits.free_min();
+    let used_max = limits.used_max();
+
+    info!(
+        "size: {} used: {} free: {} free_min: {} used_max: {}",
+        limits.size(),
+        limits.used(),
+        limits.free(),
+        free_min,
+        used_max,
+    );
+
+    limits.repaint();
+
+    let free_min = limits.free_min();
+    let used_max = limits.used_max();
+
+    info!(
+        "size: {} used: {} free: {} free_min: {} used_max: {}",
+        limits.size(),
+        limits.used(),
+        limits.free(),
+        free_min,
+        used_max,
+    );
+
+    let free_min = limits.free_min();
+    let used_max = limits.used_max();
+
+    info!(
+        "size: {} used: {} free: {} free_min: {} used_max: {}",
+        limits.size(),
+        limits.used(),
+        limits.free(),
+        free_min,
+        used_max,
+    );
 
     exit(ExitCode::SUCCESS);
 }

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -4,9 +4,49 @@
 
 use ariel_os::debug::{ExitCode, exit, log::*};
 
+use ariel_os::rt::stack::*;
+
 #[ariel_os::task(autostart)]
 async fn main() {
-    info!("Hello World!");
+    let stack = Stack::get();
+
+    let free_min = stack.free_min();
+    let used_max = stack.used_max();
+
+    info!(
+        "size: {} used: {} free: {} free_min: {} used_max: {}",
+        stack.size(),
+        stack.used(),
+        stack.free(),
+        free_min,
+        used_max,
+    );
+
+    stack.repaint();
+
+    let free_min = stack.free_min();
+    let used_max = stack.used_max();
+
+    info!(
+        "size: {} used: {} free: {} free_min: {} used_max: {}",
+        stack.size(),
+        stack.used(),
+        stack.free(),
+        free_min,
+        used_max,
+    );
+
+    let free_min = stack.free_min();
+    let used_max = stack.used_max();
+
+    info!(
+        "size: {} used: {} free: {} free_min: {} used_max: {}",
+        stack.size(),
+        stack.used(),
+        stack.free(),
+        free_min,
+        used_max,
+    );
 
     exit(ExitCode::SUCCESS);
 }

--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -4,6 +4,8 @@
 #![allow(incomplete_features)]
 // - const_generics
 
+pub mod stack;
+
 #[cfg(feature = "threading")]
 mod threading;
 
@@ -28,9 +30,13 @@ cfg_if::cfg_if! {
         compile_error!("no runtime is defined for this MCU family");
     } else {
         // Provide a default implementation, for arch-independent tooling
+        #[cfg_attr(not(context = "ariel-os"), allow(dead_code))]
         mod arch {
-            #[cfg_attr(not(context = "ariel-os"), allow(dead_code))]
+            use crate::stack::Stack;
+
             pub fn init() {}
+            pub fn sp() -> usize { 0 }
+            pub fn stack() -> Stack { Stack::default() }
         }
     }
 }
@@ -66,6 +72,27 @@ mod isr_stack {
         "#,
         size = const ISR_STACKSIZE
     );
+
+    pub fn limits() -> (usize, usize) {
+        // ISR stack
+        // TODO: multicore!
+        unsafe extern "C" {
+            static _stack_bottom: u32;
+            static _stack_start: u32;
+        }
+
+        let bottom = &raw const _stack_bottom as usize;
+        let top = &raw const _stack_start as usize;
+        (bottom, top)
+    }
+
+    pub fn init() {
+        let stack = crate::stack::Stack::get();
+        crate::debug!("ariel-os-rt: ISR stacksize: {}", stack.size());
+
+        // initial stack paint
+        stack.repaint();
+    }
 }
 
 #[cfg(feature = "_panic-handler")]
@@ -96,7 +123,7 @@ fn startup() -> ! {
     debug!("ariel_os_rt::startup()");
 
     #[cfg(any(context = "cortex-m", context = "riscv"))]
-    debug!("ariel_os_rt: ISR_STACKSIZE={}", isr_stack::ISR_STACKSIZE);
+    crate::isr_stack::init();
 
     #[cfg(feature = "alloc")]
     // SAFETY: *this* is the only place alloc should be initialized.

--- a/src/ariel-os-rt/src/stack.rs
+++ b/src/ariel-os-rt/src/stack.rs
@@ -1,0 +1,105 @@
+//! Stack usage helpers.
+use core::{marker::PhantomData, ptr::write_volatile};
+
+use crate::arch::sp;
+
+/// Struct representing the currently active stack.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Stack {
+    /// Lowest stack address
+    pub bottom: usize,
+    /// Highest stack address
+    pub top: usize,
+
+    /// We'll be implementing nasty stuff on this Struct that requires it to
+    /// not get sent across stacks.
+    _not_send: PhantomData<*const ()>,
+}
+
+impl Stack {
+    /// Gets a handle for the currently active stack.
+    pub fn get() -> Self {
+        let sp = sp();
+        let stack = crate::arch::stack();
+        if stack.size() > 0 {
+            assert!(stack.top >= stack.bottom);
+
+            // TODO: verify bounds (are they inclusive?)
+            assert!(stack.bottom <= sp && stack.top >= sp);
+        }
+        stack
+    }
+
+    pub const fn default() -> Self {
+        Self {
+            bottom: 0,
+            top: 0,
+            _not_send: PhantomData,
+        }
+    }
+
+    pub(crate) const fn new(bottom: usize, top: usize) -> Self {
+        Self {
+            bottom,
+            top,
+            _not_send: PhantomData,
+        }
+    }
+
+    /// Returns the total size of the current stack.
+    pub fn size(&self) -> usize {
+        self.top - self.bottom
+    }
+
+    /// Returns the amount of currently free stack space.
+    pub fn free(&self) -> usize {
+        self.size() - self.used()
+    }
+
+    /// Returns the amount of currently used stack space.
+    pub fn used(&self) -> usize {
+        self.top - sp()
+    }
+
+    /// Returns the minimum free stack space since last repaint.
+    ///
+    /// This re-calculates and thus runs in `O(n)`!
+    pub fn free_min(&self) -> usize {
+        let mut free = 0usize;
+        for pos in self.bottom..self.top {
+            // Safety: dereferencing ptr to valid memory, read only
+            if unsafe { *(pos as *const u8) } == 0xCC {
+                free += 1;
+            }
+        }
+        free
+    }
+
+    /// Returns the maximum stack space used since last repaint.
+    ///
+    /// Equivalent to `size() - free_min()`.
+    ///
+    /// This re-calculates and thus runs in `O(n)`!
+    pub fn used_max(&self) -> usize {
+        self.size() - self.free_min()
+    }
+
+    /// Repaints the stack.
+    pub fn repaint(&self) {
+        let sp = crate::arch::sp();
+        if self.size() == 0 {
+            return;
+        }
+
+        // sanity check
+        assert!(self.bottom <= sp && sp <= self.top);
+
+        // Safety: writing to inactive part of active is fine.
+        unsafe {
+            for pos in self.bottom..sp {
+                write_volatile(pos as *mut u8, 0xCC);
+            }
+        }
+    }
+}

--- a/src/ariel-os-threads/src/arch/cortex_m.rs
+++ b/src/ariel-os-threads/src/arch/cortex_m.rs
@@ -246,6 +246,13 @@ unsafe extern "C" fn sched() -> u64 {
             let next = scheduler.get_unchecked(next_tid);
             // SAFETY: changing the PSP as part of context switch
             unsafe { cortex_m::register::psp::write(next.data.sp as u32) };
+
+            #[cfg(armv8m)]
+            // SAFETY: changing the PSPLIM as part of context switch
+            unsafe {
+                cortex_m::register::psplim::write(next.stack_bottom as u32)
+            };
+
             let next_high_regs = next.data.high_regs.as_ptr();
 
             Some((current_high_regs as u32, next_high_regs as u32))

--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -739,3 +739,12 @@ pub fn get_priority(thread_id: ThreadId) -> Option<RunqueueId> {
 pub fn set_priority(thread_id: ThreadId, prio: RunqueueId) {
     SCHEDULER.with_mut(|mut scheduler| scheduler.set_priority(thread_id, prio));
 }
+
+/// Returns the current thread's stack limits (bottom, top).
+pub fn current_stack_limits() -> Option<(usize, usize)> {
+    SCHEDULER.with_mut(|mut scheduler| {
+        scheduler
+            .current()
+            .map(|thread| (thread.stack_bottom, thread.stack_top))
+    })
+}

--- a/src/ariel-os-threads/src/thread.rs
+++ b/src/ariel-os-threads/src/thread.rs
@@ -24,6 +24,11 @@ pub struct Thread {
     /// Core affinity of the thread.
     #[cfg(feature = "core-affinity")]
     pub core_affinity: crate::CoreAffinity,
+
+    /// Lowest stack address
+    pub stack_bottom: usize,
+    /// Highest stack address
+    pub stack_top: usize,
 }
 
 /// Possible states of a thread
@@ -60,6 +65,8 @@ impl Thread {
             tid: ThreadId::new(0),
             #[cfg(feature = "core-affinity")]
             core_affinity: crate::CoreAffinity::no_affinity(),
+            stack_top: 0,
+            stack_bottom: 0,
         }
     }
 }

--- a/src/ariel-os/src/lib.rs
+++ b/src/ariel-os/src/lib.rs
@@ -40,6 +40,8 @@ pub use ariel_os_power as power;
 #[cfg(feature = "random")]
 #[doc(inline)]
 pub use ariel_os_random as random;
+#[doc(inline)]
+pub use ariel_os_rt as rt;
 #[cfg(feature = "storage")]
 #[doc(inline)]
 pub use ariel_os_storage as storage;
@@ -53,10 +55,6 @@ pub use ariel_os_macros::spawner;
 pub use ariel_os_macros::task;
 #[cfg(any(feature = "threading", doc))]
 pub use ariel_os_macros::thread;
-
-// ensure this gets linked
-#[cfg(not(test))]
-use ariel_os_rt as _;
 
 pub use ariel_os_embassy::api::*;
 


### PR DESCRIPTION
# Description

This adds a module that allows measuring stack usage. Currently, a stack can only report for "itself".

An additional commit enables use of the psplim register on `armv8m` (Cortex-M33).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

- [ ] handle multi core isr stack
- [ ] allow access from outside the active stack, e.g., for "remote" reporting of thread stacks
- [ ] risc-v
- [ ] esp
- [ ] add some way of reporting this for tests (e.g., at thread end?)

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
