### PR TITLE
 test(i2c-controller): support the sensor on the STM32U083C-DK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3161,6 +3161,7 @@ version = "0.0.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
+ "cfg-if",
  "embassy-sync 0.6.2",
  "embedded-hal 1.0.0",
  "embedded-hal-async",

--- a/tests/i2c-controller/Cargo.toml
+++ b/tests/i2c-controller/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+cfg-if = { workspace = true }
 embassy-sync = { workspace = true }
 embedded-hal = { workspace = true }
 embedded-hal-async = { workspace = true }

--- a/tests/i2c-controller/src/main.rs
+++ b/tests/i2c-controller/src/main.rs
@@ -3,7 +3,8 @@
 //! Please use [`ariel_os::sensors`] instead for a high-level sensor abstraction that is
 //! HAL-agnostic.
 //!
-//! This example requires a LIS3DH/LSM303AGR sensor (3-axis accelerometer).
+//! This example requires an onboard sensor or an external LIS3DH/LSM303AGR sensor (3-axis
+//! accelerometer).
 #![no_main]
 #![no_std]
 
@@ -24,6 +25,9 @@ cfg_if::cfg_if! {
     if #[cfg(context = "nordic-thingy-91-x-nrf9151")] {
         // Alternate address
         const TARGET_I2C_ADDR: u8 = 0x1d;
+    } else if #[cfg(context = "stm32u083c-dk")] {
+        // STTS22H
+        const TARGET_I2C_ADDR: u8 = 0x3f;
     } else {
         const TARGET_I2C_ADDR: u8 = 0x19;
     }
@@ -33,6 +37,8 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     if #[cfg(context = "nordic-thingy-91-x-nrf9151")] {
         const WHO_AM_I_REG_ADDR: u8 = 0x02;
+    } else if #[cfg(context = "stm32u083c-dk")] {
+        const WHO_AM_I_REG_ADDR: u8 = 0x01;
     } else {
         const WHO_AM_I_REG_ADDR: u8 = 0x0f;
     }
@@ -41,6 +47,8 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     if #[cfg(context = "nordic-thingy-91-x-nrf9151")] {
         const DEVICE_ID: u8 = 0xf7;
+    } else if #[cfg(context = "stm32u083c-dk")] {
+        const DEVICE_ID: u8 = 0xa0;
     } else {
         const DEVICE_ID: u8 = 0x33;
     }

--- a/tests/i2c-controller/src/main.rs
+++ b/tests/i2c-controller/src/main.rs
@@ -20,22 +20,31 @@ use ariel_os::{
 use embassy_sync::mutex::Mutex;
 use embedded_hal_async::i2c::I2c as _;
 
-#[cfg(not(context = "nordic-thingy-91-x-nrf9151"))]
-const TARGET_I2C_ADDR: u8 = 0x19;
-#[cfg(context = "nordic-thingy-91-x-nrf9151")]
-// Alternate address
-const TARGET_I2C_ADDR: u8 = 0x1d;
+cfg_if::cfg_if! {
+    if #[cfg(context = "nordic-thingy-91-x-nrf9151")] {
+        // Alternate address
+        const TARGET_I2C_ADDR: u8 = 0x1d;
+    } else {
+        const TARGET_I2C_ADDR: u8 = 0x19;
+    }
+}
 
 // WHO_AM_I register of the sensor
-#[cfg(not(context = "nordic-thingy-91-x-nrf9151"))]
-const WHO_AM_I_REG_ADDR: u8 = 0x0f;
-#[cfg(context = "nordic-thingy-91-x-nrf9151")]
-const WHO_AM_I_REG_ADDR: u8 = 0x02;
+cfg_if::cfg_if! {
+    if #[cfg(context = "nordic-thingy-91-x-nrf9151")] {
+        const WHO_AM_I_REG_ADDR: u8 = 0x02;
+    } else {
+        const WHO_AM_I_REG_ADDR: u8 = 0x0f;
+    }
+}
 
-#[cfg(not(context = "nordic-thingy-91-x-nrf9151"))]
-const DEVICE_ID: u8 = 0x33;
-#[cfg(context = "nordic-thingy-91-x-nrf9151")]
-const DEVICE_ID: u8 = 0xf7;
+cfg_if::cfg_if! {
+    if #[cfg(context = "nordic-thingy-91-x-nrf9151")] {
+        const DEVICE_ID: u8 = 0xf7;
+    } else {
+        const DEVICE_ID: u8 = 0x33;
+    }
+}
 
 pub static I2C_BUS: once_cell::sync::OnceCell<
     Mutex<embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex, hal::i2c::controller::I2c>,


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This expands the `i2c-controller` test to use the onboard STTS22H temperature sensor on the STM32U083C-DK, which was not added as part of #986.

## How to review this PR

This PR is best reviewed commit by commit: the first one only refactors the test to use `cfg-if`, before expanding it in the second commit.

## Testing

Successfully tested in hardware on STM32U083C-DK, and on ST-NUCLEO-C031C6 with an external LIS3DH (just to check the refactoring).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
