### PR TITLE
feat: add support stm32f042k6 mcu and nucleo board

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -209,8 +209,8 @@ chips:
       debug_output: supported
       ethernet_over_usb: not_available
       hwrng: not_available
-      i2c_controller: supported
-      spi_main: supported
+      i2c_controller: not_currently_supported
+      spi_main: not_currently_supported
       logging: supported
       storage:
         status: not_currently_supported

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -202,6 +202,23 @@ chips:
       user_usb: not_available
       wifi: not_available
 
+  stm32f042k6:
+    name: STM32F042K6
+    support:
+      gpio: supported
+      debug_output: supported
+      ethernet_over_usb: not_available
+      hwrng: not_available
+      i2c_controller: supported
+      spi_main: supported
+      logging: supported
+      storage:
+        status: not_currently_supported
+        comments:
+          - would need to allocate some flash
+      user_usb: not_available
+      wifi: not_available
+
   stm32f401re:
     name: STM32F401RE
     support:
@@ -411,6 +428,12 @@ boards:
     name: ST NUCLEO-C031C6
     url: https://web.archive.org/web/20241114214921/https://www.st.com/en/evaluation-tools/nucleo-c031c6.html
     chip: stm32c031c6
+    support:
+
+  st-nucleo-f042k6:
+    name: ST NUCLEO-F042K6
+    url: https://web.archive.org/web/20241114214921/https://www.st.com/en/evaluation-tools/nucleo-f042k6.html
+    chip: stm32f042k6
     support:
 
   st-nucleo-f401re:

--- a/examples/blinky/laze.yml
+++ b/examples/blinky/laze.yml
@@ -12,6 +12,7 @@ apps:
       - rp
       - st-b-l475e-iot01a
       - st-nucleo-c031c6
+      - st-nucleo-f042k6
       - st-nucleo-f401re
       - st-nucleo-f411re
       - st-nucleo-h755zi-q

--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -39,6 +39,9 @@ ariel_os::hal::define_peripherals!(LedPeripherals { led: PA5 });
 #[cfg(context = "st-nucleo-c031c6")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: PA5 });
 
+#[cfg(context = "st-nucleo-f042k6")]
+ariel_os::hal::define_peripherals!(LedPeripherals { led: PB3 });
+
 #[cfg(any(context = "st-nucleo-f401re", context = "st-nucleo-f411re"))]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: PA5 });
 

--- a/examples/gpio/laze.yml
+++ b/examples/gpio/laze.yml
@@ -11,6 +11,7 @@ apps:
       - rp
       - st-b-l475e-iot01a
       - st-nucleo-c031c6
+      - st-nucleo-f042k6
       - st-nucleo-f401re
       - st-nucleo-f411re
       - st-nucleo-h755zi-q

--- a/examples/gpio/src/pins.rs
+++ b/examples/gpio/src/pins.rs
@@ -61,6 +61,13 @@ ariel_os::hal::define_peripherals!(Peripherals {
     btn1: PC13
 });
 
+#[cfg(context = "st-nucleo-f042k6")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    led1: PB3,
+    // Note: the board only has one physical button which is hardwired to NRST so this uses D2
+    btn1: PA12
+});
+
 #[cfg(any(context = "st-nucleo-f401re", context = "st-nucleo-f411re"))]
 ariel_os::hal::define_peripherals!(Peripherals {
     led1: PA5,

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -763,6 +763,8 @@ modules:
     conflicts:
       # disabling alloc until we have a usable use case
       - alloc
+      # embedded-test currently hard-codes a 16KiB stack for its thread
+      - embedded-test
       # disabling as the default stack sizes are too small for log (defmt works)
       - log
       # disabling until we do have a driver/stack combo that works

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -431,6 +431,19 @@ contexts:
       executor_stacksize_required_default: "3072"
       PROBE_RS_CHIP: STM32C031C6
 
+  - name: stm32f042k6
+    parent: stm32
+    selects:
+      - cortex-m0
+      - single-core
+      - ram-tiny
+    disables:
+      - semihosting
+    env:
+      isr_stacksize_required_default: "512"
+      executor_stacksize_required_default: "512"
+      PROBE_RS_CHIP: STM32F042K6
+
   - name: stm32f401re
     parent: stm32
     selects:
@@ -1561,6 +1574,15 @@ builders:
 
   - name: st-nucleo-c031c6
     parent: stm32c031c6
+    provides:
+      - has_swi
+    env:
+      CARGO_ENV:
+        # This ISR is unused on a naked board. Configured here for testing.
+        - CONFIG_SWI=USART2
+
+  - name: st-nucleo-f042k6
+    parent: stm32f042k6
     provides:
       - has_swi
     env:

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -22,6 +22,10 @@ rustflags = "0.1"
 cortex-m = { workspace = true }
 cortex-m-rt = { workspace = true }
 
+# No CAS instructions on Cortex-M0.
+[target.'cfg(context = "cortex-m0")'.dependencies]
+portable-atomic = { workspace = true, features = ["critical-section"] }
+
 # No CAS instructions on Cortex-M0+.
 [target.'cfg(context = "cortex-m0-plus")'.dependencies]
 portable-atomic = { workspace = true, features = ["critical-section"] }

--- a/src/ariel-os-stm32/src/gpio.rs
+++ b/src/ariel-os-stm32/src/gpio.rs
@@ -94,7 +94,10 @@ impl From<Speed> for embassy_stm32::gpio::Speed {
         match speed {
             Speed::Low => Self::Low,
             Speed::Medium => Self::Medium,
+            #[cfg(not(any(gpio_v1, syscfg_f0)))]
             Speed::High => Self::High,
+            #[cfg(any(gpio_v1, syscfg_f0))]
+            Speed::High => Self::VeryHigh,
             Speed::VeryHigh => Self::VeryHigh,
         }
     }


### PR DESCRIPTION
# Description

This adds support for Cortex-M0 MCUs, the STM32F042K6 MCU in particular and the associated Nucleo-32 board