### PR TITLE
feat(boards): add support for the SMT32U083C-DK

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -232,6 +232,21 @@ chips:
           - removing items not supported
       wifi: not_available
 
+  stm32u083mc:
+    name: STM32U083MC
+    support:
+      gpio: supported
+      debug_output: supported
+      hwrng: supported
+      i2c_controller: supported
+      spi_main: supported
+      logging: supported
+      storage:
+        status: supported_with_caveats
+        comments:
+          - removing items not supported
+      wifi: not_available
+
   stm32wb55rg:
     name: STM32WB55RG
     support:
@@ -381,3 +396,15 @@ boards:
       user_usb: supported
       wifi: not_available
       ethernet_over_usb: supported
+
+  stm32u083c-dk:
+    name: STM32U083C-DK
+    url: https://web.archive.org/web/20250119131656/https://www.st.com/en/evaluation-tools/stm32u083c-dk.html
+    chip: stm32u083mc
+    support:
+      user_usb: supported
+      wifi: not_available
+      ethernet_over_usb:
+        status: not_currently_supported
+        comments:
+          - not enough RAM

--- a/examples/blinky/laze.yml
+++ b/examples/blinky/laze.yml
@@ -15,3 +15,4 @@ apps:
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
       - st-nucleo-wba55
+      - stm32u083c-dk

--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -47,3 +47,6 @@ ariel_os::hal::define_peripherals!(LedPeripherals { led: PB5 });
 
 #[cfg(context = "st-nucleo-wba55")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: PB4 });
+
+#[cfg(context = "stm32u083c-dk")]
+ariel_os::hal::define_peripherals!(LedPeripherals { led: PA5 });

--- a/examples/gpio/laze.yml
+++ b/examples/gpio/laze.yml
@@ -13,3 +13,4 @@ apps:
       - st-nucleo-f401re
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
+      - stm32u083c-dk

--- a/examples/gpio/src/pins.rs
+++ b/examples/gpio/src/pins.rs
@@ -72,3 +72,9 @@ ariel_os::hal::define_peripherals!(Peripherals {
     led1: PB5,
     btn1: PC4
 });
+
+#[cfg(context = "stm32u083mc")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    led1: PA5,
+    btn1: PC2
+});

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -438,6 +438,22 @@ contexts:
         - --cfg capability=\"hw/stm32-hash-rng\"
         - --cfg capability=\"hw/stm32-usb-synopsis\"
 
+  - name: stm32u083mc
+    parent: stm32
+    selects:
+      - cortex-m0-plus
+    disables:
+      # TODO: not enough RAM
+      - network
+    provides:
+      - has_hwrng
+      - has_storage_support
+    env:
+      PROBE_RS_CHIP: STM32U083MC
+      RUSTFLAGS:
+        - --cfg capability=\"hw/stm32-rng-cryp\"
+        - --cfg capability=\"hw/stm32-usb-drd-fs\"
+
   - name: stm32wb55rg
     parent: stm32
     selects:
@@ -1492,6 +1508,16 @@ builders:
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.
         - CONFIG_SWI=LPUART1
+
+  - name: stm32u083c-dk
+    parent: stm32u083mc
+    provides:
+      - has_swi
+      - has_usb_device_port
+    env:
+      CARGO_ENV:
+        # This ISR is unused on a naked board. Configured here for testing.
+        - CONFIG_SWI=USART2_LPUART2
 
 apps:
   # define a dummy host application so the host tasks work

--- a/src/ariel-os-stm32/src/i2c/controller/mod.rs
+++ b/src/ariel-os-stm32/src/i2c/controller/mod.rs
@@ -229,6 +229,11 @@ define_i2c_drivers!(
    I2C3_EV + I2C3_ER => I2C3,
    I2C4_EV + I2C4_ER => I2C4,
 );
+#[cfg(context = "stm32u083mc")]
+define_i2c_drivers!(
+   I2C1 => I2C1,
+   // FIXME: the other three I2C peripherals share the same interrupt
+);
 #[cfg(context = "stm32wb55rg")]
 define_i2c_drivers!(
    I2C1_EV + I2C1_ER => I2C1,

--- a/src/ariel-os-stm32/src/i2c/mod.rs
+++ b/src/ariel-os-stm32/src/i2c/mod.rs
@@ -22,6 +22,8 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
             take_all_i2c_peripherals!(I2C1, I2C2, I2C3);
         } else if #[cfg(context = "stm32h755zi")] {
             take_all_i2c_peripherals!(I2C1, I2C2, I2C3, I2C4);
