### PR TITLE
chore(tests): remove the unneeded `repository` key in test crates

### DIFF
--- a/tests/i2c-controller/Cargo.toml
+++ b/tests/i2c-controller/Cargo.toml
@@ -2,7 +2,6 @@
 name = "i2c-controller"
 license.workspace = true
 edition.workspace = true
-repository.workspace = true
 
 [lints]
 workspace = true

--- a/tests/spi-loopback/Cargo.toml
+++ b/tests/spi-loopback/Cargo.toml
@@ -2,7 +2,6 @@
 name = "spi-loopback"
 license.workspace = true
 edition.workspace = true
-repository.workspace = true
 
 [lints]
 workspace = true

--- a/tests/spi-main/Cargo.toml
+++ b/tests/spi-main/Cargo.toml
@@ -2,7 +2,6 @@
 name = "spi-main"
 license.workspace = true
 edition.workspace = true
-repository.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Removes the leftover [`repository` key](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) in test crates.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
