### PR TITLE
docs: use `Timer::after_millis()` to avoid the need for `Duration`

### DIFF
--- a/examples/blinky/src/main.rs
+++ b/examples/blinky/src/main.rs
@@ -5,7 +5,7 @@ mod pins;
 
 use ariel_os::{
     gpio::{Level, Output},
-    time::{Duration, Timer},
+    time::Timer,
 };
 
 #[ariel_os::task(autostart, peripherals)]
@@ -18,6 +18,6 @@ async fn blinky(peripherals: pins::LedPeripherals) {
 
     loop {
         led.toggle();
-        Timer::after(Duration::from_millis(500)).await;
+        Timer::after_millis(500).await;
     }
 }

--- a/examples/gpio/src/main.rs
+++ b/examples/gpio/src/main.rs
@@ -5,7 +5,7 @@ mod pins;
 
 use ariel_os::{
     gpio::{Input, Level, Output, Pull},
-    time::{Duration, Timer},
+    time::Timer,
 };
 
 #[ariel_os::task(autostart, peripherals)]
@@ -27,13 +27,10 @@ async fn blinky(peripherals: pins::Peripherals) {
 
     loop {
         // Wait for the button being pressed or 300 ms, whichever comes first.
-        let _ = embassy_futures::select::select(
-            btn1.wait_for_low(),
-            Timer::after(Duration::from_millis(300)),
-        )
-        .await;
+        let _ =
+            embassy_futures::select::select(btn1.wait_for_low(), Timer::after_millis(300)).await;
 
         led1.toggle();
-        Timer::after(Duration::from_millis(100)).await;
+        Timer::after_millis(100).await;
     }
 }

--- a/examples/power/src/main.rs
+++ b/examples/power/src/main.rs
@@ -1,16 +1,12 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::{
-    debug::log::info,
-    power,
-    time::{Duration, Timer},
-};
+use ariel_os::{debug::log::info, power, time::Timer};
 
 #[ariel_os::task(autostart)]
 async fn main() {
     info!("Rebooting in 3 s");
 
-    Timer::after(Duration::from_secs(3)).await;
+    Timer::after_secs(3).await;
     power::reboot();
 }

--- a/examples/thread-async-interop/src/main.rs
+++ b/examples/thread-async-interop/src/main.rs
@@ -6,7 +6,7 @@ use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal}
 use ariel_os::{
     asynch::{blocker, spawner},
     debug::{ExitCode, exit, log::*},
-    time::{Duration, Instant, Timer},
+    time::{Instant, Timer},
 };
 
 static SIGNAL: Signal<CriticalSectionRawMutex, u32> = Signal::new();
@@ -21,7 +21,7 @@ async fn async_task() {
     loop {
         info!("async_task(): signaling, counter={}", counter);
         SIGNAL.signal(counter);
-        Timer::after(Duration::from_millis(100)).await;
+        Timer::after_millis(100).await;
         counter += 1;
     }
 }

--- a/examples/usb-keyboard/src/main.rs
+++ b/examples/usb-keyboard/src/main.rs
@@ -7,7 +7,7 @@ use ariel_os::{
     cell::ConstStaticCell,
     debug::log::*,
     reexports::{embassy_usb, usbd_hid},
-    time::{Duration, Timer},
+    time::Timer,
     usb::UsbDriver,
 };
 use embassy_usb::class::hid::{self, HidReaderWriter};
@@ -86,7 +86,7 @@ async fn usb_keyboard(button_peripherals: pins::Buttons) {
         }
 
         // Debounce events
-        Timer::after(Duration::from_millis(50)).await;
+        Timer::after_millis(50).await;
     }
 }
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This replaces usage of `Timer::after(Duration::from_*())` with `Timer::after_*()` to avoid the need for importing `Duration`, and make these statements a bit shorter.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
