### PR TITLE
refactor: remove unused heapless dependencies in some examples and tests

### DIFF
--- a/examples/coap-client/Cargo.toml
+++ b/examples/coap-client/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 workspace = true
 
 [dependencies]
-heapless = { workspace = true }
 ariel-os = { path = "../../src/ariel-os" }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 embedded-nal-coap = { workspace = true }

--- a/examples/coap-server/Cargo.toml
+++ b/examples/coap-server/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 
 [dependencies]
 embassy-sync = { workspace = true }
-heapless = { workspace = true }
 ariel-os = { path = "../../src/ariel-os" }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 coap-message = "0.3.2"

--- a/examples/http-client/Cargo.toml
+++ b/examples/http-client/Cargo.toml
@@ -16,7 +16,6 @@ ariel-os = { path = "../../src/ariel-os", features = [
   "time",
 ] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
-heapless = { workspace = true }
 rand_core = { workspace = true }
 reqwless = { version = "0.13.0", default-features = true, features = [
   "embedded-tls",

--- a/examples/http-server/Cargo.toml
+++ b/examples/http-server/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 ariel-os = { path = "../../src/ariel-os" }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 embassy-sync = { workspace = true }
-heapless = { workspace = true }
 picoserve = { version = "0.14.1", default-features = false, features = [
   "embassy",
 ] }

--- a/examples/tcp-echo/Cargo.toml
+++ b/examples/tcp-echo/Cargo.toml
@@ -9,6 +9,5 @@ workspace = true
 
 [dependencies]
 embedded-io-async = "0.6.1"
-heapless = { workspace = true }
 ariel-os = { path = "../../src/ariel-os", features = ["tcp", "time"] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }

--- a/examples/udp-echo/Cargo.toml
+++ b/examples/udp-echo/Cargo.toml
@@ -8,6 +8,5 @@ publish = false
 workspace = true
 
 [dependencies]
-heapless = { workspace = true }
 ariel-os = { path = "../../src/ariel-os", features = ["udp"] }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }

--- a/tests/coap-blinky/Cargo.toml
+++ b/tests/coap-blinky/Cargo.toml
@@ -15,6 +15,3 @@ coap-handler-implementations = "0.5.0"
 riot-coap-handler-demos = { git = "https://gitlab.com/etonomy/riot-module-examples", rev = "09fa2d45e92ca4e46da7f18af3db3d1bcec238d3", default-features = false, features = [
   "gpio",
 ] }
-
-# Just for the network config
-heapless = { workspace = true }

--- a/tests/coap/Cargo.toml
+++ b/tests/coap/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 
 [dependencies]
 embassy-sync = { workspace = true }
-heapless = { workspace = true }
 ariel-os = { path = "../../src/ariel-os" }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
 embassy-futures = { workspace = true }


### PR DESCRIPTION
# Description

Removes unused `heapless` dependencies in the `coap`, `http` and `tcp/udp echos` examples and in the `coap` tests.

<!-- ## Issues/PRs references -->

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

<!-- ## Change checklist -->

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
