### PR TITLE
chore(book): remove the unused and deprecated `multilingual` field

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -6,7 +6,6 @@ authors = [
   "Elena Frank",
 ]
 language = "en"
-multilingual = false
 src = "src"
 title = "Ariel OS manual"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10