### PR TITLE
docs(config)!: remove the `network-config-static` feature from the docs

### DIFF
--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -66,7 +66,7 @@ csprng = ["dep:ariel-os-random", "ariel-os-random?/csprng"]
 # Enables seeding the random number generator from hardware.
 hwrng = ["ariel-os-embassy/hwrng"]
 
-#! ## Network protocols and configuration
+#! ## Network protocols
 ## Enables support for TCP.
 tcp = ["ariel-os-embassy/tcp"]
 ## Enables support for UDP.
@@ -92,7 +92,7 @@ coap-server-config-unprotected = [
 # build system that knows who provides an abort and assert handler.
 liboscore-provide-abort = ["ariel-os-coap/liboscore-provide-abort"]
 liboscore-provide-assert = ["ariel-os-coap/liboscore-provide-assert"]
-## Selects static IP configuration.
+# Selects static IP configuration.
 network-config-static = ["ariel-os-embassy/network-config-static"]
 
 #! ## Serial communication


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Users must use the laze module of the same name instead.

This is needed for #915, as we need to be able to separately choose to provide *static* configuration for IPv4 and/or IPv6.

BREAKING CHANGE: this removes a Cargo feature from the documentation.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Should likely have been part of #737.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
