### PR TITLE
docs(udp-example): use smaller buffers

### DIFF
--- a/examples/udp-echo/src/main.rs
+++ b/examples/udp-echo/src/main.rs
@@ -4,15 +4,19 @@
 use ariel_os::{debug::log::*, net, reexports::embassy_net};
 use embassy_net::udp::{PacketMetadata, UdpSocket};
 
+// UDP datagrams with payloads larger than this will be dropped and ignored, both when receiving
+// and sending, so the size of the three buffers needs to be the same in this echo example.
+const BUFFER_SIZE: usize = 128;
+
 #[ariel_os::task(autostart)]
 async fn udp_echo() {
     let stack = net::network_stack().await.unwrap();
 
-    let mut rx_meta = [PacketMetadata::EMPTY; 16];
-    let mut rx_buffer = [0; 4096];
-    let mut tx_meta = [PacketMetadata::EMPTY; 16];
-    let mut tx_buffer = [0; 4096];
-    let mut buf = [0; 4096];
+    let mut rx_meta = [PacketMetadata::EMPTY; 1];
+    let mut rx_buffer = [0; BUFFER_SIZE];
+    let mut tx_meta = [PacketMetadata::EMPTY; 1];
+    let mut tx_buffer = [0; BUFFER_SIZE];
+    let mut buf = [0; BUFFER_SIZE];
 
     loop {
         let mut socket = UdpSocket::new(


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Shrink the buffers used in the UDP echo example, and add the reasoning for their sizing, as it is not currently documented upstream.
This is a first step in being able to compile the networking examples for MCUs with little RAM.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
