### PR TITLE
feat(boards): add support for ST B-L475E-IOT01A

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -247,6 +247,21 @@ chips:
           - removing items not supported
       wifi: not_available
 
+  stm32l475vg:
+    name: STM32L475VG
+    support:
+      gpio: supported
+      debug_output: supported
+      hwrng: supported
+      i2c_controller: needs_testing
+      spi_main: needs_testing
+      logging: supported
+      storage:
+        status: supported_with_caveats
+        comments:
+          - removing items not supported
+      wifi: not_available
+
   stm32u083mc:
     name: STM32U083MC
     support:
@@ -377,6 +392,19 @@ boards:
     chip: esp32s3
     support:
       user_usb: not_currently_supported
+      ethernet_over_usb: not_currently_supported
+
+  st-b-l475e-iot01a:
+    name: ST B-L475E-IOT01A
+    url: https://web.archive.org/web/20250402084429/https://www.st.com/en/evaluation-tools/b-l475e-iot01a.html
+    chip: stm32l475vg
+    support:
+      user_usb:
+        status: supported
+      wifi:
+        status: not_currently_supported
+        comments:
+          - an external Wi-Fi module is present on the board
       ethernet_over_usb: not_currently_supported
 
   st-nucleo-c031c6:

--- a/examples/blinky/laze.yml
+++ b/examples/blinky/laze.yml
@@ -10,6 +10,7 @@ apps:
       - nrf9160dk-nrf9160
       - particle-xenon
       - rp
+      - st-b-l475e-iot01a
       - st-nucleo-c031c6
       - st-nucleo-f401re
       - st-nucleo-f411re

--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -33,6 +33,9 @@ ariel_os::hal::define_peripherals!(LedPeripherals { led: PIN_1 });
 #[cfg(all(context = "esp", not(context = "dfrobot-firebeetle2-esp32-c6")))]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: GPIO0 });
 
+#[cfg(context = "st-b-l475e-iot01a")]
+ariel_os::hal::define_peripherals!(LedPeripherals { led: PA5 });
+
 #[cfg(context = "st-nucleo-c031c6")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: PA5 });
 

--- a/examples/gpio/laze.yml
+++ b/examples/gpio/laze.yml
@@ -9,6 +9,7 @@ apps:
       - nrf5340dk
       - nrf9160dk-nrf9160
       - rp
+      - st-b-l475e-iot01a
       - st-nucleo-c031c6
       - st-nucleo-f401re
       - st-nucleo-f411re

--- a/examples/gpio/src/pins.rs
+++ b/examples/gpio/src/pins.rs
@@ -49,6 +49,12 @@ ariel_os::hal::define_peripherals!(Peripherals {
     btn1: GPIO1
 });
 
