### PR TITLE
feat(boards): add support for the ST NUCLEO-F411RE

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -217,6 +217,21 @@ chips:
           - unsupported heterogeneous flash organization
       wifi: not_available
 
+  stm32f411re:
+    name: STM32F411RE
+    support:
+      gpio: supported
+      debug_output: supported
+      hwrng: not_available
+      i2c_controller: needs_testing
+      spi_main: needs_testing
+      logging: supported
+      storage:
+        status: not_currently_supported
+        comments:
+          - unsupported heterogeneous flash organization
+      wifi: not_available
+
   stm32h755zi:
     name: STM32H755ZI
     support:
@@ -374,6 +389,15 @@ boards:
     name: ST NUCLEO-F401RE
     url: https://web.archive.org/web/20250115005425/https://www.st.com/en/evaluation-tools/nucleo-f401re.html
     chip: stm32f401re
+    support:
+      user_usb: not_available
+      wifi: not_available
+      ethernet_over_usb: not_available
+
+  st-nucleo-f411re:
+    name: ST NUCLEO-F411RE
+    url: https://web.archive.org/web/20250311221905/https://www.st.com/en/evaluation-tools/nucleo-f411re.html
+    chip: stm32f411re
     support:
       user_usb: not_available
       wifi: not_available

--- a/examples/blinky/laze.yml
+++ b/examples/blinky/laze.yml
@@ -12,6 +12,7 @@ apps:
       - rp
       - st-nucleo-c031c6
       - st-nucleo-f401re
+      - st-nucleo-f411re
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
       - st-nucleo-wba55

--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -36,7 +36,7 @@ ariel_os::hal::define_peripherals!(LedPeripherals { led: GPIO0 });
 #[cfg(context = "st-nucleo-c031c6")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: PA5 });
 
-#[cfg(context = "st-nucleo-f401re")]
+#[cfg(any(context = "st-nucleo-f401re", context = "st-nucleo-f411re"))]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: PA5 });
 
 #[cfg(context = "st-nucleo-h755zi-q")]

--- a/examples/gpio/laze.yml
+++ b/examples/gpio/laze.yml
@@ -11,6 +11,7 @@ apps:
       - rp
       - st-nucleo-c031c6
       - st-nucleo-f401re
+      - st-nucleo-f411re
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
       - stm32u083c-dk

--- a/examples/gpio/src/pins.rs
+++ b/examples/gpio/src/pins.rs
@@ -55,7 +55,7 @@ ariel_os::hal::define_peripherals!(Peripherals {
     btn1: PC13
 });
 
