### PR TITLE
feat(stm32): provide stm32 peripheral `cfg` metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,7 @@ dependencies = [
  "paste",
  "portable-atomic",
  "static_cell",
+ "stm32-metapac",
 ]
 
 [[package]]

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -30,6 +30,9 @@ ariel-os-embassy-common = { workspace = true }
 ariel-os-random = { workspace = true, optional = true }
 static_cell = { workspace = true }
 
+[build-dependencies]
+stm32-metapac = "16.0.0"
+
 [features]
 ## Enables GPIO interrupt support.
 external-interrupts = [

--- a/src/ariel-os-stm32/build.rs
+++ b/src/ariel-os-stm32/build.rs
@@ -24,4 +24,24 @@ fn main() {
 
         println!("cargo::rerun-if-env-changed=CONFIG_SWI");
     }
+
+    peripheral_cfg_from_metapac();
+}
+
+// Enable peripheral `cfg` flags, data taken from `stm32-metapac`.
+// Similar to https://github.com/embassy-rs/embassy/blob/ef32187ed7349f3883d997b6f1590e11dbc8db81/embassy-stm32/build.rs#L38-L43
+fn peripheral_cfg_from_metapac() {
+    use std::collections::HashSet;
+    fn cfg_only_once(seen: &mut HashSet<String>, cfg: &str) {
+        if seen.insert(cfg.to_string()) {
+            println!("cargo::rustc-cfg={cfg}");
+        }
+    }
+    let mut seen = HashSet::new();
+    for p in stm32_metapac::metadata::METADATA.peripherals {
+        if let Some(r) = &p.registers {
+            cfg_only_once(&mut seen, r.kind);
+            cfg_only_once(&mut seen, &format!("{}_{}", r.kind, r.version));
+        }
+    }
 }


### PR DESCRIPTION
# Description

This uses `stm32-metadata` to provide per-MCU `cfg` based on actual peripherals of each mcu.

## Issues/PRs references

Needed to make sth like #1040 work.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
