### PR TITLE
docs(README): add missing `i2c-scanner`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ This directory contains example applications that showcase how to use Ariel OS.
 - [hello-world-threading/](./hello-world-threading): A classic, using a thread
 - [http-client/](./http-client): HTTP client example
 - [http-server/](./http-server): HTTP server example
+- [i2c-scanner/](./i2c-scanner): I2C bus scanner
 - [log](./log): Example demonstrating different log levels for printing feedback messages.
 - [minimal/](./minimal): Minimized to the max Ariel OS config
 - [power/](./power): Demonstrates power management functionality


### PR DESCRIPTION
# Description

The link to the examples readme was missing in #1071, this PR adds it.

## Issues/PRs references

follow-up to #1071

## Open Questions


## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
