### PR TITLE
chore(release): bump all `ariel-os*` crates to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "ariel-os"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os-bench",
  "ariel-os-boards",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-alloc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -174,7 +174,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-bench"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -184,18 +184,18 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-boards"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "ariel-os-buildinfo"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os-utils",
 ]
 
 [[package]]
 name = "ariel-os-coap"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os-debug",
  "ariel-os-embassy",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-debug"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os-debug-log",
  "ariel-os-utils",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-debug-log"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "defmt 1.0.1",
  "featurecomb",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-embassy"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os-buildinfo",
  "ariel-os-debug",
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-embassy-common"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os-buildinfo",
  "ariel-os-utils",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-esp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os-debug",
  "ariel-os-embassy-common",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-hal"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os-embassy-common",
  "ariel-os-esp",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-identity"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os",
  "ariel-os-boards",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os",
  "enum-iterator",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-nrf"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os-debug",
  "ariel-os-embassy-common",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-power"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cfg-if",
  "cortex-m",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-random"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "embassy-sync 0.6.2",
  "rand_chacha",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-rp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os-debug",
  "ariel-os-embassy-common",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-rt"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os-alloc",
  "ariel-os-debug",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-runqueue"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "defmt 1.0.1",
  "hax-lib",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-stm32"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os-embassy-common",
  "ariel-os-random",
@@ -478,14 +478,14 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-stm32-mapping"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "embassy-stm32",
 ]
 
 [[package]]
 name = "ariel-os-storage"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os-debug",
  "ariel-os-hal",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-threads"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariel-os-debug",
  "ariel-os-runqueue",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "ariel-os-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "const-str",
  "const_panic",

--- a/src/ariel-os-alloc/Cargo.toml
+++ b/src/ariel-os-alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-alloc"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-bench/Cargo.toml
+++ b/src/ariel-os-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-bench"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-boards/Cargo.toml
+++ b/src/ariel-os-boards/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-boards"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-buildinfo/Cargo.toml
+++ b/src/ariel-os-buildinfo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-buildinfo"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-coap/Cargo.toml
+++ b/src/ariel-os-coap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-coap"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-debug-log/Cargo.toml
+++ b/src/ariel-os-debug-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-debug-log"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-debug/Cargo.toml
+++ b/src/ariel-os-debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-debug"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-embassy-common/Cargo.toml
+++ b/src/ariel-os-embassy-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-embassy-common"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-embassy"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-esp"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-hal/Cargo.toml
+++ b/src/ariel-os-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-hal"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-identity/Cargo.toml
+++ b/src/ariel-os-identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-identity"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-macros/Cargo.toml
+++ b/src/ariel-os-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-macros"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-nrf"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-power/Cargo.toml
+++ b/src/ariel-os-power/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-power"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-random/Cargo.toml
+++ b/src/ariel-os-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-random"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-rp"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-rt"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os-runqueue/Cargo.toml
+++ b/src/ariel-os-runqueue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-runqueue"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 description = "Ariel OS runqueue implementation"

--- a/src/ariel-os-stm32-mapping/Cargo.toml
+++ b/src/ariel-os-stm32-mapping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-stm32-mapping"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-stm32"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/src/ariel-os-storage/Cargo.toml
+++ b/src/ariel-os-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-storage"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 description = "Ariel OS storage API"

--- a/src/ariel-os-threads/Cargo.toml
+++ b/src/ariel-os-threads/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-threads"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 description = "generic embedded scheduler & IPC"

--- a/src/ariel-os-utils/Cargo.toml
+++ b/src/ariel-os-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os-utils"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ariel-os"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This prepares for the v0.2.0 release by bumping the version numbers of all `ariel-os*` crates. It leaves the crates in `src/lib/` alone.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Works towards #1011.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
