### PR TITLE
feat(nrf): Add support for BBC micro:bit v1

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -53,8 +53,8 @@ functionalities:
 
 # Encodes support status for each chip.
 chips:
-  nrf51822:
-    name: nRF51822
+  nrf51822-xxaa:
+    name: nRF51822_xxAA
     support:
       gpio: supported
       debug_output: supported
@@ -358,7 +358,7 @@ boards:
   bbc-microbit-v1:
     name: BBC micro:bit V1
     url: https://web.archive.org/web/20250109121140/https://microbit.org/get-started/features/overview/#original-micro:bit
-    chip: nrf51822
+    chip: nrf51822-xxaa
     support:
       user_usb: not_available
       ethernet_over_usb: not_available

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -64,6 +64,8 @@ chips:
       logging: supported
       storage: not_currently_supported
       wifi: not_available
+      user_usb: not_available
+      ethernet_over_usb: not_available
 
   nrf52832:
     name: nRF52832
@@ -361,8 +363,6 @@ boards:
     chip: nrf51822-xxaa
     tier: "3"
     support:
-      user_usb: not_available
-      ethernet_over_usb: not_available
 
   bbc-microbit-v2:
     name: BBC micro:bit V2

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -58,7 +58,7 @@ chips:
     support:
       gpio: supported
       debug_output: supported
-      hwrng: not_currently_supported
+      hwrng: supported
       i2c_controller: not_currently_supported
       spi_main: not_currently_supported
       logging: supported

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -53,6 +53,18 @@ functionalities:
 
 # Encodes support status for each chip.
 chips:
+  nrf51822:
+    name: nRF51822
+    support:
+      gpio: supported
+      debug_output: supported
+      hwrng: not_currently_supported
+      i2c_controller: not_currently_supported
+      spi_main: not_currently_supported
+      logging: supported
+      storage: not_currently_supported
+      wifi: not_available
+
   nrf52832:
     name: nRF52832
     support:

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -359,6 +359,7 @@ boards:
     name: BBC micro:bit V1
     url: https://web.archive.org/web/20250109121140/https://microbit.org/get-started/features/overview/#original-micro:bit
     chip: nrf51822-xxaa
+    tier: "3"
     support:
       user_usb: not_available
       ethernet_over_usb: not_available

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -343,6 +343,14 @@ chips:
 # Encodes support status for each board.
 # Boards inherit support statuses of their chip, but can also override them.
 boards:
+  bbc-microbit-v1:
+    name: BBC micro:bit V1
+    url: https://web.archive.org/web/20250109121140/https://microbit.org/get-started/features/overview/#original-micro:bit
+    chip: nrf51822
+    support:
+      user_usb: not_available
+      ethernet_over_usb: not_available
+
   bbc-microbit-v2:
     name: BBC micro:bit V2
     url: https://web.archive.org/web/20250109121140/https://microbit.org/new-microbit/

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -54,7 +54,7 @@ functionalities:
 # Encodes support status for each chip.
 chips:
   nrf51822-xxaa:
-    name: nRF51822_xxAA
+    name: nRF51822-xxAA
     support:
       gpio: supported
       debug_output: supported

--- a/examples/blinky/laze.yml
+++ b/examples/blinky/laze.yml
@@ -2,6 +2,7 @@ apps:
   - name: blinky
     context:
       # list of contexts that have an entry in `pins.rs`
+      - bbc-microbit-v1
       - bbc-microbit-v2
       - esp
       - nordic-thingy-91-x-nrf9151

