### PR TITLE
docs: fix paths to the networking setup instructions

### DIFF
--- a/examples/coap-client/README.md
+++ b/examples/coap-client/README.md
@@ -10,7 +10,7 @@ On the CoAP client side, security is work in progress and not available for the 
 
 ## Running
 
-* [Set up networking](../README.md).
+* [Set up networking](../README.md#networking).
 * In one terminal, run `pipx run ./server.py`, which runs the server for the embedded device to interact with.
 * Run on any board with networking, eg. `laze build -b particle-xenon run`.
 

--- a/examples/coap-server/README.md
+++ b/examples/coap-server/README.md
@@ -14,7 +14,7 @@ making the former configurable and the latter dynamic is work in progress.
 ## Running
 
 * Run on any board with networking, eg. `laze build -b particle-xenon run`.
-* [Set up networking](../README.md).
+* [Set up networking](../README.md#networking).
 * Run `aiocoap-client`
   to list the resources of the device:
 

--- a/tests/coap-blinky/README.md
+++ b/tests/coap-blinky/README.md
@@ -7,7 +7,7 @@ This application makes the GPIO pin from the blinky example accessible over the 
 ## Running
 
 * Run on any board with networking, eg. `laze build -b particle-xenon run`.
-* [Set up networking](../README.md).
+* [Set up networking](../../examples/README.md#networking).
 * Run `pipx run --spec 'aiocoap[prettyprint]' aiocoap-client coap://10.42.0.61/led -m PUT --content-format application/cbor --payload true`
   or `false`.
 

--- a/tests/coap/README.md
+++ b/tests/coap/README.md
@@ -7,7 +7,7 @@ This application is a work in progress demo of running CoAP with OSCORE/EDHOC se
 ## Running
 
 * Run on any board with networking, eg. `laze build -b particle-xenon run`.
-* [Set up networking](../README.md).
+* [Set up networking](../../examples/README.md#networking).
 * Run `chmod go-rwX client.cosekey`.
   This file contains the key we authenticate with, and aiocoap gets jumpy around world readable key material.
 * Run `pipx run coap-console coap://10.42.0.61 --credentials client.diag`,


### PR DESCRIPTION
# Description
Fix linking to the [networking](https://github.com/ariel-os/ariel-os/tree/main/examples#networking) section in tests and examples READMEs.

