### PR TITLE
docs(support-matrix): conditionally center the support matrix

### DIFF
--- a/doc/gen_support_matrix_html.rs
+++ b/doc/gen_support_matrix_html.rs
@@ -51,6 +51,13 @@ r##"<!-- This table is auto-generated. Do not edit manually. -->
   </tbody>
 </table>
 <style>
+@media (min-width: 1920px) {
+  .support-matrix {
+    position: relative;
+    left: 50%;
+    transform: translate(-50%, 0);
+  }
+}
 .support-cell {
   text-align: center;
 }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This conditionally horizontally centers the support matrix, when the viewport is wide enough.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Follows #765, which undid centering the support matrix as it was unreadable on narrow viewports (e.g., on mobile). Making this conditional on the viewport width should avoid this issue this time. 

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
