### PR TITLE
feat: add uart abstraction

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -87,6 +87,7 @@ jobs:
                   storage,
                   tcp,
                   threading,
+                  uart,
                   udp,
                   usb,
                   usb-hid,
@@ -101,6 +102,7 @@ jobs:
                   external-interrupts,
                   i2c,
                   spi,
+                  uart,
                   " \
               -p ariel-os-esp
           RUSTDOCFLAGS='-D warnings --cfg context="rp" --cfg context="rp2040" --cfg nightly' cargo doc \
@@ -110,6 +112,7 @@ jobs:
                   external-interrupts,
                   i2c,
                   spi,
+                  uart,
                   " \
               -p ariel-os-rp
           RUSTDOCFLAGS='-D warnings --cfg context="nrf52840" --cfg nightly' cargo doc \
@@ -119,6 +122,7 @@ jobs:
                   external-interrupts,
                   i2c,
                   spi,
+                  uart,
                   " \
               -p ariel-os-nrf
           RUSTDOCFLAGS='-D warnings --cfg context="stm32wb55rg" --cfg nightly' cargo doc \
@@ -128,6 +132,7 @@ jobs:
                   external-interrupts,
                   i2c,
                   spi,
+                  uart,
                   " \
               -p ariel-os-stm32
           echo "<meta http-equiv=\"refresh\" content=\"0; url=ariel_os\">" > target/doc/index.html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,6 +124,7 @@ jobs:
                 spi,
                 storage,
                 tcp,
+                uart,
                 udp,
                 usb,
                 usb-ethernet,
@@ -163,6 +164,7 @@ jobs:
                 external-interrupts,
                 i2c,
                 spi,
+                uart,
                 "
             -p ariel-os-esp
             --
@@ -182,6 +184,7 @@ jobs:
                 external-interrupts,
                 i2c,
                 spi,
+                uart,
                 "
             -p ariel-os-rp
             --
@@ -201,6 +204,7 @@ jobs:
                 external-interrupts,
                 i2c,
                 spi,
+                uart,
                 "
             -p ariel-os-nrf
             --target=thumbv7em-none-eabi
@@ -219,6 +223,7 @@ jobs:
                 external-interrupts,
                 i2c,
                 spi,
+                uart,
                 "
             -p ariel-os-stm32
             --
@@ -281,6 +286,7 @@ jobs:
                     storage,
                     tcp,
                     threading,
+                    uart,
                     udp,
                     usb,
                     usb-hid,
@@ -298,6 +304,7 @@ jobs:
                     external-interrupts,
                     i2c,
                     spi,
+                    uart,
                     " \
                 -p ariel-os-esp
 
@@ -311,6 +318,7 @@ jobs:
                     external-interrupts,
                     i2c,
                     spi,
+                    uart,
                     " \
                 -p ariel-os-rp
 
@@ -323,6 +331,7 @@ jobs:
                     external-interrupts,
                     i2c,
                     spi,
+                    uart,
                     " \
                 -p ariel-os-nrf
 
@@ -335,6 +344,7 @@ jobs:
                     external-interrupts,
                     i2c,
                     spi,
