### PR TITLE
feat(ble): add public interface for BLE functionality

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,7 @@ jobs:
             --verbose
             --locked
             --features "
+                ble,
                 coap,
                 csprng,
                 dns,
@@ -252,6 +253,7 @@ jobs:
                 -p coapcore \
                 --features "
                     bench,
+                    ble,
                     coap,
                     core-affinity,
                     csprng,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,7 +56,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -292,6 +302,7 @@ dependencies = [
  "portable-atomic",
  "rand_core",
  "static_cell",
+ "trouble-host",
  "usbd-hid",
 ]
 
@@ -308,6 +319,7 @@ dependencies = [
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "fugit",
+ "trouble-host",
 ]
 
 [[package]]
@@ -347,13 +359,16 @@ dependencies = [
  "ariel-os-nrf",
  "ariel-os-rp",
  "ariel-os-stm32",
+ "bt-hci",
  "cfg-if",
  "embassy-executor",
  "embassy-hal-internal",
  "embassy-usb",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
+ "embedded-io 0.6.1",
  "embedded-storage-async",
+ "trouble-host",
 ]
 
 [[package]]
@@ -767,10 +782,12 @@ checksum = "d69c6b9d78fe4db539449fc8782dd2554fd4baee27f6e6dbf2e4757fcbc36139"
 dependencies = [
  "defmt 0.3.100",
  "embassy-sync 0.6.2",
+ "embassy-time",
  "embedded-io 0.6.1",
  "embedded-io-async",
  "futures-intrusive",
  "heapless 0.8.0",
+ "uuid",
 ]
 
 [[package]]
@@ -3546,6 +3563,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "ld-memory"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4247,7 +4270,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -5350,6 +5373,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
+name = "trouble-host"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b31abacc7bd8bc686160f6de3347a3b7669ae4a31e4eef9a306466e97d297cea"
+dependencies = [
+ "bt-hci",
+ "embassy-futures",
+ "embassy-sync 0.6.2",
+ "embassy-time",
+ "embedded-io 0.6.1",
+ "futures",
+ "heapless 0.8.0",
+ "rand_core",
+ "static_cell",
+ "trouble-host-macros",
+ "zerocopy 0.8.25",
+]
+
+[[package]]
+name = "trouble-host-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2798a58a818bdf9d98f5283cc7ac647f11ecbd1e5ff4cdc45a2a13c31bf86fd"
+dependencies = [
+ "Inflector",
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "uuid",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "git+https://github.com/seanmonstar/try-lock?rev=45c39685b56a4dba1b71bdbbbe5f731c3c77dc50#45c39685b56a4dba1b71bdbbbe5f731c3c77dc50"
@@ -5895,7 +5951,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -5903,6 +5968,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,8 @@ rtt-target = { version = "0.6.0" }
 rp-pac = { version = "7.0", default-features = false }
 serde = { version = "1.0.197", default-features = false }
 static_cell = { version = "2.0.0", features = ["nightly"] }
+trouble-host = "0.1"
+bt-hci = { version = "0.2.0" }
 
 [workspace.lints.rust]
 # rustc lints are documented here: https://doc.rust-lang.org/rustc/lints/listing/index.html

--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,7 @@ allow = [
   "0BSD",
   "Apache-2.0",
   "BlueOak-1.0.0",
+  "BSD-2-Clause",
   "BSD-3-Clause",
   "ISC",
   "MIT",

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1082,6 +1082,41 @@ modules:
         FEATURES:
           - ariel-os/usb-ethernet
 
+  - name: ble
+    selects:
+      - hw/ble
+    env:
+      global:
+        FEATURES:
+          - ariel-os/ble
+
+  - name: hw/ble
+    help: provided if a device has a BLE capability
+    selects:
+      - has_ble
+    env:
+      global:
+        RUSTFLAGS:
+          - --cfg capability=\"hw/ble\"
+
+  - name: ble-peripheral
+    help: Enables BLE peripheral functionality
+    selects:
+      - ble
+    env:
+      global:
+        FEATURES:
+          - ariel-os/ble-peripheral
+
+  - name: ble-central
+    help: Enables BLE central functionality
+    selects:
+      - ble
+    env:
+      global:
+        FEATURES:
+          - ariel-os/ble-central
+
   - name: usb
     selects:
       - hw/usb-device-port

--- a/src/ariel-os-embassy-common/Cargo.toml
+++ b/src/ariel-os-embassy-common/Cargo.toml
@@ -18,6 +18,7 @@ embassy-time = { workspace = true }
 embedded-hal = { workspace = true }
 embedded-hal-async = { workspace = true }
 const-sha1 = { version = "0.3.0", default-features = false }
+trouble-host = { workspace = true, optional = true }
 
 [features]
 ## Enables GPIO interrupt support.
@@ -34,3 +35,5 @@ defmt = ["dep:defmt", "fugit?/defmt"]
 executor-thread = []
 
 _test = ["i2c", "spi", "external-interrupts"]
+
+ble = ["dep:trouble-host"]

--- a/src/ariel-os-embassy-common/src/ble.rs
+++ b/src/ariel-os-embassy-common/src/ble.rs
@@ -1,0 +1,18 @@
+//! Common BLE types to be used across different HALs.
+
+/// Configuration for the BLE stack.
+///
+/// You can customize it using the `ble-config-override` feature.
+pub struct Config {
+    /// The address of the BLE device.
+    pub address: trouble_host::Address,
+}
+
+/// Default address, this one is used in the trouBLE examples, needs to be changed/randomized in production.
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            address: trouble_host::Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]),
+        }
+    }
+}