+#[cfg(context = "st-b-l475e-iot01a")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    led1: PA5,
+    btn1: PC13
+});
+
 #[cfg(context = "st-nucleo-c031c6")]
 ariel_os::hal::define_peripherals!(Peripherals {
     led1: PA5,

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -473,6 +473,19 @@ contexts:
         - --cfg capability=\"hw/stm32-hash-rng\"
         - --cfg capability=\"hw/stm32-usb-synopsis\"
 
+  - name: stm32l475vg
+    parent: stm32
+    selects:
+      - cortex-m4f
+    provides:
+      - has_hwrng
+      - has_storage_support
+    env:
+      PROBE_RS_CHIP: STM32L475VG
+      RUSTFLAGS:
+        - --cfg capability=\"hw/stm32-rng\"
+        - --cfg capability=\"hw/stm32-usb-synopsis\" # Needs an external 32.768 kHz crystal to have a stable clock
+
   - name: stm32u083mc
     parent: stm32
     selects:
@@ -1548,6 +1561,16 @@ builders:
   # TODO: there also is a companion nrf5340 on this board
   - name: nordic-thingy-91-x-nrf9151
     parent: nrf9151
+
+  - name: st-b-l475e-iot01a
+    parent: stm32l475vg
+    provides:
+      - has_swi
+      - has_usb_device_port
+    env:
+      CARGO_ENV:
+        # This ISR is unused on a naked board. Configured here for testing.
+        - CONFIG_SWI=UART5
 
   - name: st-nucleo-f401re
     parent: stm32f401re

--- a/src/ariel-os-stm32/src/i2c/controller/mod.rs
+++ b/src/ariel-os-stm32/src/i2c/controller/mod.rs
@@ -230,6 +230,12 @@ define_i2c_drivers!(
    I2C3_EV + I2C3_ER => I2C3,
    I2C4_EV + I2C4_ER => I2C4,
 );
+#[cfg(context = "stm32l475vg")]
+define_i2c_drivers!(
+    I2C1_EV + I2C1_ER => I2C1,
+    I2C2_EV + I2C2_ER => I2C2,
+    I2C3_EV + I2C3_ER => I2C3,
+);
 #[cfg(context = "stm32u083mc")]
 define_i2c_drivers!(
    I2C1 => I2C1,

--- a/src/ariel-os-stm32/src/i2c/mod.rs
+++ b/src/ariel-os-stm32/src/i2c/mod.rs
@@ -22,6 +22,8 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
             take_all_i2c_peripherals!(I2C1, I2C2, I2C3);
         } else if #[cfg(context = "stm32h755zi")] {
             take_all_i2c_peripherals!(I2C1, I2C2, I2C3, I2C4);
+        } else if #[cfg(context = "stm32l475vg")]{
+            take_all_i2c_peripherals!(I2C1, I2C2, I2C3);
         } else if #[cfg(context = "stm32u083mc")] {
             take_all_i2c_peripherals!(I2C1, I2C2, I2C3, I2C4);
         } else if #[cfg(context = "stm32wb55rg")] {

--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -80,7 +80,47 @@ pub fn init() -> OptionalPeripherals {
 }
 
 // TODO: find better place for this
+#[expect(clippy::too_many_lines)]
 fn board_config(config: &mut Config) {
+    #[cfg(context = "st-b-l475e-iot01a")]
+    {
+        use embassy_stm32::rcc::*;
+
+        // This board has an LSE clock, we can use it to calibrate the MSI clock
+        config.rcc.ls = LsConfig {
+            rtc: RtcClockSource::LSE,
+            lsi: false,
+            lse: Some(LseConfig {
+                frequency: embassy_stm32::time::Hertz(32768),
+                mode: LseMode::Oscillator(LseDrive::MediumHigh),
+            }),
+        };
+        config.rcc.hsi = false;
+        // Setting the MSI range to 48 MHz crashes the system. If the source of the issue is found,
+        // we can use MSI as the clock source for the usb peripheral directly and avoid using more PLLs.
+        config.rcc.msi = Some(MSIRange::RANGE8M);
+        config.rcc.pll = Some(Pll {
+            source: PllSource::MSI,
+            prediv: PllPreDiv::DIV1, // 8 Mhz
+            mul: PllMul::MUL20,      // 160 MHz
+            divp: None,
+            divq: None,
+            divr: Some(PllRDiv::DIV2), // sysclk 80Mhz (8 / 1  * 20 / 2)
+        });
+        config.rcc.sys = Sysclk::PLL1_R;
+        config.rcc.pllsai1 = Some(Pll {
+            source: PllSource::MSI,
+            prediv: PllPreDiv::DIV1,
+            mul: PllMul::MUL12, // 8 MHz MSI * 12 = 96 MHz
+            divp: None,
+            divq: Some(PllQDiv::DIV2), // USB 48 MHz (8 / 1 * 12 / 2)
+            divr: None,
+        });
+        // With a 32.768 kHz LSE, the MSI clock will be calibrated and considered accurate enough.
+        // Embassy automatically enables MSIPLLEN if the LSE is configured.
+        config.rcc.mux.clk48sel = mux::Clk48sel::PLLSAI1_Q;
+    }
+
     #[cfg(context = "st-nucleo-wb55")]
     {
         use embassy_stm32::rcc::*;

--- a/src/ariel-os-stm32/src/spi/main/mod.rs
+++ b/src/ariel-os-stm32/src/spi/main/mod.rs
@@ -24,6 +24,8 @@ const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(21);
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(25);
 #[cfg(context = "stm32h755zi")]
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(150);
+#[cfg(context = "stm32l475vg")]
+const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(40);
 #[cfg(context = "stm32u083mc")]
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(32);
 #[cfg(context = "stm32wb55rg")]
@@ -165,6 +167,12 @@ define_spi_drivers!(
    SPI4 => SPI4,
    SPI5 => SPI5,
    SPI6 => SPI6,
+);
+#[cfg(context = "stm32l475vg")]
+define_spi_drivers!(
+   SPI1 => SPI1,
+   SPI2 => SPI2,
+   SPI3 => SPI3,
 );
 #[cfg(context = "stm32u083mc")]
 define_spi_drivers!(

--- a/src/ariel-os-stm32/src/spi/mod.rs
+++ b/src/ariel-os-stm32/src/spi/mod.rs
@@ -42,6 +42,8 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3, SPI4, SPI5);
         } else if #[cfg(context = "stm32h755zi")] {
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3, SPI4, SPI5, SPI6);
+        }else if #[cfg(context= "stm32l475vg")]{
+            take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3);
         } else if #[cfg(context = "stm32u083mc")] {
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3);
         } else if #[cfg(context = "stm32wb55rg")] {

