### PR TITLE
feat(nrf53-net): add hwrng support

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -271,8 +271,9 @@ contexts:
     selects:
       - cortex-m33
     provides:
-    # Currently hard-faults.
-    # - has_storage_support
+      - has_hwrng
+      # Currently hard-faults.
+      # - has_storage_support
     disables:
       # USB peripheral available only on app core
       - usb

--- a/src/ariel-os-nrf/src/hwrng.rs
+++ b/src/ariel-os-nrf/src/hwrng.rs
@@ -6,7 +6,7 @@ pub fn construct_rng(peripherals: &mut crate::OptionalPeripherals) {
     cfg_if::cfg_if! {
         // The union of all contexts that wind up in a construct_rng should be synchronized
         // with laze-project.yml's hwrng module.
-        if #[cfg(any(context = "nrf51", context = "nrf52"))] {
+        if #[cfg(any(context = "nrf51", context = "nrf52", context = "nrf5340-net"))] {
             let rng = embassy_nrf::rng::Rng::new(
                 peripherals
                     .RNG


### PR DESCRIPTION
# Description

This adds hwrng support for the nrf5340-net core. I don't have the hardware to test it out.
It seems that the nrf5340 app core doesn't have a (regular) random number generator available.

No errors when building with `laze build -g -b nrf5340dk-net` and `laze build -g -b nrf5340dk`   

## Issues/PRs references

~~Depends on #1072~~

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
