### PR TITLE
feat(debug)!: drop support for print

### DIFF
--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -1,10 +1,11 @@
 #![no_main]
 #![no_std]
 
-use ariel_os::debug::log::*;
+use ariel_os::debug::{log::*, println};
 
 #[ariel_os::task(autostart)]
 async fn main() {
+    println!("-- this is printed via `println!()`");
     trace!("-- trace log level enabled");
     debug!("-- debug log level enabled");
     info!("-- info log level enabled");

--- a/src/ariel-os-debug-log/src/lib.rs
+++ b/src/ariel-os-debug-log/src/lib.rs
@@ -117,6 +117,19 @@ mod log_macros {
             }
         }};
     }
+
+    /// Prints to the debug output, with a newline.
+    #[macro_export]
+    macro_rules! println {
+        ($($arg:tt)*) => {{
+            use $crate::defmt::hidden::defmt;
+            if true {
+                defmt::println!($($arg)*);
+            } else {
+                drop(format_args!($($arg)*));
+            }
+        }};
+    }
 }
 
 #[cfg(feature = "log")]

--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -64,7 +64,11 @@ pub fn exit(code: ExitCode) {
 
 #[cfg(all(feature = "debug-console", feature = "rtt-target"))]
 mod backend {
-    pub use rtt_target::{rprint as print, rprintln as println};
+    #[cfg(not(feature = "defmt"))]
+    pub use rtt_target::rprintln as println;
+
+    #[cfg(not(feature = "defmt"))]
+    pub use defmt::println;
 
     #[doc(hidden)]
     pub fn init() {
@@ -85,11 +89,6 @@ mod backend {
                 up: {
                     0: {
                         size: 1024,
-                        mode: NoBlockTrim,
-                        name: "Terminal"
-                    }
-                    1: {
-                        size: 1024,
                         mode: NoBlockSkip,
                         // probe-run autodetects whether defmt is in use based on this channel name
                         name: "defmt"
@@ -97,15 +96,14 @@ mod backend {
                 }
             };
 
-            rtt_target::set_print_channel(channels.up.0);
-            rtt_target::set_defmt_channel(channels.up.1);
+            rtt_target::set_defmt_channel(channels.up.0);
         }
     }
 }
 
 #[cfg(all(feature = "debug-console", feature = "esp-println"))]
 mod backend {
-    pub use esp_println::{print, println};
+    pub use esp_println::println;
 
     #[doc(hidden)]
     pub fn init() {
@@ -122,17 +120,6 @@ mod backend {
     /// Prints to the debug output, with a newline.
     #[macro_export]
     macro_rules! println {
-        ($($arg:tt)*) => {{
-            let _ = ($($arg)*);
-            // Do nothing
-        }};
-    }
-
-    /// Prints to the debug output.
-    ///
-    /// Equivalent to the [`println!`] macro except that a newline is not printed at the end of the message.
-    #[macro_export]
-    macro_rules! print {
         ($($arg:tt)*) => {{
             let _ = ($($arg)*);
             // Do nothing

--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -67,8 +67,8 @@ mod backend {
     #[cfg(not(feature = "defmt"))]
     pub use rtt_target::rprintln as println;
 
-    #[cfg(not(feature = "defmt"))]
-    pub use defmt::println;
+    #[cfg(feature = "defmt")]
+    pub use ariel_os_debug_log::println;
 
     #[doc(hidden)]
     pub fn init() {
@@ -84,11 +84,12 @@ mod backend {
 
         #[cfg(feature = "defmt")]
         {
-            use rtt_target::ChannelMode::{NoBlockSkip, NoBlockTrim};
+            use rtt_target::ChannelMode::NoBlockSkip;
+            const DEFMT_BUFFER_SIZE: usize = 1024;
             let channels = rtt_target::rtt_init! {
                 up: {
                     0: {
-                        size: 1024,
+                        size: DEFMT_BUFFER_SIZE,
                         mode: NoBlockSkip,
                         // probe-run autodetects whether defmt is in use based on this channel name
                         name: "defmt"


### PR DESCRIPTION
# Description

We were not using that (internally) at all. It required us to keep the extra rtt channel in the defmt case. Without that we instantly save 1Kib RAM, which is absolutely necessary for the smaller MCUs.

This is a breaking change obviously.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
