### PR TITLE
feat: make heap requirements configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "ariel-os",
  "ariel-os-boards",
  "ariel-os-debug",
+ "ariel-os-utils",
  "embedded-alloc",
  "embedded-test",
  "esp-alloc",

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -94,11 +94,13 @@ contexts:
       PROBE_RS_PROTOCOL:
         start: --protocol=
 
-      # Executor / ISR stacksize helpers
+      # Executor / ISR stacksize and heapsize helpers
       executor_stacksize_required:
         joiner: ", "
       isr_stacksize_required:
         joiner: ", "
+      heapsize_required:
+        joiner: " + "
 
     rules:
       - name: LINK
@@ -667,9 +669,18 @@ modules:
 
   ## System functionality modules
   - name: alloc
+    help: Enables a heap, a global allocator and the `alloc` crate.
     context: ariel-os
     env:
       global:
+        # *Append* to this array to increase the heapsize. The sum of all entries will
+        # be used. By default, all unused memory is used for the heap, and the sum
+        # is used to check if the amount of heap is actually available.
+        # On esp, it always allocates the sum of `heapsize_required`, but at least 2KiB.
+        heapsize_required:
+          - "0"
+        CARGO_ENV:
+          - CONFIG_HEAPSIZE=$(${heapsize_required})
         FEATURES:
           - ariel-os/alloc
 
@@ -1182,6 +1193,7 @@ modules:
 
   - name: wifi-esp
     selects:
+      - alloc
       - riscv:
           - wifi-esp-xor-threads
     context:
@@ -1192,6 +1204,9 @@ modules:
       global:
         # esp-wifi needs a lot of ISR stack.
         isr_stacksize_required_default: "65536"
+        # esp-wifi needs 72KiB
+        heapsize_required:
+          - $(72*1024)
         FEATURES:
           - ariel-os/wifi-esp
 

--- a/src/ariel-os-alloc/Cargo.toml
+++ b/src/ariel-os-alloc/Cargo.toml
@@ -13,6 +13,7 @@ harness = false
 
 [dependencies]
 ariel-os-debug = { workspace = true }
+ariel-os-utils = { workspace = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
 embedded-alloc = { version = "0.6.0", default-features = false, features = [


### PR DESCRIPTION
# Description

This PR gives apps/modules the option to specify how much heap they'll need, similar to how we configure stack sizes.

On Cortex-M the leftover memory is used for heap in any case, and this is just a compile time check that requirements are met. On esp we can't take all leftover memory (yet), so this helps to specify that e.g., esp-wifi needs at least 72k of heap.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