--- a/src/ariel-os-storage/build.rs
+++ b/src/ariel-os-storage/build.rs
@@ -7,18 +7,19 @@ fn main() {
     // Important: only homogeneous flash organizations are currently supported.
     // Trying to restrict the storage size to the subset of homogeneous flash would not work as it
     // could be pushed out of it by a large enough binary.
-    let (storage_size_total, flash_page_size) = if is_in_current_contexts(&["stm32u083mc"]) {
-        (4 * KIBIBYTES, 2 * KIBIBYTES)
-    } else if is_in_current_contexts(&["nrf52", "nrf5340", "nrf91", "rp", "stm32wb55rg"]) {
-        (8 * KIBIBYTES, 4 * KIBIBYTES)
-    } else if is_in_current_contexts(&["stm32h755zi"]) {
-        (256 * KIBIBYTES, 128 * KIBIBYTES)
-    } else if !is_in_current_contexts(&["ariel-os"]) {
-        // Dummy value for platform-independent tooling.
-        (8 * KIBIBYTES, 4 * KIBIBYTES)
-    } else {
-        panic!("MCU not supported");
-    };
+    let (storage_size_total, flash_page_size) =
+        if is_in_current_contexts(&["stm32u083mc", "stm32l475vg"]) {
+            (4 * KIBIBYTES, 2 * KIBIBYTES)
+        } else if is_in_current_contexts(&["nrf52", "nrf5340", "nrf91", "rp", "stm32wb55rg"]) {
+            (8 * KIBIBYTES, 4 * KIBIBYTES)
+        } else if is_in_current_contexts(&["stm32h755zi"]) {
+            (256 * KIBIBYTES, 128 * KIBIBYTES)
+        } else if !is_in_current_contexts(&["ariel-os"]) {
+            // Dummy value for platform-independent tooling.
+            (8 * KIBIBYTES, 4 * KIBIBYTES)
+        } else {
+            panic!("MCU not supported");
+        };
 
     // `sequential-storage` needs at least two flash pages.
     assert!(storage_size_total / flash_page_size >= 2);

--- a/tests/coap-blinky/laze.yml
+++ b/tests/coap-blinky/laze.yml
@@ -12,6 +12,7 @@ apps:
       - nrf9160dk-nrf9160
       - particle-xenon
       - rp
+      - st-b-l475e-iot01a
       - st-nucleo-f401re
       - st-nucleo-h755zi-q
       - st-nucleo-wb55

--- a/tests/i2c-controller/laze.yml
+++ b/tests/i2c-controller/laze.yml
@@ -9,6 +9,7 @@ apps:
       - nrf9160
       - rp2040
       - rp235xa
+      - st-b-l475e-iot01a
       - st-nucleo-c031c6
       - st-nucleo-f411re
       - st-nucleo-h755zi-q

--- a/tests/i2c-controller/src/pins.rs
+++ b/tests/i2c-controller/src/pins.rs
@@ -55,6 +55,14 @@ ariel_os::hal::define_peripherals!(Peripherals {
     i2c_scl: PB8,
 });
 
+#[cfg(context = "stm32l475vg")]
+pub type SensorI2c = i2c::controller::I2C1;
+#[cfg(context = "stm32l475vg")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    i2c_sda: PB9,
+    i2c_scl: PB8,
+});
+
 #[cfg(context = "stm32wb55rg")]
 pub type SensorI2c = i2c::controller::I2C1;
 #[cfg(context = "stm32wb55rg")]

