### PR TITLE
chore(build): drop currently not used `esp-storage` patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5951,8 +5951,3 @@ dependencies = [
  "quote",
  "syn 2.0.96",
 ]
-
-[[patch.unused]]
-name = "esp-storage"
-version = "0.4.0"
-source = "git+https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995fc06eb5e6d04a2022ecf3679b4929e63"

--- a/ariel-os-cargo.toml
+++ b/ariel-os-cargo.toml
@@ -32,7 +32,6 @@ esp-hal = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel
 esp-hal-embassy = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os-threads" }
 esp-println = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os-threads" }
 esp-wifi = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os-threads" }
-esp-storage = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os-threads" }
 xtensa-lx-rt = { git = "https://github.com/ariel-os/esp-hal", branch = "v0.23.1+ariel-os-threads" }
 
 # patched to use portable-atomics <https://github.com/seanmonstar/try-lock/pull/11>


### PR DESCRIPTION
# Description

Gets rid of this:

```
warning: Patch `esp-storage v0.4.0 (https://github.com/ariel-os/esp-hal?branch=v0.23.1%2Bariel-os-threads#aa8d1995)` was not used in the crate graph.
Check that the patched package version and available features are compatible
with the dependency requirements. If the patch has a different version from                    
what is locked in the Cargo.lock file, run `cargo update` to use the new                       
version. This may also occur with an optional dependency that is not enabled.                  
```
<!-- Please write a summary of your changes and why you made them.-->

We can re-add when wiring up storage on the ESPs.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
