### PR TITLE
fix(deps): disable static cell `nightly` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ rtt-target = { version = "0.6.0" }
 
 rp-pac = { version = "7.0", default-features = false }
 serde = { version = "1.0.197", default-features = false }
-static_cell = { version = "2.0.0", features = ["nightly"] }
+static_cell = { version = "2.0.0", default-features = false }
 trouble-host = "0.1"
 bt-hci = { version = "0.2.0" }
 


### PR DESCRIPTION
# Description

In 2.1.1 the `nightly` feature of `static_cell` changed to require a nightly toolchain to compile, making it fail on stable.

We don't use features behind the `nightly` feature anymore, this PR removes the dependency.

## Issues/PRs references

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