--- a/tests/spi-loopback/laze.yml
+++ b/tests/spi-loopback/laze.yml
@@ -8,6 +8,7 @@ apps:
       - nrf9160
       - rp2040
       - rp235xa
+      - st-b-l475e-iot01a
       - st-nucleo-c031c6
       - st-nucleo-f401re
       - st-nucleo-f411re

--- a/tests/spi-loopback/src/pins.rs
+++ b/tests/spi-loopback/src/pins.rs
@@ -81,6 +81,17 @@ ariel_os::hal::define_peripherals!(Peripherals {
     spi_cs: PD14,
 });
 
+// Side SPI of Arduino v3 connector on the st-b-l475e-iot01a board
+#[cfg(context = "stm32l475vg")]
+pub type SensorSpi = spi::main::SPI1;
+#[cfg(context = "stm32l475vg")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    spi_sck: PA5,  // Arduino D13
+    spi_miso: PA6, // Arduino D12
+    spi_mosi: PA7, // Arduino D11
+    spi_cs: PA2,   // Arduion D10
+});
+
 // Side SPI of Arduino v3 connector
 #[cfg(context = "stm32u083mc")]
 pub type SensorSpi = spi::main::SPI1;

--- a/tests/spi-main/laze.yml
+++ b/tests/spi-main/laze.yml
@@ -8,6 +8,7 @@ apps:
       - nrf9160
       - rp2040
       - rp235xa
+      - st-b-l475e-iot01a
       - st-nucleo-c031c6
       - st-nucleo-f411re
       - st-nucleo-h755zi-q

--- a/tests/spi-main/src/pins.rs
+++ b/tests/spi-main/src/pins.rs
@@ -79,6 +79,17 @@ ariel_os::hal::define_peripherals!(Peripherals {
     spi_cs: PD14,
 });
 
+// Side SPI of Arduino v3 connector on the st-b-l475e-iot01a board
+#[cfg(context = "stm32l475vg")]
+pub type SensorSpi = spi::main::SPI1;
+#[cfg(context = "stm32l475vg")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    spi_sck: PA5,  // Arduino D13
+    spi_miso: PA6, // Arduino D12
+    spi_mosi: PA7, // Arduino D11
+    spi_cs: PA2,   // Arduion D10
+});
+
 // Side SPI of Arduino v3 connector
 #[cfg(context = "stm32u083mc")]
 pub type SensorSpi = spi::main::SPI1;


### PR DESCRIPTION
# Description

This PR adds support to the ST B-L475E-IOT01A board and its STM32L475VG MCU 

## Open Questions

~~Do we support USB for this board ? The clock would need to be generated by the MSI (calibrated using the LSE)~~
USB will be supported on this board, I was confused on how to change `MSIPLLEN` but embassy does it automatically. 

## Testing

Successfully tested on hardware through the IoT-LAB platform: 

- `examples/gpio`
- `examples/log`
- `examples/random`
- `examples/storage`
- `examples/usb-serial`
- `tests/gpio-interrupt-stm32`

I also ran some other tests that didn't pass because it needs some external hardware connected, the errors I got were because the hardware was not connected: 

- `tests/i2c-controller`
- `tests/spi-loopback`
- `tests/spi-main`

Finally I ran `examples/http-server` and got the network interface to show up on my computer, but the link stayed down with the `NO-CARRIER` status.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
