### PR TITLE
docs(dfrobot-firebeetle2-esp32-c6): fix pin definitions

### DIFF
--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -30,7 +30,7 @@ ariel_os::hal::define_peripherals!(LedPeripherals { led: PIN_25 });
 #[cfg(all(context = "rp", not(any(context = "rpi-pico", context = "rpi-pico2"))))]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: PIN_1 });
 
-#[cfg(context = "esp")]
+#[cfg(all(context = "esp", not(context = "dfrobot-firebeetle2-esp32-c6")))]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: GPIO0 });
 
 #[cfg(context = "st-nucleo-c031c6")]

--- a/examples/gpio/src/pins.rs
+++ b/examples/gpio/src/pins.rs
@@ -14,7 +14,7 @@ ariel_os::hal::define_peripherals!(Peripherals {
 });
 
 #[cfg(context = "dfrobot-firebeetle2-esp32-c6")]
-ariel_os::hal::define_peripherals!(LedPeripherals {
+ariel_os::hal::define_peripherals!(Peripherals {
     led1: GPIO15,
     btn1: GPIO1
 });
@@ -43,7 +43,7 @@ ariel_os::hal::define_peripherals!(Peripherals {
     btn1: PIN_2
 });
 
-#[cfg(context = "esp")]
+#[cfg(all(context = "esp", not(context = "dfrobot-firebeetle2-esp32-c6")))]
 ariel_os::hal::define_peripherals!(Peripherals {
     led1: GPIO0,
     btn1: GPIO1


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Follow-up to #983, fixes the nightly scheduled build.

## Testing

Successfully tested with:

```sh
CONFIG_WIFI_NETWORK=<ssid> CONFIG_WIFI_PASSWORD=<pwd> laze build -g -b dfrobot-firebeetle2-esp32-c6
```

(to check the new board) and

```sh
CONFIG_WIFI_NETWORK=<ssid> CONFIG_WIFI_PASSWORD=<pwd> laze build -g -b espressif-esp32-c6-devkitc-1
```

(to check that the existing board still compiles).


## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