+                    uart,
                     " \
                 -p ariel-os-stm32
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,7 @@ dependencies = [
  "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
+ "embedded-io-async",
  "esp-alloc",
  "esp-hal",
  "esp-hal-embassy",
@@ -432,6 +433,7 @@ dependencies = [
  "embassy-nrf",
  "embassy-sync 0.6.2",
  "embedded-hal-async",
+ "embedded-io-async",
  "nrf-sdc",
  "paste",
  "portable-atomic",
@@ -477,6 +479,7 @@ dependencies = [
  "embassy-rp",
  "embassy-sync 0.6.2",
  "embedded-hal-async",
+ "embedded-io-async",
  "paste",
  "static_cell",
  "trouble-host",
@@ -533,6 +536,7 @@ dependencies = [
  "embassy-executor",
  "embassy-stm32",
  "embedded-hal-async",
+ "embedded-io-async",
  "paste",
  "portable-atomic",
  "static_cell",
@@ -3178,6 +3182,7 @@ version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
+ "embedded-io-async",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,7 +3182,6 @@ version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
- "embedded-io-async",
 ]
 
 [[package]]
@@ -5638,6 +5637,15 @@ name = "typewit_proc_macros"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
+
+[[package]]
+name = "uart-loopback"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+ "embedded-io-async",
+]
 
 [[package]]
 name = "udp-echo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
   "tests/threading-lock",
   "tests/threading-mutex",
   "tests/threading-fpu",
+  "tests/uart-loopback",
 ]
 
 exclude = ["src/lib", "doc"]

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -32,6 +32,9 @@ functionalities:
   - name: spi_main
     title: SPI Main Mode
     description: SPI in main mode
+  - name: uart
+    title: UART
+    description: UART
   - name: logging
     title: Logging
     description:
@@ -61,6 +64,7 @@ chips:
       hwrng: supported
       i2c_controller: not_currently_supported
       spi_main: not_currently_supported
+      uart: not_currently_supported
       logging: supported
       storage: not_currently_supported
       wifi: not_available
@@ -75,6 +79,7 @@ chips:
       hwrng: supported
       i2c_controller: not_currently_supported
       spi_main: not_currently_supported
+      uart: not_currently_supported
       logging: supported
       storage: supported
       wifi: not_available
@@ -89,6 +94,7 @@ chips:
       hwrng: supported
       i2c_controller: supported
       spi_main: supported
+      uart: supported
       logging: supported
       storage: supported
       wifi: not_available
@@ -101,6 +107,7 @@ chips:
       hwrng: supported
       i2c_controller: supported
       spi_main: supported
+      uart: supported
       logging: supported
       storage: supported
       wifi: not_available
@@ -113,6 +120,7 @@ chips:
       hwrng: not_currently_supported
       i2c_controller: supported
       spi_main: supported
+      uart: supported
       logging: supported
       storage: supported
       wifi: not_available
@@ -128,6 +136,7 @@ chips:
           - only available through the CryptoCell
       i2c_controller: supported
       spi_main: supported
+      uart: not_currently_supported
       logging: supported
       storage: supported
       wifi: not_available
@@ -143,6 +152,7 @@ chips:
           - only available through the CryptoCell
       i2c_controller: supported
       spi_main: supported
+      uart: not_currently_supported
       logging: supported
       storage: supported
       wifi: not_available
@@ -155,6 +165,7 @@ chips:
       hwrng: supported
       i2c_controller: supported
       spi_main: supported
+      uart: supported
       logging: supported
       storage: supported
       wifi: not_available
@@ -167,6 +178,7 @@ chips:
       hwrng: supported
       i2c_controller: supported
       spi_main: supported
+      uart: not_currently_supported
       logging: supported
       storage: supported
       wifi: not_available
@@ -179,6 +191,7 @@ chips:
       hwrng: supported
       i2c_controller: supported
       spi_main: supported
+      uart: supported
       logging: supported
       storage: not_currently_supported
       wifi:
@@ -194,6 +207,7 @@ chips:
       hwrng: supported
       i2c_controller: supported
       spi_main: supported
+      uart: supported
       logging: supported
       storage: not_currently_supported
       wifi:
@@ -209,6 +223,7 @@ chips:
       hwrng: supported
       i2c_controller: needs_testing
       spi_main: needs_testing
+      uart: not_currently_supported
       logging: supported
       storage: not_currently_supported
       wifi: supported
@@ -222,6 +237,7 @@ chips:
       hwrng: not_available
       i2c_controller: supported
       spi_main: supported
+      uart: supported
       logging: supported
       storage:
         status: not_currently_supported
@@ -239,6 +255,7 @@ chips:
       hwrng: not_available
       i2c_controller: not_currently_supported
       spi_main: not_currently_supported
+      uart: supported
       logging: supported
       storage:
         status: not_currently_supported
@@ -255,6 +272,7 @@ chips:
       hwrng: not_available
       i2c_controller: needs_testing
       spi_main: needs_testing
+      uart: supported
       logging: supported
       storage:
         status: not_currently_supported
@@ -270,6 +288,7 @@ chips:
       hwrng: not_available
       i2c_controller: supported
       spi_main: supported
+      uart: not_currently_supported
       logging: supported
       storage:
         status: not_currently_supported
@@ -285,6 +304,7 @@ chips:
       hwrng: supported
       i2c_controller: supported
       spi_main: supported
+      uart: supported
       logging: supported
       storage:
         status: supported_with_caveats
@@ -300,6 +320,7 @@ chips:
       hwrng: supported
       i2c_controller: needs_testing
       spi_main: needs_testing
+      uart: supported
       logging: supported
       storage:
         status: supported_with_caveats
@@ -315,6 +336,7 @@ chips:
       hwrng: supported
       i2c_controller: supported
       spi_main: supported
+      uart: not_currently_supported
       logging: supported
       storage:
         status: supported_with_caveats
@@ -330,6 +352,7 @@ chips:
       hwrng: supported
       i2c_controller: supported
       spi_main: supported
+      uart: supported
       logging: supported
       storage: supported
       wifi: not_available
@@ -342,6 +365,7 @@ chips:
       hwrng: supported
       i2c_controller: supported
       spi_main: supported
+      uart: supported
       logging: supported
       storage:
         status: supported_with_caveats
@@ -357,6 +381,7 @@ chips:
       hwrng: supported
       i2c_controller: not_currently_supported
       spi_main: not_currently_supported
+      uart: supported
       logging: supported
       storage:
         status: not_currently_supported

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1867,7 +1867,7 @@ builders:
     env:
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.
-        - CONFIG_SWI=LPUART1
+        - CONFIG_SWI=USART2
 
   - name: st-steval-mkboxpro
     parent: stm32u585ai

--- a/src/ariel-os-embassy-common/Cargo.toml
+++ b/src/ariel-os-embassy-common/Cargo.toml
@@ -31,10 +31,13 @@ i2c = ["dep:fugit"]
 ## Enables SPI support.
 spi = ["dep:fugit"]
 
+## Enables UART support.
+uart = []
+
 defmt = ["dep:defmt", "fugit?/defmt"]
 
 executor-thread = []
 
-_test = ["i2c", "spi", "external-interrupts"]
+_test = ["i2c", "spi", "external-interrupts", "uart"]
 
 ble = ["dep:static_cell", "dep:trouble-host"]

--- a/src/ariel-os-embassy-common/src/lib.rs
+++ b/src/ariel-os-embassy-common/src/lib.rs
@@ -23,6 +23,9 @@ pub mod identity;
 #[cfg(feature = "spi")]
 pub mod spi;
 
+#[cfg(feature = "uart")]
+pub mod uart;
+
 pub mod reexports {
     //! Crate re-exports.
 

--- a/src/ariel-os-embassy-common/src/uart.rs
+++ b/src/ariel-os-embassy-common/src/uart.rs
@@ -1,0 +1,245 @@
+//! Provides HAL-agnostic UART-related types.
+
+/// Common UART baud rates.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Baud {
+    /// Custom baud rate
+    Baud(u32),
+    /// 2400 bauds,
+    _2400,
+    /// 4800 bauds
+    _4800,
+    /// 9600 bauds
+    _9600,
+    /// 19200 bauds
+    _19200,
+    /// 38400 bauds
+    _34800,
+    /// 57600 bauds
+    _57600,
+    /// 57600 bauds
+    _115200,
+}
+
+impl From<Baud> for u32 {
+    fn from(b: Baud) -> u32 {
+        match b {
+            Baud::Baud(b) => b,
+            Baud::_2400 => 2400,
+            Baud::_4800 => 4800,
+            Baud::_9600 => 9600,
+            Baud::_19200 => 19200,
+            Baud::_34800 => 34800,
+            Baud::_57600 => 57600,
+            Baud::_115200 => 115_200,
+        }
+    }
+}
+
+impl From<u32> for Baud {
+    fn from(b: u32) -> Self {
+        match b {
+            2400 => Baud::_2400,
+            4800 => Baud::_4800,
+            9600 => Baud::_9600,
+            19200 => Baud::_19200,
+            34800 => Baud::_34800,
+            57600 => Baud::_57600,
+            115_200 => Baud::_115200,
+            b => Baud::Baud(b),
+        }
+    }
+}
+
+impl core::fmt::Display for Baud {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", Into::<u32>::into(*self))
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Baud {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        use defmt::write;
+        write!(f, "{=u32}", Into::<u32>::into(*self));
+    }
+}
+
+/// UART parity.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Parity {
+    /// No parity bit.
+    None,
+    /// Even parity bit.
+    Even,
+    /// Odd parity bit.
+    Odd,
+}
+
+impl core::fmt::Display for Parity {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::None => write!(f, "N"),
+            Self::Even => write!(f, "E"),
+            Self::Odd => write!(f, "O"),
+        }
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Parity {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        use defmt::write;
+        match self {
+            Self::None => write!(f, "N"),
+            Self::Even => write!(f, "E"),
+            Self::Odd => write!(f, "O"),
+        }
+    }
+}
+
+/// UART number of stop bits.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum StopBits {
+    /// One stop bit.
+    Stop1,
+    /// Two stop bits.
+    Stop2,
+}
+
+impl core::fmt::Display for StopBits {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Stop1 => write!(f, "1"),
+            Self::Stop2 => write!(f, "2"),
+        }
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for StopBits {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        use defmt::write;
+        match self {
+            Self::Stop1 => write!(f, "1"),
+            Self::Stop2 => write!(f, "2"),
+        }
+    }
+}
+
+/// UART number of data bits.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum DataBits {
+    /// 7 bits per character.
+    Data7,
+    /// 8 bits per character.
+    Data8,
+}
+
+impl core::fmt::Display for DataBits {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Data7 => write!(f, "7"),
+            Self::Data8 => write!(f, "8"),
+        }
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for DataBits {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        use defmt::write;
+        match self {
+            Self::Data7 => write!(f, "7"),
+            Self::Data8 => write!(f, "8"),
+        }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_defmt_display_for_config {
+    () => {
+        impl core::fmt::Display for Config {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                write!(
+                    f,
+                    "{} {}{}{}",
+                    self.baudrate, self.data_bits, self.parity, self.stop_bits
+                )
+            }
+        }
+        #[cfg(feature = "defmt")]
+        impl defmt::Format for Config {
+            fn format(&self, f: defmt::Formatter<'_>) {
+                use defmt::write;
+                write!(
+                    f,
+                    "{} {}{}{}",
+                    self.baudrate, self.data_bits, self.parity, self.stop_bits
+                )
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_async_uart_bufread_for_driver_enum {
+    ($driver_enum:ident, $( $peripheral:ident ),*) => {
+        impl embedded_io_async::BufRead for $driver_enum<'_> {
+            async fn fill_buf(&mut self) -> Result<&[u8], Self::Error> {
+                match self {
+                    $( Self::$peripheral(uart) => embedded_io_async::BufRead::fill_buf(&mut uart.uart).await, )*
+                }
+            }
+
+            fn consume(&mut self, amt: usize) {
+                match self {
+                    $( Self::$peripheral(uart) => embedded_io_async::BufRead::consume(&mut uart.uart, amt), )*
+                }
+            }
+        }
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_async_uart_for_driver_enum {
+    ($driver_enum:ident, $( $peripheral:ident ),*) => {
+        impl embedded_io_async::Read for $driver_enum<'_> {
+            async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+                match self {
+                    $( Self::$peripheral(uart) => embedded_io_async::Read::read(&mut uart.uart, buf).await, )*
+                }
+            }
+        }
+
+
+        impl embedded_io_async::ReadReady for $driver_enum<'_> {
+            fn read_ready(&mut self) -> Result<bool, Self::Error> {
+                match self {
+                    $( Self::$peripheral(uart) => embedded_io_async::ReadReady::read_ready(&mut uart.uart), )*
+                }
+            }
+        }
+
+        impl embedded_io_async::Write for $driver_enum<'_> {
+            async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+                match self {
+                    $( Self::$peripheral(uart) => embedded_io_async::Write::write(&mut uart.uart, buf).await, )*
+                }
+            }
+            async fn flush(&mut self) -> Result<(), Self::Error> {
+                match self {
+                    $( Self::$peripheral(uart) => embedded_io_async::Write::flush(&mut uart.uart).await, )*
+                }
+            }
+            async fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+                match self {
+                    $( Self::$peripheral(uart) => embedded_io_async::Write::write_all(&mut uart.uart, buf).await, )*
+                }
+            }
+        }
+    }
+}

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -85,6 +85,9 @@ spi = [
   "ariel-os-hal/spi",
 ]
 
