### PR TITLE
feat(network): Add ethernet from nucleo-144 board family

### DIFF
--- a/examples/blinky/laze.yml
+++ b/examples/blinky/laze.yml
@@ -15,4 +15,5 @@ apps:
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
       - st-nucleo-wba55
+      - st-nucleo-f767zi
       - stm32u083c-dk

--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -42,6 +42,9 @@ ariel_os::hal::define_peripherals!(LedPeripherals { led: PA5 });
 #[cfg(context = "st-nucleo-h755zi-q")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: PB0 });
 
+#[cfg(context = "st-nucleo-f767zi")]
+ariel_os::hal::define_peripherals!(LedPeripherals { led: PB0 });
+
 #[cfg(context = "st-nucleo-wb55")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: PB5 });
 

--- a/examples/tcp-echo/laze.yml
+++ b/examples/tcp-echo/laze.yml
@@ -3,6 +3,6 @@ apps:
     env:
       global:
         executor_stacksize_required:
-          - "16384"
+          - "32768"
     selects:
       - network

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -423,6 +423,17 @@ contexts:
       RUSTFLAGS:
         - --cfg capability=\"async-flash-driver\"
 
+  - name: stm32f767zi
+    parent: stm32
+    selects:
+      - cortex-m7f
+    provides:
+      - has_hwrng
+    env:
+      PROBE_RS_CHIP: STM32F767ZITx
+      RUSTFLAGS:
+        - --cfg capability=\"hw/stm32-rng\"
+
   - name: stm32h755zi
     parent: stm32
     selects:
@@ -943,6 +954,20 @@ modules:
           - ariel-os/wifi-cyw43
 
   - name: has_wifi_cyw43
+    selects:
+      - doc-only
+
+  - name: eth-stm32
+    selects:
+      - has_eth_stm32
+    provides_unique:
+      - network_device
+    env:
+      global:
+        FEATURES:
+          - ariel-os/eth-stm32
+
+  - name: has_eth_stm32
     selects:
       - doc-only
 
@@ -1475,6 +1500,16 @@ builders:
     parent: stm32f401re
     provides:
       - has_swi
+    env:
+      CARGO_ENV:
+        # This ISR is unused on a naked board. Configured here for testing.
+        - CONFIG_SWI=USART2
+
+  - name: st-nucleo-f767zi
+    parent: stm32f767zi
+    provides:
+      - has_swi
+      - has_eth_stm32
     env:
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -102,6 +102,9 @@ wifi = []
 wifi-cyw43 = ["ariel-os-hal/wifi-cyw43", "net", "wifi"]
 wifi-esp = ["ariel-os-hal/wifi-esp", "net", "wifi"]
 
+eth = []
+eth-stm32 = ["ariel-os-hal/eth-stm32", "net", "eth"]
+
 threading = ["dep:ariel-os-threads", "ariel-os-hal/threading"]
 network-config-static = ["network-config-override"]
 network-config-override = []

--- a/src/ariel-os-embassy/src/eth.rs
+++ b/src/ariel-os-embassy/src/eth.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "eth-stm32")]
+pub(crate) use crate::hal::eth::NetworkDevice;

