### PR TITLE
fix(stm32): increase eth-stm32 executor stacksize requirement

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -979,6 +979,8 @@ modules:
       - network_device
     env:
       global:
+        executor_stacksize_required:
+          - "32768"
         FEATURES:
           - ariel-os/eth-stm32
 


### PR DESCRIPTION
# Description

This increases the stacksize requirements for stm32 ethernet.
Tested `tcp-echo`, `udp-echo`, `http-server`, `http-client` with both thread and interrupt executors.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
