### PR TITLE
test(i2c-controller, spi-main): Add support for ST NUCLEO-F411RE

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -223,8 +223,8 @@ chips:
       gpio: supported
       debug_output: supported
       hwrng: not_available
-      i2c_controller: needs_testing
-      spi_main: needs_testing
+      i2c_controller: supported
+      spi_main: supported
       logging: supported
       storage:
         status: not_currently_supported

--- a/tests/i2c-controller/laze.yml
+++ b/tests/i2c-controller/laze.yml
@@ -10,6 +10,7 @@ apps:
       - rp2040
       - rp235xa
       - st-nucleo-c031c6
+      - st-nucleo-f411re
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
       - stm32u083c-dk

--- a/tests/i2c-controller/src/pins.rs
+++ b/tests/i2c-controller/src/pins.rs
@@ -70,3 +70,11 @@ ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: PB7,
     i2c_scl: PB8,
 });
+
+#[cfg(any(context = "stm32f401re", context = "stm32f411re"))]
+pub type SensorI2c = i2c::controller::I2C1;
+#[cfg(any(context = "st-nucleo-f401re", context = "st-nucleo-f411re"))]
+ariel_os::hal::define_peripherals!(Peripherals {
+    i2c_sda: PB9,
+    i2c_scl: PB8,
+});

--- a/tests/spi-main/laze.yml
+++ b/tests/spi-main/laze.yml
@@ -9,6 +9,7 @@ apps:
       - rp2040
       - rp235xa
       - st-nucleo-c031c6
+      - st-nucleo-f411re
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
       - stm32u083c-dk

--- a/tests/spi-main/src/pins.rs
+++ b/tests/spi-main/src/pins.rs
@@ -100,3 +100,13 @@ ariel_os::hal::define_peripherals!(Peripherals {
     spi_mosi: PA7,
     spi_cs: PA4,
 });
+
+#[cfg(any(context = "stm32f401re", context = "stm32f411re"))]
+pub type SensorSpi = spi::main::SPI1;
+#[cfg(any(context = "st-nucleo-f401re", context = "st-nucleo-f411re"))]
+ariel_os::hal::define_peripherals!(Peripherals {
+    spi_sck: PA5,
+    spi_miso: PA6,
+    spi_mosi: PA7,
+    spi_cs: PB6,
+});


### PR DESCRIPTION
# Description
Got my hands on a `LIS3DH` sensor and was able to successfully execute `tests/spi-main` and `tests/i2c-controller`. 

**I2C output**
```bash
laze build -b st-nucleo-f411re -DLOG=debug run                                                                                                                    1 ↵
laze: project root: /Users/h0ps/Programming/ariel-os relpath: tests/i2c-controller project_file: laze-project.yml
laze: building all for st-nucleo-f411re
laze: reading cache took 1.220084ms.
laze: executing task run for builder st-nucleo-f411re bin i2c-controller
warning: Patch `esp-storage v0.4.0 (https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995)` was not used in the crate graph.
Check that the patched package version and available features are compatible
with the dependency requirements. If the patch has a different version from
what is locked in the Cargo.lock file, run `cargo update` to use the new
version. This may also occur with an optional dependency that is not enabled.
    Finished `release` profile [optimized + debuginfo] target(s) in 0.47s
     Running `probe-rs run --protocol=swd --chip STM32F411RE --preverify ../../build/bin/st-nucleo-f411re/cargo/thumbv7em-none-eabi/release/i2c-controller`
     Finished in 0.37s
DEBUG ariel_os_rt::startup()
DEBUG ariel_os_rt: ISR_STACKSIZE=10240
DEBUG ariel-os-embassy::init(): using interrupt mode executor
DEBUG flash: latency=0
DEBUG rcc: Clocks { hclk1: MaybeHertz(16000000), pclk1: MaybeHertz(16000000), pclk1_tim: MaybeHertz(16000000), pclk2: MaybeHertz(16000000), pclk2_tim: MaybeHertz(16000000), pll1_q: MaybeHertz(0), plli2s1_p: MaybeHertz(0), plli2s1_q: MaybeHertz(0), plli2s1_r: MaybeHertz(0), pllsai1_q: MaybeHertz(0), rtc: MaybeHertz(32000), sys: MaybeHertz(16000000) }
DEBUG ariel-os-embassy::init_task()
DEBUG ariel-os-embassy::init_task() done
DEBUG Selected frequency: UpTo400k(400 kHz)
INFO  WHO_AM_I_COMMAND register value: 0x33
INFO  Test passed!
```

**SPI output**
```bash
laze build -b st-nucleo-f411re -DLOG=debug run
laze: project root: /Users/h0ps/Programming/ariel-os relpath: tests/spi-main project_file: laze-project.yml
laze: building all for st-nucleo-f411re
laze: reading cache took 950.042µs.
laze: executing task run for builder st-nucleo-f411re bin spi-main
warning: Patch `esp-storage v0.4.0 (https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995)` was not used in the crate graph.
Check that the patched package version and available features are compatible
with the dependency requirements. If the patch has a different version from
what is locked in the Cargo.lock file, run `cargo update` to use the new
version. This may also occur with an optional dependency that is not enabled.
    Finished `release` profile [optimized + debuginfo] target(s) in 0.47s
     Running `probe-rs run --protocol=swd --chip STM32F411RE --preverify ../../build/bin/st-nucleo-f411re/cargo/thumbv7em-none-eabi/release/spi-main`
     Finished in 0.37s
DEBUG ariel_os_rt::startup()
DEBUG ariel_os_rt: ISR_STACKSIZE=10240
DEBUG ariel-os-embassy::init(): using interrupt mode executor
DEBUG flash: latency=0
DEBUG rcc: Clocks { hclk1: MaybeHertz(16000000), pclk1: MaybeHertz(16000000), pclk1_tim: MaybeHertz(16000000), pclk2: MaybeHertz(16000000), pclk2_tim: MaybeHertz(16000000), pll1_q: MaybeHertz(0), plli2s1_p: MaybeHertz(0), plli2s1_q: MaybeHertz(0), plli2s1_r: MaybeHertz(0), pllsai1_q: MaybeHertz(0), rtc: MaybeHertz(32000), sys: MaybeHertz(16000000) }
DEBUG ariel-os-embassy::init_task()
DEBUG ariel-os-embassy::init_task() done
DEBUG Selected frequency: F(2000 kHz)
INFO  WHO_AM_I_COMMAND register value: 0x33
INFO  Test passed!
```

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