+        } else if #[cfg(context = "stm32u083mc")] {
+            take_all_i2c_peripherals!(I2C1, I2C2, I2C3, I2C4);
         } else if #[cfg(context = "stm32wb55rg")] {
             take_all_i2c_peripherals!(I2C1, I2C3);
         } else {

--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -134,6 +134,27 @@ fn board_config(config: &mut Config) {
         config.rcc.mux.spi123sel = mux::Saisel::PLL1_Q; // Reset value
     }
 
+    #[cfg(context = "stm32u083mc")]
+    {
+        use embassy_stm32::rcc::*;
+
+        config.rcc.hsi48 = Some(Hsi48Config {
+            sync_from_usb: true,
+        }); // needed for USB
+        // No HSE fitted on the stm32u083c-dk board
+        config.rcc.hsi = true;
+        config.rcc.sys = Sysclk::PLL1_R;
+        config.rcc.pll = Some(Pll {
+            source: PllSource::HSI,
+            prediv: PllPreDiv::DIV1,
+            mul: PllMul::MUL7,
+            divp: None,
+            divq: None,
+            divr: Some(PllRDiv::DIV2), // sysclk 56Mhz
+        });
+        config.rcc.mux.clk48sel = mux::Clk48sel::HSI48;
+    }
+
     // mark used
     let _ = config;
 }

--- a/src/ariel-os-stm32/src/spi/main/mod.rs
+++ b/src/ariel-os-stm32/src/spi/main/mod.rs
@@ -22,6 +22,8 @@ const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(24);
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(21);
 #[cfg(context = "stm32h755zi")]
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(150);
+#[cfg(context = "stm32u083mc")]
+const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(32);
 #[cfg(context = "stm32wb55rg")]
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(32);
 
@@ -153,6 +155,11 @@ define_spi_drivers!(
    SPI4 => SPI4,
    SPI5 => SPI5,
    SPI6 => SPI6,
+);
+#[cfg(context = "stm32u083mc")]
+define_spi_drivers!(
+   SPI1 => SPI1,
+   // FIXME: the other two SPI peripherals share the same interrupt
 );
 #[cfg(context = "stm32wb55rg")]
 define_spi_drivers!(

--- a/src/ariel-os-stm32/src/spi/mod.rs
+++ b/src/ariel-os-stm32/src/spi/mod.rs
@@ -40,6 +40,8 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3);
         } else if #[cfg(context = "stm32h755zi")] {
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3, SPI4, SPI5, SPI6);
+        } else if #[cfg(context = "stm32u083mc")] {
+            take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3);
         } else if #[cfg(context = "stm32wb55rg")] {
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2);
         } else {

--- a/src/ariel-os-storage/build.rs
+++ b/src/ariel-os-storage/build.rs
@@ -7,17 +7,18 @@ fn main() {
     // Important: only homogeneous flash organizations are currently supported.
     // Trying to restrict the storage size to the subset of homogeneous flash would not work as it
     // could be pushed out of it by a large enough binary.
-    let (storage_size_total, flash_page_size) =
-        if is_in_current_contexts(&["nrf52", "nrf5340", "nrf91", "rp", "stm32wb55rg"]) {
-            (8 * KIBIBYTES, 4 * KIBIBYTES)
-        } else if is_in_current_contexts(&["stm32h755zi"]) {
-            (256 * KIBIBYTES, 128 * KIBIBYTES)
-        } else if !is_in_current_contexts(&["ariel-os"]) {
-            // Dummy value for platform-independent tooling.
-            (8 * KIBIBYTES, 4 * KIBIBYTES)
-        } else {
-            panic!("MCU not supported");
-        };
+    let (storage_size_total, flash_page_size) = if is_in_current_contexts(&["stm32u083mc"]) {
+        (4 * KIBIBYTES, 2 * KIBIBYTES)
+    } else if is_in_current_contexts(&["nrf52", "nrf5340", "nrf91", "rp", "stm32wb55rg"]) {
+        (8 * KIBIBYTES, 4 * KIBIBYTES)
+    } else if is_in_current_contexts(&["stm32h755zi"]) {
+        (256 * KIBIBYTES, 128 * KIBIBYTES)
+    } else if !is_in_current_contexts(&["ariel-os"]) {
+        // Dummy value for platform-independent tooling.
+        (8 * KIBIBYTES, 4 * KIBIBYTES)
+    } else {
+        panic!("MCU not supported");
+    };
 
     // `sequential-storage` needs at least two flash pages.
     assert!(storage_size_total / flash_page_size >= 2);

--- a/tests/coap-blinky/laze.yml
+++ b/tests/coap-blinky/laze.yml
@@ -15,3 +15,4 @@ apps:
       - st-nucleo-f401re
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
+      - stm32u083c-dk

--- a/tests/i2c-controller/laze.yml
+++ b/tests/i2c-controller/laze.yml
@@ -12,3 +12,4 @@ apps:
       - st-nucleo-c031c6
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
+      - stm32u083c-dk

--- a/tests/i2c-controller/src/pins.rs
+++ b/tests/i2c-controller/src/pins.rs
@@ -62,3 +62,11 @@ ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: PB9,
     i2c_scl: PB8,
 });
