### PR TITLE
docs: Add link to contributing guide to GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -45,7 +45,7 @@ This privilege is granted with some expectation of responsibility: team members 
 
 ### Contributors
 
-Anyone can contribute to the Ariel OS project, for example via comments on issues or pull requests, writing code or documentation etc. 
+Anyone can contribute to the Ariel OS project, for example via comments on issues or pull requests, writing code or documentation etc. For more explanation on how to contribute to this project, please have a look at our [contributing guide](https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md). 
 
 
 ## Getting involved


### PR DESCRIPTION
# Description

Governance document: added a sentence with reference to the contribution guide under the "Contributors" section.

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
