### PR TITLE
fix(log): add support for `log` on architectures without atomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ dependencies = [
  "ariel-os-debug-log",
  "ariel-os-utils",
  "const-str",
+ "critical-section",
  "esp-println",
  "log",
  "rtt-target",

--- a/src/ariel-os-debug/Cargo.toml
+++ b/src/ariel-os-debug/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 ariel-os-debug-log = { workspace = true }
 ariel-os-utils = { workspace = true }
 const-str = { workspace = true }
+critical-section = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 rtt-target = { workspace = true, optional = true }
 semihosting = { workspace = true, optional = true }
@@ -25,7 +26,7 @@ semihosting = { workspace = true, optional = true, features = [
 
 [target.'cfg(context = "esp")'.dependencies]
 esp-println = { workspace = true, optional = true, features = ["log"] }
-log = { version = "0.4.20" }
+log = { workspace = true }
 
 [target.'cfg(context = "esp32")'.dependencies]
 esp-println = { workspace = true, optional = true, features = ["esp32"] }
@@ -47,7 +48,7 @@ defmt = [
   "esp-println?/defmt-espflash",
   "rtt-target?/defmt",
 ]
-log = ["dep:log", "ariel-os-debug-log/log"]
+log = ["dep:critical-section", "dep:log", "ariel-os-debug-log/log"]
 
 semihosting = ["dep:semihosting"]
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This adds support for logging with `log` on architectures that do not provide atomics (e.g., Cortex-M0+ (ARMv6-M), RISC-V without the (A) extension).

## Testing

Tested successfully with:

```sh
laze -C examples/log/ build -s log -b <board> run
```

where `<board>` is:

- espressif-esp32-c3-lcdkit (RISC-V without the (A) extension)
- rpi-pico-w (Cortex-M0+)
- st-nucleo-c031c6 (Cortex-M0+)
- st-nucleo-wb55 (Cortex-M4f, just to check it still works otherwise)

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
