### PR TITLE
feat(build): add vscode configuration generator

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -4,6 +4,7 @@ authors = [
   "Emmanuel Baccelli",
   "Christian Amsüss",
   "Elena Frank",
+  "Nils Ponsard",
 ]
 language = "en"
 src = "src"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -18,6 +18,7 @@
 - [Tooling](./tooling/index.md)
   - [CoAP](./tooling/coap.md)
   - [Ferrocene](./tooling/ferrocene.md)
+- [VSCode Configuration](./vscode-configuration.md)
 - [Glossary](./glossary.md)
 
 # Developer Guide

--- a/book/src/build-system.md
+++ b/book/src/build-system.md
@@ -29,6 +29,7 @@ Tasks available in Ariel OS include:
 - `flash-erase-all`: Erases the entire flash memory, including user data. Unlocks it if locked.
 - `reset`: Reboots the target.
 - `tree`: Prints the application's `cargo tree`.
+- `vscode-config`: update rust-analyzer configuration for VSCode, see [vscode-configuration](./vscode-configuration.md)
 
 > As some tasks may trigger a rebuild, it is necessary to pass the same settings to related consecutive commands:
 `laze build -DFOO=1 flash` followed by `laze build -DFOO=other debug` might not

--- a/book/src/vscode-configuration.md
+++ b/book/src/vscode-configuration.md
@@ -1,0 +1,37 @@
+# VSCode configuration
+
+This chapter covers how to setup [Visual Studio Code](https://code.visualstudio.com/) to get features in-editor linting, go to definition, documentation on hover, inlay hints.
+
+## Extensions
+
+Rust language support is provided by `rust-analyzer`, available on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) and [Open VSX Registry](https://open-vsx.org/extension/rust-lang/rust-analyzer) for open source forks of VSCode.
+
+It is also recommended to use the the `Even Better TOML` exentsion to have TOML support when editing `Cargo.toml` files: [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml), [Open VSX Registry](https://open-vsx.org/extension/tamasfe/even-better-toml).
+
+`Dependi` can be used to view information about crates and their available versions: [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=fill-labs.dependi), [Open VSX Registry](https://open-vsx.org/extension/fill-labs/dependi).
+
+## Configuration for developing Ariel OS apps
+
+This is meant to be used on projects created using the `cargo-generate` command in the getting-started guide. The configuration works by targeting one board, avoiding the linter to be confused about double declarations.
+
+You will need to have a nightly version of Rust installed, you can install the latest one using:
+
+```sh
+rustup toolchain install nightly
+```
+
+Then install configure the toolchain by running this at the root of your project:
+
+```sh
+laze build -D CARGO_TOOLCHAIN=+nightly install-toolchain
+```
+
+To generate/update your vscode configuration in `.vscode/settings.json`, run in the root of your project:
+
+```sh
+laze build -b <board> vscode-config
+```
+
+With `<board>` being the laze identifier of a board your application will run on (e.g. `nrf52840dk`).
+
+If you get an error about the JSON file being malformated, you may have comments or trailing commas in your configuration, try removing them in `.vscode/settings.json`.

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -188,6 +188,19 @@ contexts:
         cmd:
           - echo ${builder}
 
+      vscode-config:
+        help: Generate a VSCode configuration for selected board (select a board with -b)
+        build: false
+        # The --config arg in CARGO_ARGS is pointing to a file relative to the appdir, it makes more sense to generate the config in the appdir
+        workdir: ${appdir}
+        export:
+          - FEATURES
+          - CARGO_TARGET_PREFIX
+          - CARGO_ARGS
+          - CARGO_ENV
+        cmd: # We have to obfuscate the variables to avoid cargo interpreting them since we're running a rust script
+          - _CARGO_TOOLCHAIN='${CARGO_TOOLCHAIN}' ${relroot}/${root}/scripts/vscode.rs
+
   - name: nrf
     help: Nordic MCU support (based on embassy-nrf)
     parent: ariel-os

--- a/scripts/vscode.rs
+++ b/scripts/vscode.rs
@@ -1,0 +1,153 @@
+#!/usr/bin/env -S cargo +nightly -Zscript
+---cargo
+[package]
+edition = "2024"
+
+[dependencies]
+argh = { version = "0.1.13" }
+miette = { version = "7.2.0", features = ["fancy"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
+thiserror = { version = "2.0.12" }
+shlex = { version = "1.3.0" }
+
+---
+use std::{fs, io, path::PathBuf};
+
+use miette::Diagnostic;
+use serde_json::{Map, Value};
+
+#[derive(Debug, thiserror::Error, Diagnostic)]
+enum Error {
+    #[error("I/O error : {0}")]
+    Io(#[from] io::Error),
+    #[error("JSON error : {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("Environment variable CARGO_ENV not set")]
+    CargoEnvNotSet,
+    #[error("Failed to parse CARGO_ENV")]
+    CargoEnvParse,
+}
+
+fn main() -> miette::Result<()> {
+    // create directory if it doesn't exist
+    let directory_path = PathBuf::from(".vscode");
+    if !directory_path.exists() {
+        fs::create_dir_all(&directory_path).map_err(Error::from)?;
+    }
+
+    // create .vscode/settings.json file if it doesn't exist
+    let settings_path = directory_path.join("settings.json");
+    if !settings_path.exists() {
+        fs::write(&settings_path, "{}").map_err(Error::from)?;
+    }
+
+    let settings = fs::File::open(&settings_path).map_err(Error::from)?;
+
+    let mut settings_json: Map<String, Value> =
+        serde_json::from_reader(settings).map_err(Error::from)?;
+
+    settings_json.insert(
+        "rust-analyzer.check.command".to_string(),
+        Value::String("clippy".to_string()),
+    );
+    settings_json.insert(
+        "rust-analyzer.check.allTargets".to_string(),
+        Value::Bool(false),
+    );
+
+    // Having the client watch for file changes can lead to infinite loops in rust-analyzer
+    settings_json.insert(
+        "rust-analyzer.files.watcher".to_string(),
+        Value::String("server".to_string()),
+    );
+
+    let cargo_args = std::env::var("CARGO_ARGS").unwrap_or("".to_string());
+    let features_args = std::env::var("FEATURES").unwrap_or("".to_string());
+    let extra_args = format!("{} {}", cargo_args, features_args)
+        .trim()
+        .split(" ")
+        .map(|s| Value::String(s.to_string()))
+        .collect::<Vec<Value>>();
+
+    if !extra_args.is_empty() {
+        settings_json.insert(
+            "rust-analyzer.check.extraArgs".to_string(),
+            Value::Array(extra_args.clone()),
+        );
+
+        // Need to override the default check command to have the proc-macro build correctly
+
+        let mut override_command = ["cargo", "check"]
+            .map(|s| Value::String(s.to_string()))
+            .to_vec();
+        override_command.extend(extra_args);
+        override_command.push(Value::String("--message-format=json".to_string()));
+
+        settings_json.insert(
+            "rust-analyzer.cargo.buildScripts.overrideCommand".to_string(),
+            Value::Array(override_command),
+        );
+    }
+
+    let features_str = features_args.replace("--features=", "");
+    let features_list = features_str
+        .split(",")
+        .map(|s| Value::String(s.trim().to_string()))
+        .collect::<Vec<Value>>();
+    if !features_list.is_empty() {
+        settings_json.insert(
+            "rust-analyzer.cargo.features".to_string(),
+            Value::Array(features_list),
+        );
+    }
+
+    let mut extra_env = Map::new();
+
+    // Parse CARGO_ENV into a map of key-value pairs to be used as extra environment variables
+    let cargo_env = std::env::var("CARGO_ENV").map_err(|_| Error::CargoEnvNotSet)?;
+    let tokens = shlex::split(&cargo_env).ok_or(Error::CargoEnvParse)?;
+    for token in tokens {
+        if let Some((key, value)) = token.split_once('=') {
+            extra_env.insert(key.to_string(), Value::String(value.to_string()));
+        }
+    }
+
+    // Set some default environment variables for wifi so clippy doesn't block on it when using the feature
+    extra_env.insert(
+        "CONFIG_WIFI_NETWORK".to_string(),
+        Value::String("test-wifi".to_string()),
+    );
+    extra_env.insert(
+        "CONFIG_WIFI_PASSWORD".to_string(),
+        Value::String("test-password".to_string()),
+    );
+
+    // Default to nightly so cargo-metadata can correctly read the config
+    let mut toolchain = "+nightly".to_string();
+    if let Ok(toolchain_env) = std::env::var("_CARGO_TOOLCHAIN") {
+        if !toolchain_env.is_empty() {
+            toolchain = toolchain_env
+        }
+    }
+    let toolchain = toolchain[1..].to_string(); // Remove the leading '+' character
+    extra_env.insert("RUSTUP_TOOLCHAIN".to_string(), Value::String(toolchain));
+
+    if !extra_env.is_empty() {
+        settings_json.insert(
+            "rust-analyzer.server.extraEnv".to_string(),
+            Value::Object(extra_env),
+        );
+    }
+
+    let settings_json_string = serde_json::to_string_pretty(&settings_json).map_err(Error::from)?;
+    fs::write(&settings_path, settings_json_string).map_err(Error::from)?;
+    println!(
+        "Updated settings in {}",
+        std::path::absolute(settings_path)
+            .map_err(Error::from)?
+            .to_string_lossy()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
# Description

This generates a vscode configuration file targeting the selected board allowing to have linting using the rust-analyzer extension.

This is meant to be used on projects using the official Ariel OS `cargo generate` template. To generate the VSCode configuration use the `vscode-config` task with only one board selected, for example:

```sh
laze build -b rpi-pico vscode-config
```

Most of the rust-analyzer features works (including go to definition, inlay hints, documentation on hover and lint result).

I tested on some code examples (`hello-world`,`tcp-echo` and `random`) and on at least one board/builder of each vendor. User documentation in the book and configuration for developing in the Ariel repository itself will come in separate PRs.

## Issues/PRs references

This is a step required to have a good user experience when developing Ariel OS applications using VSCode, started/tracked in #942.

## Open Questions

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