+## Enables UART support.
+uart = ["ariel-os-embassy-common/uart", "ariel-os-hal/uart"]
+
 ## Enables USB support.
 usb = ["dep:embassy-usb", "ariel-os-hal/usb"]
 usb-hid = ["dep:usbd-hid", "embassy-usb?/usbd-hid", "usb"]

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -201,6 +201,9 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     #[cfg(feature = "spi")]
     hal::spi::init(&mut peripherals);
 
+    #[cfg(feature = "uart")]
+    hal::uart::init(&mut peripherals);
+
     #[cfg(feature = "hwrng")]
     hal::hwrng::construct_rng(&mut peripherals);
     // Clock startup and entropy collection may lend themselves to parallelization, provided that

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -19,6 +19,9 @@ pub mod i2c;
 #[cfg(feature = "spi")]
 pub mod spi;
 
+#[cfg(feature = "uart")]
+pub mod uart;
+
 #[cfg(feature = "usb")]
 pub mod usb;
 
@@ -64,6 +67,8 @@ pub mod api {
     pub use crate::net;
     #[cfg(feature = "spi")]
     pub use crate::spi;
+    #[cfg(feature = "uart")]
+    pub use crate::uart;
     #[cfg(feature = "usb")]
     pub use crate::usb;
 }

--- a/src/ariel-os-embassy/src/uart.rs
+++ b/src/ariel-os-embassy/src/uart.rs
@@ -1,0 +1,4 @@
+//! Provides support for UART.
+#![deny(missing_docs)]
+
+pub use ariel_os_embassy_common::uart::*;

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -16,6 +16,7 @@ embassy-executor = { workspace = true, default-features = false }
 embassy-time = { workspace = true, optional = true }
 embedded-hal = { workspace = true }
 embedded-hal-async = { workspace = true }
+embedded-io-async = { workspace = true }
 esp-alloc = { workspace = true, default-features = false, optional = true }
 esp-hal = { workspace = true, default-features = false, features = [
   "optfield",
@@ -94,6 +95,9 @@ i2c = ["dep:fugit", "ariel-os-embassy-common/i2c"]
 
 ## Enables SPI support.
 spi = ["dep:embassy-embedded-hal", "dep:fugit", "ariel-os-embassy-common/spi"]
+
+## Enables UART support.
+uart = ["ariel-os-embassy-common/uart"]
 
 ## Enables threading support.
 threading = [

--- a/src/ariel-os-esp/src/lib.rs
+++ b/src/ariel-os-esp/src/lib.rs
@@ -30,6 +30,9 @@ pub mod identity {
 #[cfg(feature = "spi")]
 pub mod spi;
 
+#[cfg(feature = "uart")]
+pub mod uart;
+
 #[cfg(feature = "usb")]
 #[doc(hidden)]
 pub mod usb;

--- a/src/ariel-os-esp/src/uart.rs
+++ b/src/ariel-os-esp/src/uart.rs
@@ -1,0 +1,163 @@
+//! UART bus configuration.
+use ariel_os_embassy_common::{
+    impl_async_uart_for_driver_enum, impl_defmt_display_for_config,
+    uart::{Baud, DataBits, Parity, StopBits},
+};
+
+use esp_hal::{
+    Async,
+    gpio::interconnect::{PeripheralInput, PeripheralOutput},
+    peripheral::Peripheral,
+    peripherals,
+    uart::Uart as EspUart,
+};
+
+/// UART interface configuration.
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct Config {
+    /// The baud rate at which the bus should operate.
+    pub baudrate: Baud,
+    /// Number of data bits
+    pub data_bits: DataBits,
+    /// Number of stop bits
+    pub stop_bits: StopBits,
+    /// Parity mode used for the interface.
+    pub parity: Parity,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            baudrate: Baud::_9600,
+            data_bits: DataBits::Data8,
+            stop_bits: StopBits::Stop1,
+            parity: Parity::None,
+        }
+    }
+}
+
+fn from_parity(parity: Parity) -> esp_hal::uart::Parity {
+    match parity {
+        Parity::None => esp_hal::uart::Parity::None,
+        Parity::Even => esp_hal::uart::Parity::Even,
+        Parity::Odd => esp_hal::uart::Parity::Odd,
+    }
+}
+
+fn from_stop_bits(stop_bits: StopBits) -> esp_hal::uart::StopBits {
+    match stop_bits {
+        StopBits::Stop1 => esp_hal::uart::StopBits::_1,
+        StopBits::Stop2 => esp_hal::uart::StopBits::_2,
+    }
+}
+
+fn from_data_bits(data_bits: DataBits) -> esp_hal::uart::DataBits {
+    match data_bits {
+        DataBits::Data7 => esp_hal::uart::DataBits::_7,
+        DataBits::Data8 => esp_hal::uart::DataBits::_8,
+    }
+}
+
+impl_defmt_display_for_config!();
+
+macro_rules! define_uart_drivers {
+    ($( $peripheral:ident ),* $(,)?) => {
+        $(
+            /// Peripheral-specific UART driver.
+            pub struct $peripheral<'d> {
+                uart: EspUart<'d, Async>
+            }
+
+            impl<'d> $peripheral<'d> {
+                #[expect(clippy::new_ret_no_self)]
+                #[must_use]
+                /// Returns a driver implementing [`embedded-io`] for this Uart
+                /// peripheral.
+                pub fn new(
+                    rx_pin: impl Peripheral<P: PeripheralInput> + 'd,
+                    tx_pin: impl Peripheral<P: PeripheralOutput> + 'd,
+                    _rx_buf: &'d mut [u8],
+                    _tx_buf: &'d mut [u8],
+                    config: Config,
+                ) -> Uart<'d> {
+                    // Make this struct a compile-time-enforced singleton: having multiple statics
+                    // defined with the same name would result in a compile-time error.
+                    paste::paste! {
+                        #[allow(dead_code)]
+                        static [<PREVENT_MULTIPLE_ $peripheral>]: () = ();
+                    }
+
+                    let uart_config = esp_hal::uart::Config::default()
+                        .with_baudrate(config.baudrate.into())
+                        .with_data_bits(from_data_bits(config.data_bits))
+                        .with_stop_bits(from_stop_bits(config.stop_bits))
+                        .with_parity(from_parity(config.parity));
+
+                    // FIXME(safety): enforce that the init code indeed has run
+                    // SAFETY: this struct being a singleton prevents us from stealing the
+                    // peripheral multiple times.
+                    let uart_peripheral = unsafe { peripherals::$peripheral::steal() };
+
+                    let uart = EspUart::new(
+                        uart_peripheral,
+                        uart_config
+                    )
+                        .expect("Invalid uart configuration")
+                        .with_tx(tx_pin)
+                        .with_rx(rx_pin)
+                        .into_async();
+
+                    Uart::$peripheral(Self { uart })
+                }
+            }
+        )*
+
+        /// Peripheral-agnostic UART driver.
+        pub enum Uart<'d> {
+            $(
+                #[doc = concat!(stringify!($peripheral), " peripheral.")]
+                $peripheral($peripheral<'d>)
+            ),*
+        }
+
+        impl embedded_io_async::ErrorType for Uart<'_> {
+            type Error = esp_hal::uart::Error;
+        }
+
+        impl_async_uart_for_driver_enum!(Uart, $( $peripheral ),*);
+    }
+}
+
+#[cfg(context = "esp32")]
+define_uart_drivers!(UART0, UART1, UART2);
+#[cfg(context = "esp32c3")]
+define_uart_drivers!(UART0, UART1);
+#[cfg(context = "esp32c6")]
+define_uart_drivers!(UART0, UART1);
+#[cfg(context = "esp32s3")]
+define_uart_drivers!(UART0, UART1, UART2);
+
+#[doc(hidden)]
+pub fn init(peripherals: &mut crate::OptionalPeripherals) {
+    // Take all SPI peripherals and do nothing with them.
+    cfg_if::cfg_if! {
+        if #[cfg(context = "esp32")] {
+            let _ = peripherals.UART0.take().unwrap();
+            let _ = peripherals.UART1.take().unwrap();
+            let _ = peripherals.UART2.take().unwrap();
+        } else if #[cfg(context = "esp32c3")] {
+            let _ = peripherals.UART0.take().unwrap();
+            let _ = peripherals.UART1.take().unwrap();
+        } else if #[cfg(context = "esp32c6")] {
+            let _ = peripherals.UART0.take().unwrap();
+            let _ = peripherals.UART1.take().unwrap();
+        } else if #[cfg(context = "esp32s3")] {
+            let _ = peripherals.UART0.take().unwrap();
+            let _ = peripherals.UART1.take().unwrap();
+            let _ = peripherals.UART2.take().unwrap();
+        } else {
+            compile_error!("this ESP32 chip is not supported");
+        }
+    }
+}