--- a/examples/blinky/src/main.rs
+++ b/examples/blinky/src/main.rs
@@ -13,7 +13,7 @@ async fn blinky(peripherals: pins::LedPeripherals) {
     let mut led = Output::new(peripherals.led, Level::Low);
 
     // The micro:bit uses an LED matrix; pull the column line low.
-    #[cfg(context = "bbc-microbit-v2")]
+    #[cfg(any(context = "bbc-microbit-v2", context = "bbc-microbit-v1"))]
     let _led_col1 = Output::new(peripherals.led_col1, Level::Low);
 
     loop {

--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -1,5 +1,11 @@
 use ariel_os::hal::peripherals;
 
+#[cfg(context = "bbc-microbit-v1")]
+ariel_os::hal::define_peripherals!(LedPeripherals {
+    led_col1: P0_04,
+    led: P0_13,
+});
+
 #[cfg(context = "bbc-microbit-v2")]
 ariel_os::hal::define_peripherals!(LedPeripherals {
     led_col1: P0_28,

--- a/examples/gpio/laze.yml
+++ b/examples/gpio/laze.yml
@@ -2,6 +2,7 @@ apps:
   - name: gpio
     context:
       # list of contexts that have an entry in `pins.rs`
+      - bbc-microbit-v1
       - bbc-microbit-v2
       - esp
       - nordic-thingy-91-x-nrf9151

--- a/examples/gpio/src/main.rs
+++ b/examples/gpio/src/main.rs
@@ -22,7 +22,7 @@ async fn blinky(peripherals: pins::Peripherals) {
         .unwrap();
 
     // The micro:bit uses an LED matrix; pull the column line low.
-    #[cfg(context = "bbc-microbit-v2")]
+    #[cfg(any(context = "bbc-microbit-v2", context = "bbc-microbit-v1"))]
     let _led_col1 = Output::new(peripherals.led_col1, Level::Low);
 
     loop {

--- a/examples/gpio/src/pins.rs
+++ b/examples/gpio/src/pins.rs
@@ -6,6 +6,13 @@ ariel_os::hal::define_peripherals!(Peripherals {
     btn1: P0_11
 });
 
+#[cfg(context = "bbc-microbit-v1")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    led_col1: P0_04,
+    led1: P0_13,
+    btn1: P0_17
+});
+
 #[cfg(context = "bbc-microbit-v2")]
 ariel_os::hal::define_peripherals!(Peripherals {
     led_col1: P0_28,

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -205,6 +205,11 @@ contexts:
     provides:
       - has_hwrng
 
+  - name: nrf51822
+    parent: nrf51
+    env:
+      PROBE_RS_CHIP: nrf51822_xxAA
+
   - name: bbc-microbit-base
     # this is a context, not a builder, to be used as parent by  "bbc-microbit" and
     # "bbc-microbit-qemu"
@@ -1518,6 +1523,9 @@ builders:
 
     disables:
       - periph_rtt
+
+  - name: bbc-microbit-v1
+    parent: nrf51822
 
   - name: bbc-microbit-v2
     parent: nrf52833

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -207,6 +207,8 @@ contexts:
 
   - name: nrf51822-xxaa
     parent: nrf51
+    selects:
+      - ram-tiny
     env:
       PROBE_RS_CHIP: nrf51822_xxAA
 
@@ -764,7 +766,7 @@ modules:
           - -Z emit-stack-sizes
 
   - name: ram-tiny
-    help: This module marks boards with very little RAM (currently, <10KiB)
+    help: This module marks boards with very little RAM (currently, <=16KiB)
     conflicts:
       # disabling alloc until we have a usable use case
       - alloc

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -205,7 +205,7 @@ contexts:
     provides:
       - has_hwrng
 
-  - name: nrf51822
+  - name: nrf51822-xxaa
     parent: nrf51
     env:
       PROBE_RS_CHIP: nrf51822_xxAA
@@ -1525,7 +1525,7 @@ builders:
       - periph_rtt
 
   - name: bbc-microbit-v1
-    parent: nrf51822
+    parent: nrf51822-xxaa
 
   - name: bbc-microbit-v2
     parent: nrf52833

--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -29,7 +29,7 @@ ariel-os-debug = { workspace = true }
 ariel-os-embassy-common = { workspace = true }
 ariel-os-random = { workspace = true, optional = true }
 
-[target.'cfg(context = "nrf51822")'.dependencies]
+[target.'cfg(context = "nrf51822-xxaa")'.dependencies]
 embassy-nrf = { workspace = true, features = ["nrf51"] }
 
 [target.'cfg(context = "nrf52832")'.dependencies]

--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -29,6 +29,9 @@ ariel-os-debug = { workspace = true }
 ariel-os-embassy-common = { workspace = true }
 ariel-os-random = { workspace = true, optional = true }
 
+[target.'cfg(context = "nrf51822")'.dependencies]
+embassy-nrf = { workspace = true, features = ["nrf51"] }
+
 [target.'cfg(context = "nrf52832")'.dependencies]
 # Disable NFC support for now, as we do not support it yet.
 embassy-nrf = { workspace = true, features = ["nfc-pins-as-gpio", "nrf52832"] }

--- a/src/ariel-os-nrf/build.rs
+++ b/src/ariel-os-nrf/build.rs
@@ -6,7 +6,9 @@ fn main() {
         return;
     }
 
-    let (ram, flash) = if is_in_current_contexts(&["nrf52832"]) {
+    let (ram, flash) = if is_in_current_contexts(&["nrf51822"]) {
+        (16, 256)
+    } else if is_in_current_contexts(&["nrf52832"]) {
         (64, 256)
     } else if is_in_current_contexts(&["nrf52833"]) {
         (128, 512)
@@ -20,7 +22,9 @@ fn main() {
         panic!("nrf52: please set MCU feature");
     };
 
-    let slot_prefix = if is_in_current_contexts(&["nrf52"]) {
+    let slot_prefix = if is_in_current_contexts(&["nrf51"]) {
+        "NRF51_FLASH"
+    } else if is_in_current_contexts(&["nrf52"]) {
         "NRF52_FLASH"
     } else if is_in_current_contexts(&["nrf5340"]) {
         "NRF5340_FLASH"

--- a/src/ariel-os-nrf/build.rs
+++ b/src/ariel-os-nrf/build.rs
@@ -6,7 +6,7 @@ fn main() {
         return;
     }
 
-    let (ram, flash) = if is_in_current_contexts(&["nrf51822"]) {
+    let (ram, flash) = if is_in_current_contexts(&["nrf51822-xxaa"]) {
         (16, 256)
     } else if is_in_current_contexts(&["nrf52832"]) {
         (64, 256)

--- a/src/ariel-os-nrf/src/lib.rs
+++ b/src/ariel-os-nrf/src/lib.rs
@@ -41,6 +41,10 @@ pub mod usb;
 pub use embassy_executor::InterruptExecutor as Executor;
 
 #[cfg(feature = "executor-interrupt")]
+#[cfg(context = "nrf51")]
+ariel_os_embassy_common::executor_swi!(SWI0);
+
+#[cfg(feature = "executor-interrupt")]
 #[cfg(context = "nrf52")]
 ariel_os_embassy_common::executor_swi!(EGU0_SWI0);
 

--- a/tests/gpio-interrupt-nrf/src/main.rs
+++ b/tests/gpio-interrupt-nrf/src/main.rs
@@ -8,7 +8,17 @@ use ariel_os::{
 };
 
 #[cfg(context = "nrf51")]
-todo!();
+ariel_os::hal::define_peripherals!(ButtonPeripherals {
+    btn_0: P0_00,
+    btn_1: P0_01,
+    btn_2: P0_02,
+    btn_3: P0_03,
+    btn_4: P0_04,
+    btn_5: P0_05,
+    btn_6: P0_06,
+    btn_7: P0_07,
+    btn_8: P0_08,
+});
 
 #[cfg(context = "nrf52")]
 ariel_os::hal::define_peripherals!(ButtonPeripherals {

--- a/tests/gpio/src/pins.rs
+++ b/tests/gpio/src/pins.rs
@@ -1,5 +1,13 @@
 use ariel_os::hal::peripherals;
 
+#[cfg(context = "nrf51")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    pin_0: P0_00,
+    pin_1: P0_01,
+    pin_2: P0_02,
+    pin_3: P0_03,
+});
+
 #[cfg(context = "nrf52")]
 ariel_os::hal::define_peripherals!(Peripherals {
     pin_0: P0_00,


### PR DESCRIPTION
# Description

This adds support for the venerable BBC micro:bit v1.

## Issues/PRs references

None

## Open Questions

None

## Change checklist

- [X] I have cleaned up my commit history and squashed fixup commits.
- [X] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [X] I have performed a self-review of my own code.
- [X] I have made corresponding changes to the documentation.
