### PR TITLE
docs(hal): reflect laze name change in ariel-os-hal

### DIFF
--- a/src/ariel-os-hal/src/lib.rs
+++ b/src/ariel-os-hal/src/lib.rs
@@ -7,7 +7,7 @@
 //! | Espressif            | ESP32       | ESP32-C6          | [`ariel-os-esp::*`](../../ariel_os_esp/index.html)     |
 //! | Nordic Semiconductor | nRF         | nRF52840          | [`ariel-os-nrf::*`](../../ariel_os_nrf/index.html)     |
 //! | Raspberry Pi         | RP          | RP2040            | [`ariel-os-rp::*`](../../ariel_os_rp/index.html)       |
-//! | STMicroelectronics   | STM32       | STM32WB55RGVX     | [`ariel-os-stm32::*`](../../ariel_os_stm32/index.html) |
+//! | STMicroelectronics   | STM32       | STM32WB55RG       | [`ariel-os-stm32::*`](../../ariel_os_stm32/index.html) |
 //!
 //! Documentation is only rendered for the MCUs listed in the table above, but [many others are
 //! supported](https://ariel-os.github.io/ariel-os/dev/docs/book/hardware-functionality-support.html).


### PR DESCRIPTION
# Description

Pull request #961 removed some unneeded info from the context identifiers. This commit updates the documentation page of the ariel-os-hal crate to reflect these changes.

## Issues/PRs references

This follows #961 that removes the unneeded information from the context names.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
