### PR TITLE
fix(stm32): select correct `stm32-metapac` features

### DIFF
--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -31,7 +31,9 @@ ariel-os-random = { workspace = true, optional = true }
 static_cell = { workspace = true }
 
 [build-dependencies]
-stm32-metapac = "16.0.0"
+stm32-metapac = { version = "16.0.0", default-features = false, features = [
+  "metadata",
+] }
 
 [features]
 ## Enables GPIO interrupt support.


### PR DESCRIPTION
# Description

#1045 enabled the default features for `stm32-metapac` for the build dependency of `ariel-os-stm32`, which caused the PAC to be compiled for the host system. That was not intended, and at least broke linking on OSX.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
