### PR TITLE
docs(stm32): add STM32WBA55CG to the support matrix

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -309,6 +309,23 @@ chips:
           - removing items not supported
       wifi: not_available
 
+  stm32wba55cg:
+    name: STM32WBA55CG
+    support:
+      gpio: supported
+      debug_output: supported
+      hwrng: supported
+      i2c_controller: not_currently_supported
+      spi_main: not_currently_supported
+      logging: supported
+      storage:
+        status: not_currently_supported
+        comments:
+          - removing items not supported
+      wifi: not_available
+      user_usb: not_available
+      ethernet_over_usb: not_available
+
 # Encodes support status for each board.
 # Boards inherit support statuses of their chip, but can also override them.
 boards:
@@ -490,6 +507,13 @@ boards:
       user_usb: supported
       wifi: not_available
       ethernet_over_usb: supported
+
+  st-nucleo-wba55:
+    name: ST NUCLEO-WBA55CG
+    url: https://web.archive.org/web/20240803070523/https://www.st.com/en/evaluation-tools/nucleo-wba55cg.html
+    chip: stm32wba55cg
+    tier: "3"
+    support:
 
   stm32u083c-dk:
     name: STM32U083C-DK


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Support for the Nucleo STM32WBA55 board was added in #782 and #783. This PR adds this board to the support matrix.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Closes #785.
Depends on #1057.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
