### PR TITLE
feat(ble): support BLE on nrf5340 network core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3890,7 +3890,7 @@ checksum = "b3c12edfda65fe16901d81d3bd93fd18ac07078b5007875a1c3b0d35f7725269"
 [[package]]
 name = "nrf-mpsl"
 version = "0.1.0"
-source = "git+https://github.com/alexmoon/nrf-sdc.git?rev=551a95436e999b4290b4a33383aa3d6747b63dd9#551a95436e999b4290b4a33383aa3d6747b63dd9"
+source = "git+https://github.com/ariel-os/nrf-sdc.git?rev=8ce4780b691ec6850b05a0382cef395846b67e02#8ce4780b691ec6850b05a0382cef395846b67e02"
 dependencies = [
  "cortex-m",
  "defmt 0.3.100",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "nrf-mpsl-sys"
 version = "0.1.0"
-source = "git+https://github.com/alexmoon/nrf-sdc.git?rev=551a95436e999b4290b4a33383aa3d6747b63dd9#551a95436e999b4290b4a33383aa3d6747b63dd9"
+source = "git+https://github.com/ariel-os/nrf-sdc.git?rev=8ce4780b691ec6850b05a0382cef395846b67e02#8ce4780b691ec6850b05a0382cef395846b67e02"
 dependencies = [
  "bindgen",
  "doxygen-rs",
@@ -3924,7 +3924,7 @@ dependencies = [
 [[package]]
 name = "nrf-sdc"
 version = "0.1.0"
-source = "git+https://github.com/alexmoon/nrf-sdc.git?rev=551a95436e999b4290b4a33383aa3d6747b63dd9#551a95436e999b4290b4a33383aa3d6747b63dd9"
+source = "git+https://github.com/ariel-os/nrf-sdc.git?rev=8ce4780b691ec6850b05a0382cef395846b67e02#8ce4780b691ec6850b05a0382cef395846b67e02"
 dependencies = [
  "bt-hci",
  "critical-section",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "nrf-sdc-sys"
 version = "0.1.0"
-source = "git+https://github.com/alexmoon/nrf-sdc.git?rev=551a95436e999b4290b4a33383aa3d6747b63dd9#551a95436e999b4290b4a33383aa3d6747b63dd9"
+source = "git+https://github.com/ariel-os/nrf-sdc.git?rev=8ce4780b691ec6850b05a0382cef395846b67e02#8ce4780b691ec6850b05a0382cef395846b67e02"
 dependencies = [
  "bindgen",
  "doxygen-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ serde = { version = "1.0.197", default-features = false }
 static_cell = { version = "2.1.1", default-features = false }
 trouble-host = "0.1"
 bt-hci = { version = "0.2.0" }
-nrf-sdc = { git = "https://github.com/alexmoon/nrf-sdc.git", rev = "551a95436e999b4290b4a33383aa3d6747b63dd9" }
+nrf-sdc = { git = "https://github.com/ariel-os/nrf-sdc.git", rev = "8ce4780b691ec6850b05a0382cef395846b67e02" }
 
 [workspace.lints.rust]
 # rustc lints are documented here: https://doc.rust-lang.org/rustc/lints/listing/index.html

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -291,6 +291,7 @@ contexts:
       - cortex-m33
     provides:
       - has_hwrng
+      - has_nrf_ble
       # Currently hard-faults.
       # - has_storage_support
     disables:
@@ -1166,6 +1167,7 @@ modules:
     help: Marks an incompatibility of nrf devices with the interrupt executor (MPSL crashing)
     context:
       - nrf52
+      - nrf53
     selects:
       - hwrng
     provides:

--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -60,6 +60,7 @@ embassy-nrf = { workspace = true, features = [
 
 [target.'cfg(context = "nrf5340-net")'.dependencies]
 embassy-nrf = { workspace = true, features = ["nrf5340-net"] }
+nrf-sdc = { workspace = true, features = ["nrf5340-net"], optional = true }
 
 [target.'cfg(context = "nrf9151")'.dependencies]
 embassy-nrf = { workspace = true, features = ["nrf9151-s"] }

--- a/src/ariel-os-nrf/src/irqs.rs
+++ b/src/ariel-os-nrf/src/irqs.rs
@@ -24,8 +24,8 @@ bind_interrupts!(pub(crate) struct Irqs {
     // SWI0 is used for the executor interrupt
     #[cfg(all(feature = "ble", context = "nrf52"))]
     EGU1_SWI1 => nrf_sdc::mpsl::LowPrioInterruptHandler;
-    #[cfg(all(feature = "ble", context = "nrf5340"))]
-    EGU1 => nrf_sdc::mpsl::LowPrioInterruptHandler;
+    #[cfg(all(feature = "ble", context = "nrf53"))]
+    EGU0 => nrf_sdc::mpsl::LowPrioInterruptHandler;
 
     #[cfg(feature = "ble")]
     RADIO => nrf_sdc::mpsl::HighPrioInterruptHandler;


### PR DESCRIPTION
# Description

This PR adds BLE support for the nrf5340 MCU, the BLE stack needs to run on the network core.

To avoid the need to upgrade embassy, I made a fork in [ariel-os/nrf-sdc, branch nrf-sdc-nrf53-backport](https://github.com/ariel-os/nrf-sdc/tree/nrf-sdc-nrf53-backport) where I selected the commits relevant to the support of the nRF5340 and adapted it to the previous embassy peripheral model.

## Issues/PRs references

- Depends on #1072
- Depends on #1074 
- Depends on #1102
- Linked to #560   

## Open Questions

How does the review process for a fork work ?

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.