### PR TITLE
feat(stm32): Add a somewhat sane clock configuration for STM32F042K6

### DIFF
--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -220,6 +220,21 @@ fn board_config(config: &mut Config) {
         config.rcc.mux.clk48sel = mux::Clk48sel::HSI48;
     }
 
+    #[cfg(context = "stm32f042k6")]
+    {
+        use embassy_stm32::rcc::*;
+
+        config.rcc.hsi48 = Some(Hsi48Config {
+            sync_from_usb: true,
+        }); // needed for USB
+        config.rcc.sys = Sysclk::HSI48;
+        config.rcc.pll = Some(Pll {
+            src: PllSource::HSI48,
+            prediv: PllPreDiv::DIV2,
+            mul: PllMul::MUL2,
+        });
+    }
+
     // mark used
     let _ = config;
 }


### PR DESCRIPTION
# Description

This adds a default clock configuration to the STM32F042K6 chip which works better than the default, with the OotB defaults e.g. I2C doesn't work.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