--- a/src/ariel-os-hal/Cargo.toml
+++ b/src/ariel-os-hal/Cargo.toml
@@ -63,6 +63,13 @@ spi = [
   "ariel-os-stm32/spi",
 ]
 
+uart = [
+  "ariel-os-esp/uart",
+  "ariel-os-nrf/uart",
+  "ariel-os-rp/uart",
+  "ariel-os-stm32/uart",
+]
+
 usb = [
   "ariel-os-esp/usb",
   "ariel-os-nrf/usb",

--- a/src/ariel-os-hal/src/dummy/mod.rs
+++ b/src/ariel-os-hal/src/dummy/mod.rs
@@ -45,6 +45,10 @@ pub mod spi;
 pub mod storage;
 
 #[doc(hidden)]
+#[cfg(feature = "uart")]
+pub mod uart;
+
+#[doc(hidden)]
 #[cfg(feature = "usb")]
 pub mod usb;
 

--- a/src/ariel-os-hal/src/dummy/uart.rs
+++ b/src/ariel-os-hal/src/dummy/uart.rs
@@ -1,0 +1,21 @@
+//! HAL- and MCU-specific types for UART.
+//!
+//! This module provides a driver for each UART peripheral, the driver name being the same as the
+//! peripheral; see the tests and examples to learn how to instantiate them.
+
+/// Peripheral-agnostic UART driver implementing [`embedded_io_async::Read`]
+/// and [`embedded_io_async::Write`].
+///
+/// This type is not meant to be instantiated directly; instead instantiate a peripheral-specific
+/// driver provided by this module.
+// NOTE: we keep this type public because it may still required in user-written type signatures.
+pub enum Uart {
+    // Make the docs show that this enum has variants, but do not show any because they are
+    // MCU-specific.
+    #[doc(hidden)]
+    Hidden,
+}
+
+pub fn init(_peripherals: &mut crate::OptionalPeripherals) {
+    unimplemented!();
+}

--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -23,6 +23,7 @@ embassy-nrf = { workspace = true, default-features = false, features = [
   "rt",
 ] }
 embedded-hal-async = { workspace = true }
+embedded-io-async = { workspace = true }
 paste = { workspace = true }
 portable-atomic = { workspace = true }
 ariel-os-debug = { workspace = true }
@@ -83,6 +84,9 @@ i2c = ["ariel-os-embassy-common/i2c"]
 
 ## Enables SPI support.
 spi = ["ariel-os-embassy-common/spi"]
+
+## Enables UART support.
+uart = ["ariel-os-embassy-common/uart"]
 
 ## Enables storage support.
 storage = ["dep:embassy-embedded-hal"]

--- a/src/ariel-os-nrf/src/lib.rs
+++ b/src/ariel-os-nrf/src/lib.rs
@@ -34,6 +34,9 @@ pub mod identity;
 #[cfg(feature = "spi")]
 pub mod spi;
 
+#[cfg(feature = "uart")]
+pub mod uart;
+
 #[cfg(feature = "storage")]
 #[doc(hidden)]
 pub mod storage;

--- a/src/ariel-os-nrf/src/spi/main/mod.rs
+++ b/src/ariel-os-nrf/src/spi/main/mod.rs
@@ -235,7 +235,7 @@ define_spi_drivers!(
 #[cfg(context = "nrf5340")]
 define_spi_drivers!(
     SERIAL2 => SERIAL2,
-    SERIAL3 => SERIAL3,
+    // SERIAL3 => SERIAL3,
 );
 // FIXME: arbitrary selected peripherals
 #[cfg(context = "nrf91")]

--- a/src/ariel-os-nrf/src/uart.rs
+++ b/src/ariel-os-nrf/src/uart.rs
@@ -1,0 +1,242 @@
+//! UART bus configuration.
+use ariel_os_embassy_common::{
+    impl_async_uart_for_driver_enum,
+    uart::{Baud, Parity},
+};
+use embassy_nrf::{
+    Peripheral, bind_interrupts,
+    buffered_uarte::{Baudrate, BufferedUarte, InterruptHandler},
+    gpio::Pin as GpioPin,
+    peripherals,
+};
+
+/// Converts a Parity into nRF UART specific settings.
+///
+/// # Panics
+///
+/// Panics when parity setting is not supported by the nRF.
+fn from_parity(parity: Parity) -> embassy_nrf::uarte::Parity {
+    match parity {
+        Parity::None => embassy_nrf::uarte::Parity::EXCLUDED,
+        Parity::Even => embassy_nrf::uarte::Parity::INCLUDED,
+        Parity::Odd => panic!("Odd parity not supported"),
+    }
+}
+
+/// Converts a baud into nRF UART specific settings.
+///
+/// # Panics
+///
+/// Panics when the baud rate setting is not supported by the nRF.
+fn from_baudrate(baudrate: u32) -> Baudrate {
+    match baudrate {
+        1200 => Baudrate::BAUD1200,
+        2400 => Baudrate::BAUD2400,
+        4800 => Baudrate::BAUD4800,
+        9600 => Baudrate::BAUD9600,
+        14_400 => Baudrate::BAUD14400,
+        19_200 => Baudrate::BAUD19200,
+        28_800 => Baudrate::BAUD28800,
+        31_250 => Baudrate::BAUD31250,
+        38_400 => Baudrate::BAUD38400,
+        56_000 => Baudrate::BAUD56000,
+        57_600 => Baudrate::BAUD57600,
+        76_800 => Baudrate::BAUD76800,
+        115_200 => Baudrate::BAUD115200,
+        230_400 => Baudrate::BAUD230400,
+        250_000 => Baudrate::BAUD250000,
+        460_800 => Baudrate::BAUD460800,
+        921_600 => Baudrate::BAUD921600,
+        1_000_000 => Baudrate::BAUD1M,
+        _ => panic!("Baud rate not supported"),
+    }
+}
+
+/// UART interface configuration.
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct Config {
+    /// The baud rate at which the interface should operate.
+    pub baudrate: Baud,
+    /// Parity mode used for the interface.
+    pub parity: Parity,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            baudrate: Baud::_9600,
+            parity: Parity::None,
+        }
+    }
+}
+
+impl core::fmt::Display for Config {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{} 8{}1", self.baudrate, self.parity)
+    }
+}
+#[cfg(feature = "defmt")]
+impl defmt::Format for Config {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        use defmt::write;
+        write!(f, "{} 8{}1", self.baudrate, self.parity)
+    }
+}
+
+macro_rules! define_uart_drivers {
+    ($( $interrupt:ident => $peripheral:ident + $timer:ident + $ppi_ch1:ident + $ppi_ch2:ident + $ppi_group:ident),* $(,)?) => {
+        $(
+            /// Peripheral-specific UART driver.
+            pub struct $peripheral<'d> {
+                uart: BufferedUarte<'d, peripherals::$peripheral, peripherals::$timer>,
+            }
+
+            impl<'d> $peripheral<'d> {
+                /// Returns a driver implementing [`embedded-io`] for this Uart
+                /// peripheral.
+                #[expect(clippy::new_ret_no_self)]
+                #[must_use]
+                pub fn new(
+                    rx_pin: impl Peripheral<P: GpioPin> + 'd,
+                    tx_pin: impl Peripheral<P: GpioPin> + 'd,
+                    rx_buffer: &'d mut [u8],
+                    tx_buffer: &'d mut [u8],
+                    config: Config,
+                ) -> Uart<'d> {
+                    // Make this struct a compile-time-enforced singleton: having multiple statics
+                    // defined with the same name would result in a compile-time error.
+                    paste::paste! {
+                        #[allow(dead_code)]
+                        static [<PREVENT_MULTIPLE_ $peripheral>]: () = ();
+                    }
+
+                    let mut uart_config = embassy_nrf::uarte::Config::default();
+                    let baudrate: u32 = config.baudrate.into();
+                    uart_config.baudrate = from_baudrate(baudrate);
+                    uart_config.parity = from_parity(config.parity);
+
+                    bind_interrupts!(struct Irqs {
+                        $interrupt => InterruptHandler<peripherals::$peripheral>;
+                    });
+
+                    // FIXME(safety): enforce that the init code indeed has run
+                    // SAFETY: this struct being a singleton prevents us from stealing the
+                    // peripheral multiple times.
+                    let uart_peripheral = unsafe { peripherals::$peripheral::steal() };
+                    let timer_peripheral = unsafe { peripherals::$timer::steal() };
+                    let ppi_ch1_peripheral = unsafe { peripherals::$ppi_ch1::steal() };
+                    let ppi_ch2_peripheral = unsafe { peripherals::$ppi_ch2::steal() };
+                    let ppi_group_peripheral = unsafe { peripherals::$ppi_group::steal() };
+
+                    let mut uart = BufferedUarte::new(
+                        uart_peripheral,
+                        timer_peripheral,
+                        ppi_ch1_peripheral,
+                        ppi_ch2_peripheral,
+                        ppi_group_peripheral,
+                        Irqs,
+                        rx_pin,
+                        tx_pin,
+                        uart_config,
+                        rx_buffer,
+                        tx_buffer
+                    );
+                    uart.set_baudrate(baudrate.into());
+
+                    Uart::$peripheral(Self { uart })
+                }
+            }
+        )*
+
+        /// Peripheral-agnostic UART driver.
+        pub enum Uart<'d> {
+            $(
+                #[doc = concat!(stringify!($peripheral), " peripheral.")]
+                $peripheral($peripheral<'d>)
+            ),*
+        }
+
+        impl embedded_io_async::ErrorType for Uart<'_> {
+            type Error = embassy_nrf::buffered_uarte::Error;
+        }
+
+        impl_async_uart_for_driver_enum!(Uart, $( $peripheral ),*);
+    }
+}
+
+// Define a driver per peripheral
+#[cfg(context = "nrf52832")]
+define_uart_drivers!(
+   UARTE0 => UARTE0 + TIMER4 + PPI_CH18 + PPI_CH19 + PPI_GROUP5,
+);
+#[cfg(context = "nrf52833")]
+define_uart_drivers!(
+   UARTE0 => UARTE0 + TIMER3 + PPI_CH16 + PPI_CH17 + PPI_GROUP4,
+   UARTE1 => UARTE1 + TIMER4 + PPI_CH18 + PPI_CH19 + PPI_GROUP5,
+);
+#[cfg(context = "nrf52840")]
+define_uart_drivers!(
+   UARTE0 => UARTE0 + TIMER3 + PPI_CH16 + PPI_CH17 + PPI_GROUP4,
+   UARTE1 => UARTE1 + TIMER4 + PPI_CH18 + PPI_CH19 + PPI_GROUP5,
+);
+#[cfg(context = "nrf5340")]
+define_uart_drivers!(
+   SERIAL3 => SERIAL3 + TIMER2 + PPI_CH18 + PPI_CH19 + PPI_GROUP5,
+);
+#[cfg(context = "nrf91")]
+define_uart_drivers!(
+   SERIAL3 => SERIAL3 + TIMER2 + PPI_CH14 + PPI_CH15 + PPI_GROUP5,
+);
+
+#[doc(hidden)]
+pub fn init(peripherals: &mut crate::OptionalPeripherals) {
+    // Take all SPI peripherals and do nothing with them.
+    cfg_if::cfg_if! {
+        if #[cfg(context = "nrf52832")] {
+            let _ = peripherals.UARTE0.take().unwrap();
+            let _ = peripherals.TIMER4.take().unwrap();
+            let _ = peripherals.PPI_CH18.take().unwrap();
+            let _ = peripherals.PPI_CH19.take().unwrap();
+            let _ = peripherals.PPI_GROUP5.take().unwrap();
+        } else if #[cfg(context = "nrf52833")] {
+            let _ = peripherals.UARTE0.take().unwrap();
+            let _ = peripherals.TIMER3.take().unwrap();
+            let _ = peripherals.PPI_CH16.take().unwrap();
+            let _ = peripherals.PPI_CH17.take().unwrap();
+            let _ = peripherals.PPI_GROUP4.take().unwrap();
+
+            let _ = peripherals.UARTE1.take().unwrap();
+            let _ = peripherals.TIMER4.take().unwrap();
+            let _ = peripherals.PPI_CH18.take().unwrap();
+            let _ = peripherals.PPI_CH19.take().unwrap();
+            let _ = peripherals.PPI_GROUP5.take().unwrap();
+        } else if #[cfg(context = "nrf52840")] {
+            let _ = peripherals.UARTE0.take().unwrap();
+            let _ = peripherals.TIMER3.take().unwrap();
+            let _ = peripherals.PPI_CH16.take().unwrap();
+            let _ = peripherals.PPI_CH17.take().unwrap();
+            let _ = peripherals.PPI_GROUP4.take().unwrap();
+
+            let _ = peripherals.UARTE1.take().unwrap();
+            let _ = peripherals.TIMER4.take().unwrap();
+            let _ = peripherals.PPI_CH18.take().unwrap();
+            let _ = peripherals.PPI_CH19.take().unwrap();
+            let _ = peripherals.PPI_GROUP5.take().unwrap();
+        } else if #[cfg(context = "nrf5340")] {
+            let _ = peripherals.SERIAL3.take().unwrap();
+            let _ = peripherals.TIMER2.take().unwrap();
+            let _ = peripherals.PPI_CH18.take().unwrap();
+            let _ = peripherals.PPI_CH19.take().unwrap();
+            let _ = peripherals.PPI_GROUP5.take().unwrap();
+        } else if #[cfg(context = "nrf91")] {
+            let _ = peripherals.SERIAL3.take().unwrap();
+            let _ = peripherals.TIMER2.take().unwrap();
+            let _ = peripherals.PPI_CH14.take().unwrap();
+            let _ = peripherals.PPI_CH15.take().unwrap();
+            let _ = peripherals.PPI_GROUP5.take().unwrap();
+        } else {
+            compile_error!("this nRF chip is not supported");
+        }
+    }
+}

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -21,6 +21,7 @@ embassy-rp = { workspace = true, default-features = false, features = [
   # "unstable-traits",
 ] }
 embedded-hal-async = { workspace = true }
