### PR TITLE
feat(build): pass through task arguments where useful

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1,4 +1,4 @@
-laze_required_version: 0.1.33
+laze_required_version: 0.1.37
 
 contexts:
   # base context that all other contexts inherit from
@@ -124,64 +124,64 @@ contexts:
       exec:
         build: false
         cmd:
-          - ${CARGO_PRESHELL} ${CARGO_ENV}
+          - ${CARGO_PRESHELL} ${CARGO_ENV} $@
 
       cargo:
         workdir: ${relpath}
         cmd:
-          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS}
+          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} $@
         build: false
 
       run:
         build: false
         workdir: ${appdir}
         cmd:
-          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --profile=${PROFILE} ${FEATURES}
+          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --profile=${PROFILE} ${FEATURES} $@
 
       clippy:
         build: false
         workdir: ${appdir}
         cmd:
-          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} clippy ${FEATURES}
+          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} clippy ${FEATURES} $@
 
       expand:
         build: false
         workdir: ${appdir}
         cmd:
-          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} expand ${FEATURES}
+          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} expand ${FEATURES} $@
 
       debug:
         workdir: ${appdir}
         cmd:
-          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --profile=${PROFILE} ${FEATURES}
+          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} run --profile=${PROFILE} ${FEATURES} $@
         build: false
         ignore_ctrl_c: true
 
       gdb:
         cmd:
-          - arm-none-eabi-gdb -ex "target extended-remote localhost:1337" ${out}
+          - arm-none-eabi-gdb -ex "target extended-remote localhost:1337" ${out} $@
         build: false
         ignore_ctrl_c: true
 
       bloat:
         workdir: ${appdir}
         cmd:
-          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} bloat --profile=${PROFILE} ${FEATURES}
+          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} bloat --profile=${PROFILE} ${FEATURES} $@
         build: false
 
       tree:
         workdir: ${appdir}
         cmd:
-          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} tree ${FEATURES}
+          - ${CARGO_PRESHELL} ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} tree ${FEATURES} $@
         build: false
 
       size:
         cmd:
-          - llvm-size ${out}
+          - llvm-size ${out} $@
 
       objdump:
         cmd:
-          - rust-objdump -S ${out}
+          - rust-objdump -S ${out} $@
 
       info-boards:
         build: false
@@ -329,7 +329,7 @@ contexts:
     tasks:
       debug-rs:
         cmd:
-          - probe-rs debug --chip ${PROBE_RS_CHIP} --exe ${out}
+          - probe-rs debug --chip ${PROBE_RS_CHIP} --exe ${out} $@
 
   - name: rp235xa
     parent: rp
@@ -348,7 +348,7 @@ contexts:
     tasks:
       flash:
         cmd:
-          - picotool load -u -v -x -t elf ${out}
+          - picotool load -u -v -x -t elf ${out} $@
 
   - name: esp
     parent: ariel-os
@@ -965,23 +965,23 @@ modules:
         help: Erases the whole chip including user data. Unlocks it if locked.
         build: false
         cmd:
-          - probe-rs erase --chip ${PROBE_RS_CHIP} --allow-erase-all
+          - probe-rs erase --chip ${PROBE_RS_CHIP} --allow-erase-all $@
 
       flash:
         help: Flashes the target using probe-rs
         cmd:
-          - probe-rs download --chip ${PROBE_RS_CHIP} ${out}
+          - probe-rs download --chip ${PROBE_RS_CHIP} ${out} $@
           - probe-rs reset --chip ${PROBE_RS_CHIP}
 
       debug:
         help: Starts a probe-rs gdb server
         cmd:
-          - probe-rs gdb --chip ${PROBE_RS_CHIP}
+          - probe-rs gdb --chip ${PROBE_RS_CHIP} $@
 
       reset:
         help: Resets the target
         cmd:
-          - probe-rs reset --chip ${PROBE_RS_CHIP}
+          - probe-rs reset --chip ${PROBE_RS_CHIP} $@
 
   - name: openocd
     tasks:
@@ -1471,7 +1471,7 @@ modules:
         build: false
         workdir: ${appdir}
         cmd:
-          - ${CARGO} test --features _test
+          - ${CARGO} test --features _test $@
 
   - name: embedded-test
     context: ariel-os
@@ -1484,7 +1484,7 @@ modules:
       test:
         workdir: ${appdir}
         cmd:
-          - ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} test ${FEATURES}
+          - ${CARGO_ENV} ${CARGO} ${CARGO_TOOLCHAIN} ${CARGO_ARGS} test ${FEATURES} $@
         build: false
 
     env:
@@ -1553,7 +1553,7 @@ builders:
         cmd:
           - echo "Installing c2rust..."
           - 'echo "WARNING: This uses *a lot* of memory!"'
-          - cargo install c2rust
+          - cargo install c2rust $@
 
   - name: nrf52dk
     parent: nrf52832
@@ -1590,7 +1590,7 @@ builders:
       qemu:
         build: true
         cmd:
-          - ${QEMU_SYSTEM_ARM} ${out}
+          - ${QEMU_SYSTEM_ARM} ${out} $@
 
     disables:
       - periph_rtt


### PR DESCRIPTION
# Description

This wires up passing through task arguments in our laze tasks.

This worked before laze 0.1.36 b/c any extra args were implicitly passed through, which was an undocumented laze feature. Current laze 0.1.37 now has proper (but still undocumented :innocent:) handlilng for this, allowing multi-cmd tasks to only pass through the extra args where desired.

This requires updating laze to at least version 0.1.37.

Try with e.g., `laze build -b nrf52840dk size`, then the same but appending `-A` to change the output mode of `size`.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
