### PR TITLE
feat(boards): add support for the FireBeetle 2 ESP32-C6

### DIFF
--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -6,6 +6,9 @@ ariel_os::hal::define_peripherals!(LedPeripherals {
     led: P0_21,
 });
 
+#[cfg(context = "dfrobot-firebeetle2-esp32-c6")]
+ariel_os::hal::define_peripherals!(LedPeripherals { led: GPIO15 });
+
 #[cfg(context = "nordic-thingy-91-x-nrf9151")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_29 });
 

--- a/examples/gpio/src/pins.rs
+++ b/examples/gpio/src/pins.rs
@@ -13,6 +13,12 @@ ariel_os::hal::define_peripherals!(Peripherals {
     btn1: P0_14
 });
 
+#[cfg(context = "dfrobot-firebeetle2-esp32-c6")]
+ariel_os::hal::define_peripherals!(LedPeripherals {
+    led1: GPIO15,
+    btn1: GPIO1
+});
+
 #[cfg(context = "nordic-thingy-91-x-nrf9151")]
 ariel_os::hal::define_peripherals!(Peripherals {
     led1: P0_29,

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1344,6 +1344,9 @@ builders:
   - name: bbc-microbit-v2
     parent: nrf52833
 
+  - name: dfrobot-firebeetle2-esp32-c6
+    parent: esp32c6
+
   - name: particle-xenon
     parent: nrf52840
     provides:


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This adds support for the [FireBeetle 2 ESP32-C6](https://web.archive.org/web/20250214091848/https://wiki.dfrobot.com/SKU_DFR1075_FireBeetle_2_Board_ESP32_C6). This doesn't update the support matrix as that board is untested for now.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