+embedded-io-async = { workspace = true }
 paste = { workspace = true }
 ariel-os-debug = { workspace = true }
 ariel-os-embassy-common = { workspace = true }
@@ -65,6 +66,9 @@ i2c = ["ariel-os-embassy-common/i2c"]
 
 ## Enables SPI support.
 spi = ["dep:embassy-embedded-hal", "ariel-os-embassy-common/spi"]
+
+## Enables UART support.
+uart = ["ariel-os-embassy-common/uart"]
 
 ## Enables storage support.
 storage = []

--- a/src/ariel-os-rp/src/lib.rs
+++ b/src/ariel-os-rp/src/lib.rs
@@ -42,6 +42,9 @@ pub mod identity {
 #[cfg(feature = "spi")]
 pub mod spi;
 
+#[cfg(feature = "uart")]
+pub mod uart;
+
 #[cfg(feature = "storage")]
 #[doc(hidden)]
 pub mod storage;

--- a/src/ariel-os-rp/src/uart.rs
+++ b/src/ariel-os-rp/src/uart.rs
@@ -1,0 +1,149 @@
+//! UART bus configuration.
+use ariel_os_embassy_common::{
+    impl_async_uart_for_driver_enum, impl_defmt_display_for_config,
+    uart::{Baud, DataBits, Parity, StopBits},
+};
+
+use embassy_rp::{
+    Peripheral, bind_interrupts, peripherals,
+    uart::{BufferedInterruptHandler, BufferedUart, RxPin, TxPin},
+};
+
+/// UART interface configuration.
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct Config {
+    /// The baud rate at which the bus should operate.
+    pub baudrate: Baud,
+    /// Number of data bits
+    pub data_bits: DataBits,
+    /// Number of stop bits
+    pub stop_bits: StopBits,
+    /// Parity mode used for the interface.
+    pub parity: Parity,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            baudrate: Baud::_9600,
+            data_bits: DataBits::Data8,
+            stop_bits: StopBits::Stop1,
+            parity: Parity::None,
+        }
+    }
+}
+
+fn from_parity(parity: Parity) -> embassy_rp::uart::Parity {
+    match parity {
+        Parity::None => embassy_rp::uart::Parity::ParityNone,
+        Parity::Even => embassy_rp::uart::Parity::ParityEven,
+        Parity::Odd => embassy_rp::uart::Parity::ParityOdd,
+    }
+}
+
+fn from_stop_bits(stop_bits: StopBits) -> embassy_rp::uart::StopBits {
+    match stop_bits {
+        StopBits::Stop1 => embassy_rp::uart::StopBits::STOP1,
+        StopBits::Stop2 => embassy_rp::uart::StopBits::STOP2,
+    }
+}
+
+fn from_data_bits(data_bits: DataBits) -> embassy_rp::uart::DataBits {
+    match data_bits {
+        DataBits::Data7 => embassy_rp::uart::DataBits::DataBits7,
+        DataBits::Data8 => embassy_rp::uart::DataBits::DataBits8,
+    }
+}
+
+impl_defmt_display_for_config!();
+
+macro_rules! define_uart_drivers {
+    ($( $interrupt:ident => $peripheral:ident ),* $(,)?) => {
+        $(
+            /// Peripheral-specific UART driver.
+            pub struct $peripheral<'d> {
+                uart: BufferedUart<'d, peripherals::$peripheral>,
+            }
+
+            impl<'d> $peripheral<'d> {
+                #[expect(clippy::new_ret_no_self)]
+                #[must_use]
+                /// Returns a driver implementing [`embedded-io`] for this Uart
+                /// peripheral.
+                pub fn new(
+                    rx_pin: impl Peripheral<P: RxPin<peripherals::$peripheral>> + 'd,
+                    tx_pin: impl Peripheral<P: TxPin<peripherals::$peripheral>> + 'd,
+                    rx_buf: &'d mut [u8],
+                    tx_buf: &'d mut [u8],
+                    config: Config,
+                ) -> Uart<'d> {
+                    // Make this struct a compile-time-enforced singleton: having multiple statics
+                    // defined with the same name would result in a compile-time error.
+                    paste::paste! {
+                        #[allow(dead_code)]
+                        static [<PREVENT_MULTIPLE_ $peripheral>]: () = ();
+                    }
+
+                    let mut uart_config = embassy_rp::uart::Config::default();
+                    uart_config.baudrate = config.baudrate.into();
+                    uart_config.data_bits = from_data_bits(config.data_bits);
+                    uart_config.stop_bits = from_stop_bits(config.stop_bits);
+                    uart_config.parity = from_parity(config.parity);
+                    bind_interrupts!(struct Irqs {
+                        $interrupt => BufferedInterruptHandler<peripherals::$peripheral>;
+                    });
+
+                    // FIXME(safety): enforce that the init code indeed has run
+                    // SAFETY: this struct being a singleton prevents us from stealing the
+                    // peripheral multiple times.
+                    let uart_peripheral = unsafe { peripherals::$peripheral::steal() };
+
+                    let uart = BufferedUart::new(
+                        uart_peripheral,
+                        Irqs,
+                        tx_pin,
+                        rx_pin,
+                        tx_buf,
+                        rx_buf,
+                        uart_config,
+                    );
+
+                    Uart::$peripheral(Self { uart })
+                }
+            }
+        )*
+
+        /// Peripheral-agnostic UART driver.
+        pub enum Uart<'d> {
+            $(
+                #[doc = concat!(stringify!($peripheral), " peripheral.")]
+                $peripheral($peripheral<'d>)
+            ),*
+        }
+
+        impl embedded_io_async::ErrorType for Uart<'_> {
+            type Error = embassy_rp::uart::Error;
+        }
+
+        impl_async_uart_for_driver_enum!(Uart, $( $peripheral ),*);
+    }
+}
+
+define_uart_drivers!(
+   UART0_IRQ => UART0,
+   UART1_IRQ => UART1,
+);
+
+#[doc(hidden)]
+pub fn init(peripherals: &mut crate::OptionalPeripherals) {
+    // Take all SPI peripherals and do nothing with them.
+    cfg_if::cfg_if! {
+        if #[cfg(context = "rp")] {
+            let _ = peripherals.UART0.take().unwrap();
+            let _ = peripherals.UART1.take().unwrap();
+        } else {
+            compile_error!("this RP chip is not supported");
+        }
+    }
+}

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -24,6 +24,7 @@ embassy-stm32 = { workspace = true, default-features = false, features = [
   "unstable-pac",
 ] }
 embedded-hal-async = { workspace = true }
