### PR TITLE
feat(build): introduce `ram-tiny` laze module

### DIFF
--- a/examples/threading-channel/laze.yml
+++ b/examples/threading-channel/laze.yml
@@ -2,3 +2,7 @@ apps:
   - name: threading-channel
     selects:
       - sw/threading
+    conflicts:
+      # This example uses five threads with the default stack size of 2KiB,
+      # which is too much for the smallest MCUs.
+      - ram-tiny

--- a/examples/threading-event/laze.yml
+++ b/examples/threading-event/laze.yml
@@ -4,3 +4,7 @@ apps:
       - sw/threading
       - "context::stm32c031c6":
           - too-little-memory
+    conflicts:
+      # This example uses five threads with the default stack size of 2KiB,
+      # which is too much for the smallest MCUs.
+      - ram-tiny

--- a/examples/threading/src/main.rs
+++ b/examples/threading/src/main.rs
@@ -9,7 +9,7 @@ fn thread0() {
 }
 
 // `stacksize` and `priority` can be arbitrary expressions.
-#[ariel_os::thread(autostart, stacksize = 2048, priority = 2)]
+#[ariel_os::thread(autostart, stacksize = 512, priority = 2)]
 fn thread1() {
     info!("Hello from thread 1");
 }

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -745,6 +745,20 @@ modules:
           - -Clink-arg=-Tkeep-stack-sizes.x
           - -Z emit-stack-sizes
 
+  - name: ram-tiny
+    help: This module marks boards with very little RAM (currently, <10KiB)
+    conflicts:
+      # disabling alloc until we have a usable use case
+      - alloc
+      # disabling as the default stack sizes are too small for log (defmt works)
+      - log
+      # disabling until we do have a driver/stack combo that works
+      - network
+    env:
+      global:
+        isr_stacksize_required_default: "512"
+        executor_stacksize_required_default: "512"
+
   - name: stable
     help: build with stable Rust
     provides_unique:

--- a/tests/benchmarks/bench_sched_flags/laze.yml
+++ b/tests/benchmarks/bench_sched_flags/laze.yml
@@ -3,3 +3,5 @@ apps:
     selects:
       - sw/threading
       - sw/benchmark
+    conflicts:
+      - ram-tiny

--- a/tests/benchmarks/bench_sched_yield/laze.yml
+++ b/tests/benchmarks/bench_sched_yield/laze.yml
@@ -3,3 +3,5 @@ apps:
     selects:
       - sw/threading
       - sw/benchmark
+    conflicts:
+      - ram-tiny

--- a/tests/threading-dynamic-prios/laze.yml
+++ b/tests/threading-dynamic-prios/laze.yml
@@ -3,3 +3,5 @@ apps:
     selects:
       - single-core
       - sw/threading
+    conflicts:
+      - ram-tiny

--- a/tests/threading-lock/laze.yml
+++ b/tests/threading-lock/laze.yml
@@ -5,3 +5,5 @@ apps:
       - sw/threading
       - "context::stm32c031c6":
           - too-little-memory
+    conflicts:
+      - ram-tiny

--- a/tests/threading-mutex/laze.yml
+++ b/tests/threading-mutex/laze.yml
@@ -6,3 +6,5 @@ apps:
       - sw/threading
       - "context::stm32c031c6":
           - too-little-memory
+    conflicts:
+      - ram-tiny


### PR DESCRIPTION
# Description

This PR adds a module bundling tiny RAM requirements.
I started this for #1050, in combination with this ram-tiny, the st-nucleo-f042k6 builds fine.

As we currently don't have a way to filter builds by actually available / used RAM, this is just an arbitrary set of `small ram settings`.

E.g., when not using log but defmt, the stack requirements go way down.
Or, currently there's no network stack / driver combo that works with little ram devices.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages, but please make sure that
the commit history is clear and informative.
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