-#[cfg(context = "st-nucleo-f401re")]
+#[cfg(any(context = "st-nucleo-f401re", context = "st-nucleo-f411re"))]
 ariel_os::hal::define_peripherals!(Peripherals {
     led1: PA5,
     btn1: PC13

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -423,6 +423,13 @@ contexts:
       RUSTFLAGS:
         - --cfg capability=\"async-flash-driver\"
 
+  - name: stm32f411re
+    parent: stm32
+    selects:
+      - cortex-m4f
+    env:
+      PROBE_RS_CHIP: STM32F411RE
+
   - name: stm32f767zi
     parent: stm32
     selects:
@@ -1498,6 +1505,15 @@ builders:
 
   - name: st-nucleo-f401re
     parent: stm32f401re
+    provides:
+      - has_swi
+    env:
+      CARGO_ENV:
+        # This ISR is unused on a naked board. Configured here for testing.
+        - CONFIG_SWI=USART2
+
+  - name: st-nucleo-f411re
+    parent: stm32f411re
     provides:
       - has_swi
     env:

--- a/src/ariel-os-stm32/src/i2c/controller/mod.rs
+++ b/src/ariel-os-stm32/src/i2c/controller/mod.rs
@@ -216,7 +216,7 @@ fn from_error(err: embassy_stm32::i2c::Error) -> ariel_os_embassy_common::i2c::c
 define_i2c_drivers!(
    I2C1 => I2C1,
 );
-#[cfg(context = "stm32f401re")]
+#[cfg(any(context = "stm32f401re", context = "stm32f411re"))]
 define_i2c_drivers!(
    I2C1_EV + I2C1_ER => I2C1,
    I2C2_EV + I2C2_ER => I2C2,

--- a/src/ariel-os-stm32/src/i2c/mod.rs
+++ b/src/ariel-os-stm32/src/i2c/mod.rs
@@ -18,7 +18,7 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
     cfg_if::cfg_if! {
         if #[cfg(context = "stm32c031c6")] {
             take_all_i2c_peripherals!(I2C1);
-        } else if #[cfg(context = "stm32f401re")] {
+        } else if #[cfg(any(context = "stm32f401re", context = "stm32f411re"))] {
             take_all_i2c_peripherals!(I2C1, I2C2, I2C3);
         } else if #[cfg(context = "stm32h755zi")] {
             take_all_i2c_peripherals!(I2C1, I2C2, I2C3, I2C4);

--- a/src/ariel-os-stm32/src/spi/main/mod.rs
+++ b/src/ariel-os-stm32/src/spi/main/mod.rs
@@ -20,6 +20,8 @@ use embassy_stm32::{
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(24);
 #[cfg(context = "stm32f401re")]
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(21);
+#[cfg(context = "stm32f411re")]
+const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(25);
 #[cfg(context = "stm32h755zi")]
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(150);
 #[cfg(context = "stm32u083mc")]
@@ -146,6 +148,14 @@ define_spi_drivers!(
    SPI1 => SPI1,
    SPI2 => SPI2,
    SPI3 => SPI3,
+);
+#[cfg(context = "stm32f411re")]
+define_spi_drivers!(
+   SPI1 => SPI1,
+   SPI2 => SPI2,
+   SPI3 => SPI3,
+   SPI4 => SPI4,
+   SPI5 => SPI5,
 );
 #[cfg(context = "stm32h755zi")]
 define_spi_drivers!(

--- a/src/ariel-os-stm32/src/spi/mod.rs
+++ b/src/ariel-os-stm32/src/spi/mod.rs
@@ -38,6 +38,8 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
             take_all_spi_peripherals!(Peripherals, SPI1);
         } else if #[cfg(context = "stm32f401re")] {
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3);
+        } else if #[cfg(context = "stm32f411re")] {
+            take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3, SPI4, SPI5);
         } else if #[cfg(context = "stm32h755zi")] {
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3, SPI4, SPI5, SPI6);
         } else if #[cfg(context = "stm32u083mc")] {

--- a/tests/spi-loopback/laze.yml
+++ b/tests/spi-loopback/laze.yml
@@ -10,6 +10,7 @@ apps:
       - rp235xa
       - st-nucleo-c031c6
       - st-nucleo-f401re
+      - st-nucleo-f411re
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
       - stm32u083c-dk

--- a/tests/spi-loopback/src/pins.rs
+++ b/tests/spi-loopback/src/pins.rs
@@ -104,9 +104,9 @@ ariel_os::hal::define_peripherals!(Peripherals {
 });
 
 // Side SPI of Arduino v3 connector
-#[cfg(context = "stm32f401re")]
+#[cfg(any(context = "stm32f401re", context = "stm32f411re"))]
 pub type SensorSpi = spi::main::SPI1;
-#[cfg(context = "stm32f401re")]
+#[cfg(any(context = "stm32f401re", context = "stm32f411re"))]
 ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: PA5,
     spi_miso: PA6,


### PR DESCRIPTION
# Description
This adds support for the STM32F411RE  MCU and the NUCLEO-F411RE board. 

<!-- Please write a summary of your changes and why you made them.-->

## Testing
Successfully tested in hardware:
+ `examples/blinky`
+ `examples/log`
+ `examples/gpio`
+ `examples/hello-world`
+ `tests/spi-loopback`
+ `tests/gpio-interrupt-stm32`

Some things are untestet (e.g. `tests/i2c_controller`) as I don't have the sensor.

Running the following also succeeds:
```bash
laze build -gm -b stm32u083c-dk test
laze build -g -b stm32u083c-dk
```

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