+embedded-io-async = { workspace = true }
 paste = { workspace = true }
 portable-atomic = { workspace = true }
 ariel-os-utils = { workspace = true }
@@ -56,6 +57,9 @@ i2c = [
 
 ## Enables SPI support.
 spi = ["dep:embassy-embedded-hal", "ariel-os-embassy-common/spi"]
+
+## Enables UART support.
+uart = ["ariel-os-embassy-common/uart"]
 
 ## Enables storage support.
 storage = ["dep:embassy-embedded-hal"]

--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -24,6 +24,9 @@ pub mod identity;
 #[cfg(feature = "spi")]
 pub mod spi;
 
+#[cfg(feature = "uart")]
+pub mod uart;
+
 #[cfg(feature = "storage")]
 #[doc(hidden)]
 pub mod storage;

--- a/src/ariel-os-stm32/src/uart.rs
+++ b/src/ariel-os-stm32/src/uart.rs
@@ -1,0 +1,242 @@
+//! UART bus configuration.
+use ariel_os_embassy_common::{
+    impl_async_uart_for_driver_enum, impl_defmt_display_for_config,
+    uart::{Baud, DataBits, Parity, StopBits},
+};
+use embassy_stm32::{
+    Peripheral, bind_interrupts, peripherals,
+    usart::{BufferedInterruptHandler, BufferedUart, RxPin, TxPin},
+};
+
+/// UART interface configuration.
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct Config {
+    /// The baud rate at which the bus should operate.
+    pub baudrate: Baud,
+    /// Number of data bits
+    pub data_bits: DataBits,
+    /// Number of stop bits
+    pub stop_bits: StopBits,
+    /// Parity mode used for the interface.
+    pub parity: Parity,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            baudrate: Baud::_9600,
+            data_bits: DataBits::Data8,
+            stop_bits: StopBits::Stop1,
+            parity: Parity::None,
+        }
+    }
+}
+
+fn from_parity(parity: Parity) -> embassy_stm32::usart::Parity {
+    match parity {
+        Parity::None => embassy_stm32::usart::Parity::ParityNone,
+        Parity::Even => embassy_stm32::usart::Parity::ParityEven,
+        Parity::Odd => embassy_stm32::usart::Parity::ParityOdd,
+    }
+}
+
+fn from_stop_bits(stop_bits: StopBits) -> embassy_stm32::usart::StopBits {
+    match stop_bits {
+        StopBits::Stop1 => embassy_stm32::usart::StopBits::STOP1,
+        StopBits::Stop2 => embassy_stm32::usart::StopBits::STOP2,
+    }
+}
+
+fn from_data_bits(data_bits: DataBits) -> embassy_stm32::usart::DataBits {
+    match data_bits {
+        DataBits::Data7 => embassy_stm32::usart::DataBits::DataBits7,
+        DataBits::Data8 => embassy_stm32::usart::DataBits::DataBits8,
+    }
+}
+
+impl_defmt_display_for_config!();
+
+macro_rules! define_uart_drivers {
+    ($( $interrupt:ident => $peripheral:ident ),* $(,)?) => {
+        $(
+            /// Peripheral-specific UART driver.
+            pub struct $peripheral<'d> {
+                uart: BufferedUart<'d>,
+            }
+
+            impl<'d> $peripheral<'d> {
+                #[expect(clippy::new_ret_no_self)]
+                #[must_use]
+                /// Returns a driver implementing [`embedded-io`] for this Uart
+                /// peripheral.
+                pub fn new(
+                    rx_pin: impl Peripheral<P: RxPin<peripherals::$peripheral>> + 'd,
+                    tx_pin: impl Peripheral<P: TxPin<peripherals::$peripheral>> + 'd,
+                    rx_buf: &'d mut [u8],
+                    tx_buf: &'d mut [u8],
+                    config: Config,
+                ) -> Uart<'d> {
+                    // Make this struct a compile-time-enforced singleton: having multiple statics
+                    // defined with the same name would result in a compile-time error.
+                    paste::paste! {
+                        #[allow(dead_code)]
+                        static [<PREVENT_MULTIPLE_ $peripheral>]: () = ();
+                    }
+
+                    let mut uart_config = embassy_stm32::usart::Config::default();
+                    uart_config.baudrate = config.baudrate.into();
+                    uart_config.data_bits = from_data_bits(config.data_bits);
+                    uart_config.stop_bits = from_stop_bits(config.stop_bits);
+                    uart_config.parity = from_parity(config.parity);
+                    bind_interrupts!(struct Irqs {
+                        $interrupt => BufferedInterruptHandler<peripherals::$peripheral>;
+                    });
+
+                    // FIXME(safety): enforce that the init code indeed has run
+                    // SAFETY: this struct being a singleton prevents us from stealing the
+                    // peripheral multiple times.
+                    let uart_peripheral = unsafe { peripherals::$peripheral::steal() };
+
+                    let uart = BufferedUart::new(
+                        uart_peripheral,
+                        Irqs,
+                        rx_pin,
+                        tx_pin,
+                        tx_buf,
+                        rx_buf,
+                        uart_config,
+                    ).expect("Invalid config for UART");
+
+                    Uart::$peripheral(Self { uart })
+                }
+            }
+        )*
+
+        /// Peripheral-agnostic UART driver.
+        pub enum Uart<'d> {
+            $(
+                #[doc = concat!(stringify!($peripheral), " peripheral.")]
+                $peripheral($peripheral<'d>)
+            ),*
+        }
+
+        impl embedded_io_async::ErrorType for Uart<'_> {
+            type Error = embassy_stm32::usart::Error;
+        }
+
+        impl_async_uart_for_driver_enum!(Uart, $( $peripheral ),*);
+    }
+}
+
+#[cfg(context = "stm32c031c6")]
+define_uart_drivers!(
+   USART1 => USART1,
+   // USART2 => USART2, // Often used as SWI
+);
+#[cfg(context = "stm32f042k6")]
+define_uart_drivers!(
+   USART1 => USART1,
+   // USART2 => USART2, // Often used as SWI
+);
+#[cfg(context = "stm32f401re")]
+define_uart_drivers!(
+   USART1 => USART1,
+   // USART2 => USART2, // Often used as SWI
+   USART6 => USART6,
+);
+#[cfg(context = "stm32h755zi")]
+define_uart_drivers!(
+   USART1 => USART1,
+   USART2 => USART2,
+   USART3 => USART3,
+   UART4 => UART4,
+   // UART5 => UART5, // Often used as SWI
+   USART6 => USART6,
+   UART7 => UART7,
+   UART8 => UART8,
+);
+#[cfg(context = "stm32l475vg")]
+define_uart_drivers!(
+   USART1 => USART1,
+   USART2 => USART2,
+   USART3 => USART3,
+   UART4 => UART4,
+   // UART5 => UART5, // Often used as SWI
+);
+#[cfg(context = "stm32u083mc")]
+define_uart_drivers!(
+   USART1 => USART1,
+   USART2 => USART2,
+   USART3 => USART3,
+   USART4 => USART4,
+);
+#[cfg(context = "stm32u585ai")]
+define_uart_drivers!(
+   USART1 => USART1,
+   // USART2 => USART2, // Often used as SWI
+   USART3 => USART3,
+   UART4 => UART4,
+   UART5 => UART5,
+);
+#[cfg(context = "stm32wb55rg")]
+define_uart_drivers!(
+   USART1 => USART1,
+);
+#[cfg(context = "stm32wba55cg")]
+define_uart_drivers!(
+   USART1 => USART1,
+   // USART2 => USART2, // Often used as SWI
+   LPUART1 => LPUART1,
+);
+
+#[doc(hidden)]
+pub fn init(peripherals: &mut crate::OptionalPeripherals) {
+    // Take all SPI peripherals and do nothing with them.
+    cfg_if::cfg_if! {
+        if #[cfg(context = "stm32c031c6")] {
+            let _ = peripherals.USART1.take().unwrap();
+        } else if #[cfg(context = "stm32f042k6")] {
+            let _ = peripherals.USART1.take().unwrap();
+            let _ = peripherals.USART2.take().unwrap();
+        } else if #[cfg(context = "stm32f401re")] {
+            let _ = peripherals.USART1.take().unwrap();
+            let _ = peripherals.USART2.take().unwrap();
+            let _ = peripherals.USART6.take().unwrap();
+        } else if #[cfg(context = "stm32wb55rg")] {
+            let _ = peripherals.USART1.take().unwrap();
+        } else if #[cfg(context = "stm32h755zi")] {
+            let _ = peripherals.USART1.take().unwrap();
+            let _ = peripherals.USART2.take().unwrap();
+            let _ = peripherals.USART3.take().unwrap();
+            let _ = peripherals.UART4.take().unwrap();
+            let _ = peripherals.UART5.take().unwrap();
+            let _ = peripherals.USART6.take().unwrap();
+            let _ = peripherals.UART7.take().unwrap();
+            let _ = peripherals.UART8.take().unwrap();
+        } else if #[cfg(context = "stm32l475vg")] {
+            let _ = peripherals.USART1.take().unwrap();
+            let _ = peripherals.USART2.take().unwrap();
+            let _ = peripherals.USART3.take().unwrap();
+            let _ = peripherals.UART4.take().unwrap();
+            let _ = peripherals.UART5.take().unwrap();
+        } else if #[cfg(context = "stm32u083mc")] {
+            let _ = peripherals.USART1.take().unwrap();
+            let _ = peripherals.USART2.take().unwrap();
+            let _ = peripherals.USART3.take().unwrap();
+            let _ = peripherals.USART4.take().unwrap();
+        } else if #[cfg(context = "stm32u585ai")] {
+            let _ = peripherals.USART1.take().unwrap();
+            let _ = peripherals.USART2.take().unwrap();
+            let _ = peripherals.USART3.take().unwrap();
+        } else if #[cfg(context = "stm32wb55rg")] {
+            let _ = peripherals.USART1.take().unwrap();
+        } else if #[cfg(context = "stm32wba55cg")] {
+            let _ = peripherals.USART1.take().unwrap();
+            let _ = peripherals.USART2.take().unwrap();
+            let _ = peripherals.LPUART1.take().unwrap();
+        } else {
+            compile_error!("this STM32 chip is not supported");
+        }
+    }
+}

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -104,6 +104,8 @@ network-config-static = ["ariel-os-embassy/network-config-static"]
 i2c = ["ariel-os-embassy/i2c"]
 ## Enables SPI support.
 spi = ["ariel-os-embassy/spi"]
