### PR TITLE
fix(build): model `xtensa` being `nightly`

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -25,6 +25,9 @@ contexts:
       - ?hw/device-identity
       - ?lto
       - ?semihosting
+
+      # Selecting default toolchain here. try xtensa, stable, nightly.
+      - ?xtensa
       - ?stable
       - ?nightly
     env:
@@ -626,14 +629,23 @@ modules:
           - --cfg context=\"cortex-m33f\"
 
   - name: xtensa
+    context:
+      - esp32
+      - esp32s3
+    provides_unique:
+      - cargo-toolchain
+      - nightly
     conflicts:
       # no xtensa in stable Rust
+      # this is implicit by `provides_unique: cargo-toolchain`, adding here for
+      # clarity
       - stable
     env:
       global:
         CARGO_TOOLCHAIN: +esp
         RUSTFLAGS:
           - --cfg context=\"xtensa\"
+          - --cfg nightly
         CFLAGS:
           - -mlongcalls
         CARGO_ARGS:
@@ -708,8 +720,8 @@ modules:
 
   - name: stable
     help: build with stable Rust
-    conflicts:
-      - nightly
+    provides_unique:
+      - cargo-toolchain
     env:
       global:
         # Using the empty string here, as specifying "+stable" would make rustup
@@ -720,8 +732,8 @@ modules:
 
   - name: nightly
     help: build with nightly Rust
-    conflicts:
-      - stable
+    provides_unique:
+      - cargo-toolchain
     env:
       global:
         # this pins our nightly version


### PR DESCRIPTION
# Description

b/c dependency resolution ordering reasons, it wasn't possible to build `examples/http-client` for xtensa boards.

This PR

- makes all three toolchain-providing modules (esp, stable, nightly) provide_unique `cargo-toolchain` (implicitly conflicting with each other)
- make esp set `--cfg nightly`
- make the ariel-os context try `?xtensa` before `?stable`.
- actually limits `xtensa` to be available only in the `esp32` and `esp32s3` contexts

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
