### PR TITLE
feat(xtensa): take control of `xtensa` ISR stacksize

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -644,10 +644,13 @@ modules:
       - stable
     env:
       global:
+        # xtensa needs a bit more isr stack.
+        isr_stacksize_required_default: "32768"
         CARGO_TOOLCHAIN: +esp
         RUSTFLAGS:
           - --cfg context=\"xtensa\"
           - --cfg nightly
+          - -Clink-arg=-Tisr_stack.x
         CFLAGS:
           - -mlongcalls
         CARGO_ARGS:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1219,7 +1219,7 @@ modules:
     env:
       global:
         # esp-wifi needs a lot of ISR stack.
-        isr_stacksize_required_default: "65536"
+        isr_stacksize_required: "32768"
         # esp-wifi needs 72KiB
         heapsize_required:
           - $(72*1024)

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -21,21 +21,21 @@ fn main() {
     // Put the linker scripts somewhere the linker can find them
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
-    if let Some(context) = context_any(&["cortex-m", "riscv"]) {
-        let insert_before = match *context {
-            "riscv" => ".trap",
-            "cortex-m" => ".data",
-            _ => unreachable!(),
+    if let Some(context) = context_any(&["cortex-m", "riscv", "xtensa"]) {
+        let insert_somewhere = match *context {
+            "cortex-m" => "INSERT BEFORE .data;",
+            "riscv" => "INSERT BEFORE .trap;",
+            _ => "",
         };
 
         let region = match *context {
-            "riscv" => "RWDATA",
             "cortex-m" => "RAM",
+            "riscv" | "xtensa" => "RWDATA",
             _ => unreachable!(),
         };
 
         let mut isr_stack_template = std::fs::read_to_string("isr_stack.ld.in").unwrap();
-        isr_stack_template = isr_stack_template.replace("${INSERT_BEFORE}", insert_before);
+        isr_stack_template = isr_stack_template.replace("${INSERT_SOMEWHERE}", insert_somewhere);
         isr_stack_template = isr_stack_template.replace("${STACK_REGION}", region);
         std::fs::write(out.join("isr_stack.x"), &isr_stack_template).unwrap();
         println!("cargo:rerun-if-changed=isr_stack.ld.in");

--- a/src/ariel-os-rt/isr_stack.ld.in
+++ b/src/ariel-os-rt/isr_stack.ld.in
@@ -9,12 +9,16 @@ SECTIONS
     } > ${STACK_REGION}
 }
 
-INSERT BEFORE ${INSERT_BEFORE};
+${INSERT_SOMEWHERE}
 
 /* using `_tmp` helpers so this overrides other linker script variables */
 _stack_end = _stack_bottom_tmp;
 _stack_bottom = _stack_bottom_tmp;
 _stack_start = _stack_start_tmp;
+
+/* used by xtensa. grep for `xtensa_lx::set_stack_pointer` in esp-hal repo. */
+_stack_end_cpu0 = _stack_bottom_tmp;
+_stack_start_cpu0 = _stack_start_tmp;
 
 ASSERT(_stack_start != _stack_bottom, "ERROR(ariel-os-rt): isr stack too small");
 ASSERT(_stack_start == _stack_start_tmp, "ERROR(ariel-os-rt): _stack_start not used!");

--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(test, no_main)]
 //
 #![allow(incomplete_features)]
-// - const_generics
+#![cfg_attr(context = "xtensa", feature(asm_experimental_arch))]
 
 #[cfg(feature = "threading")]
 mod threading;
@@ -35,7 +35,7 @@ cfg_if::cfg_if! {
     }
 }
 
-#[cfg(any(context = "cortex-m", context = "riscv"))]
+#[cfg(any(context = "cortex-m", context = "riscv", context = "xtensa"))]
 mod isr_stack {
     pub(crate) const ISR_STACKSIZE: usize = {
         const CONFIG_ISR_STACKSIZE: usize = ariel_os_utils::usize_from_env_or!(
@@ -95,7 +95,7 @@ fn startup() -> ! {
 
     debug!("ariel_os_rt::startup()");
 
-    #[cfg(any(context = "cortex-m", context = "riscv"))]
+    #[cfg(any(context = "cortex-m", context = "riscv", context = "xtensa"))]
     debug!("ariel_os_rt: ISR_STACKSIZE={}", isr_stack::ISR_STACKSIZE);
 
     #[cfg(feature = "alloc")]


### PR DESCRIPTION
# Description

This PR makes `xtensa` use the same ISR stack machinery as `cortex-m` and `risc-v`.

I went with a default ISR stacksize of 32k, as it had a lot more (all leftover memory, so >100k). We can tune that as soon as we can measure (#977).

This now also shows the used stacksize (with `-DLOG=debug`):

```
    Running `probe-rs run --protocol=jtag --chip esp32s3 --preverify ../../build/bin/espressif-esp32-s3-devkitc-1/cargo/xtensa-esp32s3-none-elf/release/http-c
lient`                                                                         
     Finished in 8.40s
DEBUG ariel_os_rt::startup()                                                   
DEBUG ariel_os_rt: ISR_STACKSIZE=65536
...
```

## Issues/PRs references

Depends on #1037.
Cut out of #977.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