+## Enables UART support.
+uart = ["ariel-os-embassy/uart"]
 ## Enables USB support.
 usb = ["ariel-os-embassy/usb"]
 ## Enables USB HID support.
@@ -201,4 +203,11 @@ executor-thread = ["ariel-os-embassy/executor-thread", "threading"]
 executor-none = ["ariel-os-embassy/executor-none"]
 
 # features needed for `cargo test`
-_test = ["i2c", "no-boards", "spi", "external-interrupts", "ariel-os-rt/_test"]
+_test = [
+  "i2c",
+  "no-boards",
+  "spi",
+  "external-interrupts",
+  "uart",
+  "ariel-os-rt/_test",
+]

--- a/tests/laze.yml
+++ b/tests/laze.yml
@@ -12,3 +12,4 @@ subdirs:
   - threading-fpu
   - threading-lock
   - threading-mutex
+  - uart-loopback

--- a/tests/uart-loopback/Cargo.toml
+++ b/tests/uart-loopback/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "uart-loopback"
+license.workspace = true
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+ariel-os = { path = "../../src/ariel-os", features = ["time", "uart"] }
+ariel-os-boards = { path = "../../src/ariel-os-boards" }
+embedded-io-async = { workspace = true }

--- a/tests/uart-loopback/README.md
+++ b/tests/uart-loopback/README.md
@@ -1,0 +1,19 @@
+# UART loopback test
+
+## About
+
+This application tests the UART peripheral via an external loopback wire
+
+## How to run
+
+1. Ensure a wire is present between the TX and RX pins
+2. In this directory, run:
+
+    laze build -b nrf52840dk run
+
+The test attempts to do a transfer and compares if what was sent has been read back.
+
+## Potential issues
+
+- An existing serial connection on the board can interfere with the test.
+  The TX pin of the other serial endpoint can conflict with the loopback operation.

