### PR TITLE
refactor(storage): use `if` in place of `match` with an empty branch

### DIFF
--- a/src/ariel-os-hal/src/dummy/storage.rs
+++ b/src/ariel-os-hal/src/dummy/storage.rs
@@ -38,7 +38,7 @@ impl embedded_storage_async::nor_flash::ReadNorFlash for Flash {
         todo!()
     }
 }
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct FlashError;
 impl embedded_storage_async::nor_flash::NorFlashError for FlashError {
     fn kind(&self) -> embedded_storage_async::nor_flash::NorFlashErrorKind {

--- a/src/ariel-os-storage/src/lib.rs
+++ b/src/ariel-os-storage/src/lib.rs
@@ -90,14 +90,9 @@ pub async fn init(p: &mut OptionalPeripherals) {
     embassy_time::block_for(embassy_time::Duration::from_millis(10));
 
     // Use a marker to ensure that this storage is initialized.
-    match get::<u8>(MARKER_KEY).await {
-        Ok(Some(val)) if val == MARKER_VALUE => {
-            // all good
-        }
-        _ => {
-            ariel_os_debug::log::info!("storage: initializing");
-            erase_all().await.unwrap();
-        }
+    if Ok(Some(MARKER_VALUE)) != get::<u8>(MARKER_KEY).await {
+        ariel_os_debug::log::info!("storage: initializing");
+        erase_all().await.unwrap();
     }
 }
 


### PR DESCRIPTION
# Description

Small refactoring of the `init` function in [ariel-os-storage/src/lib.rs](https://github.com/ariel-os/ariel-os/blob/92d3aeac74ba33b3d9ed3dd575ae91a3a227678f/src/ariel-os-storage/src/lib.rs#L93-L101) to use an `if` statement instead of a `match` with an empty branch.

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
