### PR TITLE
fix(nrf5340-net): remove USB capability

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1650,8 +1650,6 @@ builders:
 
   - name: nrf5340dk-net
     parent: nrf5340-net
-    provides:
-      - has_usb_device_port
 
   - name: st-nucleo-c031c6
     parent: stm32c031c6


### PR DESCRIPTION
# Description

The nRF5340 network core does not have access to the USB (see reference manual section 6.3.2), USB is also feature gated in embassy-nrf to only be available on the application core.

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
