### PR TITLE
chore(stm32): enable `has_eth_stm32` for the `st-nucleo-h755zi-q`

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1518,6 +1518,7 @@ builders:
   - name: st-nucleo-h755zi-q
     parent: stm32h755zi
     provides:
+      - has_eth_stm32
       - has_swi
       - has_usb_device_port
     env:


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
... tested with `http-client` ...

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