+
+#[cfg(context = "stm32u083mc")]
+pub type SensorI2c = i2c::controller::I2C1;
+#[cfg(context = "stm32u083mc")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    i2c_sda: PB7,
+    i2c_scl: PB8,
+});

--- a/tests/spi-loopback/laze.yml
+++ b/tests/spi-loopback/laze.yml
@@ -12,3 +12,4 @@ apps:
       - st-nucleo-f401re
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
+      - stm32u083c-dk

--- a/tests/spi-loopback/src/pins.rs
+++ b/tests/spi-loopback/src/pins.rs
@@ -82,6 +82,17 @@ ariel_os::hal::define_peripherals!(Peripherals {
 });
 
 // Side SPI of Arduino v3 connector
+#[cfg(context = "stm32u083mc")]
+pub type SensorSpi = spi::main::SPI1;
+#[cfg(context = "stm32u083mc")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    spi_sck: PA5,
+    spi_miso: PA6,
+    spi_mosi: PA7,
+    spi_cs: PA15,
+});
+
+// Side SPI of Arduino v3 connector
 #[cfg(context = "stm32wb55rg")]
 pub type SensorSpi = spi::main::SPI1;
 #[cfg(context = "stm32wb55rg")]

--- a/tests/spi-main/laze.yml
+++ b/tests/spi-main/laze.yml
@@ -11,3 +11,4 @@ apps:
       - st-nucleo-c031c6
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
+      - stm32u083c-dk

--- a/tests/spi-main/src/pins.rs
+++ b/tests/spi-main/src/pins.rs
@@ -80,6 +80,17 @@ ariel_os::hal::define_peripherals!(Peripherals {
 });
 
 // Side SPI of Arduino v3 connector
+#[cfg(context = "stm32u083mc")]
+pub type SensorSpi = spi::main::SPI1;
+#[cfg(context = "stm32u083mc")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    spi_sck: PA5,
+    spi_miso: PA6,
+    spi_mosi: PA7,
+    spi_cs: PA15,
+});
+
+// Side SPI of Arduino v3 connector
 #[cfg(context = "stm32wb55rg")]
 pub type SensorSpi = spi::main::SPI1;
 #[cfg(context = "stm32wb55rg")]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This adds support for the STM32U083MC MCU and the SMT32U083C-DK board.

There doesn't seem to be enough RAM to run networking-enabled examples for now, so networking is disabled.
However, unlike the STM32C032C6, there seems to be enough RAM for `embedded-test`.

## How to review this PR

The first commit (which completes the HWRNG support started in #911) is best viewed in isolation.

## Testing

Successfully tested in hardware:

- `examples/blinky`
- `examples/gpio`
- `examples/hello-world`
- `examples/log`
- `examples/random`
- `examples/storage`
- `examples/usb-serial`
- `tests/gpio-interrupt-stm32`
- `tests/i2c-controller`
- `tests/spi-loopback`
- `tests/spi-main`

Additionally, the following complete successfully:

```sh
laze build -gm -b stm32u083c-dk test
```

and

```sh
laze build -g -b stm32u083c-dk
```

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