--- a/src/ariel-os-hal/Cargo.toml
+++ b/src/ariel-os-hal/Cargo.toml
@@ -86,6 +86,8 @@ threading = [
 wifi-cyw43 = ["ariel-os-rp/wifi-cyw43"]
 wifi-esp = ["ariel-os-esp/wifi-esp"]
 
+eth-stm32 = ["ariel-os-stm32/eth-stm32"]
+
 executor-single-thread = ["ariel-os-esp/executor-single-thread"]
 
 executor-interrupt = [

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -57,6 +57,9 @@ storage = ["dep:embassy-embedded-hal"]
 ## Enables USB support.
 usb = []
 
+eth = []
+eth-stm32 = ["dep:embassy-embedded-hal", "eth"]
+
 ## Enables defmt support.
 defmt = ["dep:defmt", "embassy-stm32/defmt"]
 

--- a/src/ariel-os-stm32/src/eth.rs
+++ b/src/ariel-os-stm32/src/eth.rs
@@ -1,0 +1,34 @@
+use embassy_stm32::eth::Ethernet;
+use embassy_stm32::eth::generic_smi::GenericSMI;
+use embassy_stm32::peripherals::ETH;
+use embassy_stm32::{bind_interrupts, eth};
+use static_cell::StaticCell;
+
+bind_interrupts!(struct Irqs {
+    ETH => eth::InterruptHandler;
+});
+
+pub type NetworkDevice = Ethernet<'static, ETH, GenericSMI>;
+
+pub fn device(peripherals: &mut crate::OptionalPeripherals) -> NetworkDevice {
+    static PKTS: StaticCell<eth::PacketQueue<4, 4>> = StaticCell::new();
+
+    let mac_addr = [0xCA, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC];
+
+    Ethernet::new(
+        PKTS.init(eth::PacketQueue::<4, 4>::new()),
+        peripherals.ETH.take().unwrap(),
+        Irqs,
+        peripherals.PA1.take().unwrap(),
+        peripherals.PA2.take().unwrap(),
+        peripherals.PC1.take().unwrap(),
+        peripherals.PA7.take().unwrap(),
+        peripherals.PC4.take().unwrap(),
+        peripherals.PC5.take().unwrap(),
+        peripherals.PG13.take().unwrap(),
+        peripherals.PB13.take().unwrap(),
+        peripherals.PG11.take().unwrap(),
+        eth::generic_smi::GenericSMI::new(0),
+        mac_addr,
+    )
+}

--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -32,6 +32,10 @@ pub mod storage;
 #[doc(hidden)]
 pub mod usb;
 
+#[cfg(feature = "eth")]
+#[doc(hidden)]
+pub mod eth;
+
 use embassy_stm32::Config;
 
 #[doc(hidden)]
@@ -99,6 +103,27 @@ fn board_config(config: &mut Config) {
             divr: Some(PllRDiv::DIV2), // sysclk 80Mhz (32 / 2 * 10 / 2)
         });
         config.rcc.mux.clk48sel = mux::Clk48sel::HSI48;
+    }
+
+    #[cfg(context = "st-nucleo-f767zi")]
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.hse = Some(Hse {
+            freq: embassy_stm32::time::Hertz(8000000),
+            mode: HseMode::Bypass,
+        });
+        config.rcc.pll_src = PllSource::HSE;
+        config.rcc.pll = Some(Pll {
+            prediv: PllPreDiv::DIV4,
+            mul: PllMul::MUL216,
+            divp: Some(PllPDiv::DIV2),
+            divq: None,
+            divr: None,
+        });
+        config.rcc.ahb_pre = AHBPrescaler::DIV1;
+        config.rcc.apb1_pre = APBPrescaler::DIV4;
+        config.rcc.apb2_pre = APBPrescaler::DIV2;
+        config.rcc.sys = Sysclk::PLL1_P;
     }
 
     #[cfg(context = "stm32h755zi")]

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -121,6 +121,8 @@ usb-ethernet = ["ariel-os-embassy/usb-ethernet"]
 wifi-cyw43 = ["ariel-os-embassy/wifi-cyw43"]
 # Selects Wi-Fi (on ESP chips).
 wifi-esp = ["ariel-os-embassy/wifi-esp"]
+# Selects STM32 Ethernet
+eth-stm32 = ["ariel-os-embassy/eth-stm32"]
 
 #! ## Development and debugging
 # Enables the debug console, required to use


### PR DESCRIPTION
# Description

This PR add the ability of providing network from the embedded PHY of the Nucleo-144 board family

## Open Questions

Each nucleo board have a different way to connect the PHY depending on the STM32 family used.
How do we properly abstract the pin definition of the ethernet PHY ?

## Change checklist
- [x] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