--- a/src/ariel-os-embassy-common/src/lib.rs
+++ b/src/ariel-os-embassy-common/src/lib.rs
@@ -15,6 +15,9 @@ pub mod executor_thread;
 #[cfg(feature = "i2c")]
 pub mod i2c;
 
+#[cfg(feature = "ble")]
+pub mod ble;
+
 pub mod identity;
 
 #[cfg(feature = "spi")]

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -46,6 +46,7 @@ ariel-os-utils = { workspace = true }
 heapless = "0.8.0"
 once_cell = { workspace = true }
 usbd-hid = { version = "0.8.2", optional = true }
+trouble-host = { workspace = true, optional = true }
 
 # ISA-specific
 [target.'cfg(context = "cortex-m")'.dependencies]
@@ -117,10 +118,15 @@ wifi-esp = ["ariel-os-hal/wifi-esp", "net", "wifi"]
 eth = []
 eth-stm32 = ["ariel-os-hal/eth-stm32", "net", "eth"]
 
+ble = ["ariel-os-hal/ble", "dep:trouble-host", "ariel-os-embassy-common/ble"]
+ble-peripheral = ["ble", "ariel-os-hal/ble-peripheral"]
+ble-central = ["ble", "ariel-os-hal/ble-central"]
+
 threading = ["dep:ariel-os-threads", "ariel-os-hal/threading"]
 network-config-static = ["network-config-override"]
 network-config-override = []
 override-usb-config = []