--- a/tests/uart-loopback/laze.yml
+++ b/tests/uart-loopback/laze.yml
@@ -1,0 +1,19 @@
+apps:
+  - name: uart-loopback
+    context:
+      - bbc-microbit-v2
+      - esp
+      - nrf52840
+      - nrf52832
+      - nrf5340
+      - nrf91
+      - rp2040
+      - rp235xa
+      - st-nucleo-c031c6
+      - st-nucleo-f042k6
+      - st-nucleo-f401re
+      - st-nucleo-h755zi-q
+      - st-b-l475e-iot01a
+      - st-nucleo-wb55
+      - st-nucleo-wba55
+      - st-steval-mkboxpro

--- a/tests/uart-loopback/src/main.rs
+++ b/tests/uart-loopback/src/main.rs
@@ -1,0 +1,57 @@
+//! This is a test for UART loopback operation
+
+#![no_main]
+#![no_std]
+
+mod pins;
+
+use ariel_os::{
+    debug::{
+        ExitCode, exit,
+        log::{Hex, info},
+    },
+    hal,
+    time::Duration,
+    uart::Baud,
+};
+
+use ariel_os::reexports::embassy_time::WithTimeout;
+
+use embedded_io_async::{Read as _, Write as _};
+
+#[ariel_os::task(autostart, peripherals)]
+async fn main(peripherals: pins::Peripherals) {
+    info!("Starting UART test");
+
+    let mut config = hal::uart::Config::default();
+    config.baudrate = Baud::_9600;
+    info!("Selected configuration: {}", config);
+
+    let mut rx_buf = [0u8; 32];
+    let mut tx_buf = [0u8; 32];
+
+    let mut uart = pins::TestUart::new(
+        peripherals.uart_rx,
+        peripherals.uart_tx,
+        &mut rx_buf,
+        &mut tx_buf,
+        config,
+    );
+
+    const OUT: &str = "Test Message";
+    let mut in_ = [0u8; OUT.len()];
+
+    uart.write_all(OUT.as_bytes()).await.unwrap();
+    uart.flush().await.unwrap();
+    info!("Wrote bytes");
+    let _ = uart
+        .read_exact(&mut in_)
+        .with_timeout(Duration::from_secs(5))
+        .await;
+
+    info!("Got: {}", Hex(in_));
+    assert_eq!(OUT.as_bytes(), in_);
+    info!("Test passed!");
+
+    exit(ExitCode::SUCCESS);
+}

--- a/tests/uart-loopback/src/pins.rs
+++ b/tests/uart-loopback/src/pins.rs
@@ -1,0 +1,141 @@
+use ariel_os::hal::{peripherals, uart};
+
+#[cfg(context = "esp")]
+pub type TestUart<'a> = uart::UART0<'a>;
+#[cfg(context = "esp")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_tx: GPIO16,
+    uart_rx: GPIO17,
+});
+
+#[cfg(context = "nrf52832")]
+pub type TestUart<'a> = uart::UARTE0<'a>;
+#[cfg(context = "nrf52832")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: P0_02,
+    uart_tx: P0_03,
+});
+
+#[cfg(context = "nrf52833")]
+pub type TestUart<'a> = uart::UARTE0<'a>;
+#[cfg(context = "nrf52833")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: P0_02,
+    uart_tx: P0_03,
+});
+
+// Side UART of Arduino v3 connector
+#[cfg(context = "nrf52840")]
+pub type TestUart<'a> = uart::UARTE0<'a>;
+#[cfg(context = "nrf52840")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: P1_01,
+    uart_tx: P1_02,
+});
+
+// Side UART of Arduino v3 connector
+#[cfg(context = "nrf5340")]
+pub type TestUart<'a> = uart::SERIAL3<'a>;
+#[cfg(context = "nrf5340")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: P1_00,
+    uart_tx: P1_01,
+});
+
+// Side UART of Arduino v3 connector
+#[cfg(context = "nrf9160")]
+pub type TestUart<'a> = uart::SERIAL3<'a>;
+#[cfg(context = "nrf9160")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: P0_00,
+    uart_tx: P0_01,
+});
+
+// Side UART of Arduino v3 connector
+#[cfg(context = "nrf9151")]
+pub type TestUart<'a> = uart::SERIAL3<'a>;
+#[cfg(context = "nrf9151")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: P0_00,
+    uart_tx: P0_01,
+});
+
+#[cfg(context = "rp")]
+pub type TestUart<'a> = uart::UART0<'a>;
+#[cfg(context = "rp")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: PIN_17,
+    uart_tx: PIN_16,
+});
+
+// Side UART of Arduino v3 connector
+#[cfg(context = "stm32c031c6")]
+pub type TestUart<'a> = uart::USART1<'a>;
+#[cfg(context = "stm32c031c6")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: PB7,
+    uart_tx: PB6,
+});
+
+// Side UART of Arduino v3 connector
+#[cfg(context = "stm32f042k6")]
+pub type TestUart<'a> = uart::USART1<'a>;
+#[cfg(context = "stm32f042k6")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: PA10,
+    uart_tx: PA9,
+});
+
+// Side UART of Arduino v3 connector
+#[cfg(context = "stm32f401re")]
+pub type TestUart<'a> = uart::USART1<'a>;
+#[cfg(context = "stm32f401re")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: PA10,
+    uart_tx: PA9,
+});
+
+// Side UART of Arduino v3 connector
+#[cfg(context = "stm32h755zi")]
+pub type TestUart<'a> = uart::USART1<'a>;
+#[cfg(context = "stm32h755zi")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: PB7,
+    uart_tx: PB6,
+});
+
+// Side UART of Arduino v3 connector
+#[cfg(context = "stm32l475vg")]
+pub type TestUart<'a> = uart::UART4<'a>;
+#[cfg(context = "stm32l475vg")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: PA1,
+    uart_tx: PA0,
+});
+
+// Side UART of Arduino v3 connector
+#[cfg(context = "stm32wb55rg")]
+pub type TestUart<'a> = uart::USART1<'a>;
+#[cfg(context = "stm32wb55rg")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: PA10,
+    uart_tx: PA9,
+});
+
+// Side UART of Arduino v3 connector
+#[cfg(context = "stm32wba55cg")]
+pub type TestUart<'a> = uart::LPUART1<'a>;
+#[cfg(context = "stm32wba55cg")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: PA10,
+    uart_tx: PB5,
+});
+
+// JTAG UART
+#[cfg(context = "st-steval-mkboxpro")]
+pub type TestUart<'a> = uart::UART4<'a>;
+#[cfg(context = "st-steval-mkboxpro")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    uart_rx: PA1,
+    uart_tx: PA0,
+});


### PR DESCRIPTION
# Description

This PR provides an abstraction layer for UART peripherals.
The focus is on the shared UART TX/RX and provide the buffered mode of the peripherals.
The drivers implement the [`embedded-io-async::Read`](https://docs.rs/embedded-io-async/0.6.1/embedded_io_async/trait.Read.html), [`embedded-io-async::ReadReady`](https://docs.rs/embedded-io-async/0.6.1/embedded_io_async/trait.ReadReady.html), and [`embedded-io-async::Write`](https://docs.rs/embedded-io-async/0.6.1/embedded_io_async/trait.Write.html) traits. The [`BufRead`](https://docs.rs/embedded-io-async/0.6.1/embedded_io_async/trait.BufRead.html) can be added for peripherals that support it (esp_hal is the only one that doesn't implement it on the peripherals).

## Issues/PRs references

~~Depends on #1203~~, needs a rebase now 

Closes #830 

## Open issues

### nRF

Tested on the nRF52840 DK

### stm32

Compiles, but untested

### esp32

Tested on both the esp32-c6-devkitc-1 and esp32-c3-devkit-something-something

- [x] ~~RX doesn't work yet~~

### rp

Compiles, but untested

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
