### PR TITLE
refactor(rp): make Clippy pedantic happy

### DIFF
--- a/src/ariel-os-rp/src/gpio.rs
+++ b/src/ariel-os-rp/src/gpio.rs
@@ -121,16 +121,14 @@ impl From<DriveStrength> for embassy_rp::gpio::Drive {
 
 impl ariel_os_embassy_common::gpio::FromDriveStrength for DriveStrength {
     fn from(drive_strength: ariel_os_embassy_common::gpio::DriveStrength<Self>) -> Self {
-        use ariel_os_embassy_common::gpio::DriveStrength::*;
-
         // ESPs are able to output up to 40 mA, so we somewhat normalize this.
         match drive_strength {
-            Hal(drive_strength) => drive_strength,
-            Lowest => Self::_2mA,
-            Standard => Self::default(),
-            Medium => Self::_8mA,
-            High => Self::_12mA,
-            Highest => Self::_12mA,
+            ariel_os_embassy_common::gpio::DriveStrength::Hal(drive_strength) => drive_strength,
+            ariel_os_embassy_common::gpio::DriveStrength::Lowest => Self::_2mA,
+            ariel_os_embassy_common::gpio::DriveStrength::Standard => Self::default(),
+            ariel_os_embassy_common::gpio::DriveStrength::Medium => Self::_8mA,
+            ariel_os_embassy_common::gpio::DriveStrength::High
+            | ariel_os_embassy_common::gpio::DriveStrength::Highest => Self::_12mA,
         }
     }
 }
@@ -165,14 +163,12 @@ impl From<Speed> for embassy_rp::gpio::SlewRate {
 
 impl ariel_os_embassy_common::gpio::FromSpeed for Speed {
     fn from(speed: ariel_os_embassy_common::gpio::Speed<Self>) -> Self {
-        use ariel_os_embassy_common::gpio::Speed::*;
-
         match speed {
-            Hal(speed) => speed,
-            Low => Self::Low,
-            Medium => Self::Low,
-            High => Self::High,
-            VeryHigh => Self::High,
+            ariel_os_embassy_common::gpio::Speed::Hal(speed) => speed,
+            ariel_os_embassy_common::gpio::Speed::Low
+            | ariel_os_embassy_common::gpio::Speed::Medium => Self::Low,
+            ariel_os_embassy_common::gpio::Speed::High
+            | ariel_os_embassy_common::gpio::Speed::VeryHigh => Self::High,
         }
     }
 }

--- a/src/ariel-os-rp/src/lib.rs
+++ b/src/ariel-os-rp/src/lib.rs
@@ -3,6 +3,7 @@
 #![no_std]
 #![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
+#![deny(clippy::pedantic)]
 
 pub mod gpio;
 

--- a/src/ariel-os-rp/src/spi/main/mod.rs
+++ b/src/ariel-os-rp/src/spi/main/mod.rs
@@ -49,7 +49,7 @@ ariel_os_embassy_common::impl_spi_from_frequency!();
 ariel_os_embassy_common::impl_spi_frequency_const_functions!(MAX_FREQUENCY);
 
 impl Frequency {
-    fn as_hz(&self) -> u32 {
+    fn as_hz(self) -> u32 {
         match self {
             Self::F(kilohertz) => kilohertz.to_Hz(),
         }
@@ -75,19 +75,19 @@ macro_rules! define_spi_drivers {
                     mosi_pin: impl Peripheral<P: MosiPin<peripherals::$peripheral>> + 'static,
                     config: Config,
                 ) -> Spi {
-                    let (pol, phase) = crate::spi::from_mode(config.mode);
-
-                    let mut spi_config = embassy_rp::spi::Config::default();
-                    spi_config.frequency = config.frequency.as_hz();
-                    spi_config.polarity = pol;
-                    spi_config.phase = phase;
-
                     // Make this struct a compile-time-enforced singleton: having multiple statics
                     // defined with the same name would result in a compile-time error.
                     paste::paste! {
                         #[allow(dead_code)]
                         static [<PREVENT_MULTIPLE_ $peripheral>]: () = ();
                     }
+
+                    let (pol, phase) = crate::spi::from_mode(config.mode);
+
+                    let mut spi_config = embassy_rp::spi::Config::default();
+                    spi_config.frequency = config.frequency.as_hz();
+                    spi_config.polarity = pol;
+                    spi_config.phase = phase;
 
                     // FIXME(safety): enforce that the init code indeed has run
                     // SAFETY: this struct being a singleton prevents us from stealing the


### PR DESCRIPTION
# Description

Enables the pedantic group in ariel-os-esp and refactors to make Clippy happy.

## Issues/PRs references

Works towards https://github.com/ariel-os/ariel-os/pull/948.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