+ble-config-override = []
 
 executor-single-thread = [
   "ariel-os-hal/executor-single-thread",

--- a/src/ariel-os-embassy/src/ble.rs
+++ b/src/ariel-os-embassy/src/ble.rs
@@ -1,0 +1,19 @@
+use ariel_os_embassy_common::ble::Config;
+
+// Must be async and return &trouble_host::Stack<'static, impl Controller>
+pub use crate::hal::ble::ble_stack;
+
+#[allow(dead_code, reason = "false positive during builds outside of laze")]
+pub(crate) fn config() -> Config {
+    #[cfg(not(feature = "ble-config-override"))]
+    {
+        Config::default()
+    }
+    #[cfg(feature = "ble-config-override")]
+    {
+        unsafe extern "Rust" {
+            fn __ariel_os_ble_config() -> Config;
+        }
+        unsafe { __ariel_os_ble_config() }
+    }
+}

--- a/src/ariel-os-hal/Cargo.toml
+++ b/src/ariel-os-hal/Cargo.toml
@@ -33,6 +33,11 @@ embedded-storage-async = { workspace = true }
 
 ariel-os-embassy-common = { workspace = true }
 
+# For ble dummy implementation
+bt-hci = { workspace = true, optional = true }
+embedded-io = { workspace = true, optional = true }
+trouble-host = { workspace = true, optional = true }
+
 [features]
 external-interrupts = [
   "ariel-os-esp/external-interrupts",
@@ -61,6 +66,10 @@ usb = [
   "ariel-os-rp/usb",
   "ariel-os-stm32/usb",
 ]
+
+ble = ["dep:bt-hci", "dep:embedded-io", "dep:trouble-host"]
+ble-peripheral = []
+ble-central = []
 
 hwrng = [
   "ariel-os-esp/hwrng",

--- a/src/ariel-os-hal/src/dummy/ble.rs
+++ b/src/ariel-os-hal/src/dummy/ble.rs
@@ -1,0 +1,77 @@
+use bt_hci::{
+    cmd,
+    controller::{ControllerCmdAsync, ControllerCmdSync},
+};
+use embassy_executor::Spawner;
+
+pub struct Peripherals {}
+
+impl Peripherals {
+    pub fn new(_peripherals: &mut crate::OptionalPeripherals) -> Self {
+        unimplemented!();
+    }
+}
+
+pub async fn ble_stack() -> &'static trouble_host::Stack<'static, DummyController> {
+    async { unimplemented!() }.await
+}
+
+pub fn driver(_p: Peripherals, _spawner: Spawner, _config: ariel_os_embassy_common::ble::Config) {
+    unimplemented!();
+}
+
+pub struct DummyController {}
+
+#[derive(Debug)]
+pub struct DummyError {}
+
+impl embedded_io::Error for DummyError {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        unimplemented!()
+    }
+}
+
+impl embedded_io::ErrorType for DummyController {
+    type Error = DummyError;
+}
+impl bt_hci::controller::Controller for DummyController {
+    async fn write_acl_data(
+        &self,
+        _packet: &bt_hci::data::AclPacket<'_>,
+    ) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+
+    async fn write_sync_data(
+        &self,
+        _packet: &bt_hci::data::SyncPacket<'_>,
+    ) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+
+    async fn write_iso_data(
+        &self,
+        _packet: &bt_hci::data::IsoPacket<'_>,
+    ) -> Result<(), Self::Error> {
+        unimplemented!()
+    }
+
+    async fn read<'a>(
+        &self,
+        _buf: &'a mut [u8],
+    ) -> Result<bt_hci::ControllerToHostPacket<'a>, Self::Error> {
+        unimplemented!()
+    }
+}
+
+impl<C: cmd::AsyncCmd + ?Sized> ControllerCmdAsync<C> for DummyController {
+    async fn exec(&self, _cmd: &C) -> Result<(), cmd::Error<Self::Error>> {
+        unimplemented!();
+    }
+}
+
+impl<C: cmd::SyncCmd + ?Sized> ControllerCmdSync<C> for DummyController {
+    async fn exec(&self, _cmd: &C) -> Result<C::Return, cmd::Error<Self::Error>> {
+        unimplemented!();
+    }
+}

--- a/src/ariel-os-hal/src/dummy/mod.rs
+++ b/src/ariel-os-hal/src/dummy/mod.rs
@@ -24,6 +24,10 @@ pub mod peripheral {
 }
 
 #[doc(hidden)]
