### PR TITLE
fix(rp235x): fix non-deterministic panics at startup when using the TRNG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,7 +1786,7 @@ dependencies = [
 [[package]]
 name = "embassy-rp"
 version = "0.4.0"
-source = "git+https://github.com/ariel-os/embassy?branch=embassy-rp-v0.4.0%2Bariel-os#dab783fcee77ed024728de37a2ea4cb26de7d01c"
+source = "git+https://github.com/ariel-os/embassy?branch=embassy-rp-v0.4.0%2Bariel-os%2Btrng-panic-fix#1dd58227a73efa8da2aef96aaccf17b8749b9f7b"
 dependencies = [
  "atomic-polyfill",
  "cfg-if",

--- a/ariel-os-cargo.toml
+++ b/ariel-os-cargo.toml
@@ -23,7 +23,7 @@ embassy-executor-macros = { git = "https://github.com/ariel-os/embassy", branch 
 embassy-hal-internal = { git = "https://github.com/ariel-os/embassy", branch = "embassy-hal-internal-v0.2.0+ariel-os" }
 embassy-nrf = { git = "https://github.com/ariel-os/embassy", branch = "embassy-nrf-v0.3.1+ariel-os" }
 embassy-net = { git = "https://github.com/ariel-os/embassy", branch = "embassy-net-v0.6.0+ariel-os" }
-embassy-rp = { git = "https://github.com/ariel-os/embassy", branch = "embassy-rp-v0.4.0+ariel-os" }
+embassy-rp = { git = "https://github.com/ariel-os/embassy", branch = "embassy-rp-v0.4.0+ariel-os+trng-panic-fix" }
 embassy-stm32 = { git = "https://github.com/ariel-os/embassy", branch = "embassy-stm32-v0.2.0+ariel-os" }
 
 # ariel-os esp-hal fork


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Fixes a non-deterministic issue when using the TRNG on an RP235x, introduced when adding support for that TRNG in #1077. The issue was present upstream, but fixed since our last fork update. This backports the fix from https://github.com/embassy-rs/embassy/pull/4139 in our Embassy fork (one single commit), and use that new fork branch for `embassy-rp`.

There were some conflicts when cherry-picking the fix, as Embassy has reworked how they handle peripherals in the meantime (`Peripheral` → `Peri`).

## How to review this PR

Without this fix, the `random` example *sometimes* panics at startup on rpi-pico2(-w), with the following error (happens abount once every three runs in my testing, YMMV):

```
[ERROR] panicked at 'RNG not busy, but ehr is not valid!'
```

With this fix, that example does not panic anymore (tested successfully about two dozens of times).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