+#[cfg(feature = "ble")]
+pub mod ble;
+
+#[doc(hidden)]
 #[cfg(feature = "hwrng")]
 pub mod hwrng;
 

--- a/src/ariel-os-macros/src/config.rs
+++ b/src/ariel-os-macros/src/config.rs
@@ -9,10 +9,11 @@
 ///
 /// - The name of the driver the constant provides configuration for.
 ///
-/// | Driver    | Expected type                  | Cargo feature to enable   |
-/// | --------- | ------------------------------ | ------------------------- |
-/// | `network` | `embassy_net::Config`          | `network-config-override` |
-/// | `usb`     | `embassy_usb::Config`          | `override-usb-config`     |
+/// | Driver    | Expected type                     | Cargo feature to enable   |
+/// | --------- | --------------------------------- | ------------------------- |
+// | `ble`     | `ariel_os::reexport::ble::Config` | `ble-config-override`     |
+/// | `network` | `embassy_net::Config`             | `network-config-override` |
+/// | `usb`     | `embassy_usb::Config`             | `override-usb-config`     |
 ///
 /// # Note
 ///
@@ -58,6 +59,10 @@ pub fn config(args: TokenStream, item: TokenStream) -> TokenStream {
     let ariel_os_crate = utils::ariel_os_crate();
 
     let (config_fn_name, return_type) = match attrs.kind {
+        // Some(ConfigKind::Ble) => (
+        //     format_ident!("__ariel_os_ble_config"),
+        //     quote! {#ariel_os_crate::reexports::ble::Config},
+        // ),
         Some(ConfigKind::Network) => (
             format_ident!("__ariel_os_network_config"),
             quote! {#ariel_os_crate::reexports::embassy_net::Config},
@@ -134,6 +139,7 @@ mod config_macro {
 
     #[derive(Debug, enum_iterator::Sequence)]
     pub enum ConfigKind {
+        // Ble,
         Network,
         Usb,
     }
@@ -141,6 +147,7 @@ mod config_macro {
     impl ConfigKind {
         pub fn as_name(&self) -> &'static str {
             match self {
+                // Self::Ble => "ble",
                 Self::Network => "network",
                 Self::Usb => "usb",
             }

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -110,6 +110,8 @@ usb-hid = ["ariel-os-embassy/usb-hid"]
 #! specific system functionality.
 #! The features below need to be enabled so that the provided custom
 #! configuration is taken into account.
+# Enables custom BLE configuration.
+ble-config-override = ["ariel-os-embassy/ble-config-override"]
 ## Enables custom network configuration.
 network-config-override = ["ariel-os-embassy/network-config-override"]
 ## Enables custom USB configuration.
@@ -138,6 +140,13 @@ wifi-cyw43 = ["ariel-os-embassy/wifi-cyw43"]
 wifi-esp = ["ariel-os-embassy/wifi-esp"]
 # Selects STM32 Ethernet
 eth-stm32 = ["ariel-os-embassy/eth-stm32"]
+
+# ## Bluetooth support
+ble = ["ariel-os-embassy/ble"]
+# Enables BLE to act as a peripheral. Can be used in conjunction with `ble-central`.
+ble-peripheral = ["ble", "ariel-os-embassy/ble-peripheral"]
+# Enables BLE to act as a central. Can be used in conjunction with `ble-peripheral`.
+ble-central = ["ble", "ariel-os-embassy/ble-central"]
 
 #! ## Development and debugging
 # Enables the debug console, required to use


### PR DESCRIPTION
# Description

This PR adds the public interface to access the TrouBLE stack, an example is provided to show how to use it

## Issues/PRs references

This is a step towards #560. 

## Open Questions

Does the book page about BLE need to be in this PR or should it be a separate one ? 

At this time the public API lacks some features:

- [x] ~~There needs to be a way to switch between peripheral and central mode.~~
- [x] ~~A way to change the address.~~
- A way to customize the MTU, though 27 is probably fine.

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
