### PR TITLE
fix(coapcore): restore functionality of `log` feature

### DIFF
--- a/src/lib/coapcore/src/ace.rs
+++ b/src/lib/coapcore/src/ace.rs
@@ -28,7 +28,7 @@ const MAX_SUPPORTED_ENCRYPT_PROTECTED_LEN: usize = 32;
 /// Full attribute references are in the [OAuth Parameters CBOR Mappings
 /// registry](https://www.iana.org/assignments/ace/ace.xhtml#oauth-parameters-cbor-mappings).
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(minicbor::Decode, minicbor::Encode, Default)]
+#[derive(minicbor::Decode, minicbor::Encode, Default, Debug)]
 #[cbor(map)]
 #[non_exhaustive]
 struct AceCbor<'a> {
@@ -58,7 +58,7 @@ type UnprotectedAuthzInfoPost<'a> = AceCbor<'a>;
 /// Full attribute references are in the [COSE Header Parameters
 /// registry](https://www.iana.org/assignments/cose/cose.xhtml#header-parameters).
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(minicbor::Decode)]
+#[derive(minicbor::Decode, Debug)]
 #[cbor(map)]
 #[non_exhaustive]
 pub struct HeaderMap<'a> {
@@ -112,7 +112,7 @@ pub(crate) struct CoseKey<'a> {
 
 /// A `COSE_Encrypt0` structure as defined in [RFC8152](https://www.rfc-editor.org/rfc/rfc8152)
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(minicbor::Decode)]
+#[derive(minicbor::Decode, Debug)]
 #[cbor(tag(16))]
 #[non_exhaustive]
 struct CoseEncrypt0<'a> {
@@ -170,7 +170,7 @@ impl CoseEncrypt0<'_> {
         let mut aad_encoded = heapless::Vec::<u8, AADSIZE>::new();
         minicbor::encode(&aad, minicbor_adapters::WriteToHeapless(&mut aad_encoded))
             .map_err(|_| CredentialErrorDetail::ConstraintExceeded)?;
-        trace!("Serialized AAD: {:02x}", aad_encoded); // :02x could be :cbor
+        trace!("Serialized AAD: {:?}", aad_encoded); // :? could go through something like ariel_os_debug_log::Cbor
 
         buffer.clear();
         // Copying around is not a constraint of this function (well that too but that could
@@ -192,7 +192,7 @@ type EncryptedCwt<'a> = CoseEncrypt0<'a>;
 
 /// A `COSE_Sign1` structure as defined in [RFC8152](https://www.rfc-editor.org/rfc/rfc8152)
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[derive(minicbor::Decode)]
+#[derive(minicbor::Decode, Debug)]
 #[cbor(tag(18))]
 #[non_exhaustive]
 struct CoseSign1<'a> {
@@ -427,7 +427,7 @@ pub(crate) fn process_acecbor_authz_info<GC: crate::GeneralClaims>(
     nonce2: [u8; OWN_NONCE_LEN],
     server_recipient_id: impl FnOnce(&[u8]) -> COwn,
 ) -> Result<(AceCborAuthzInfoResponse, liboscore::PrimitiveContext, GC), CredentialError> {
-    trace!("Processing authz_info {=[u8]:02x}", payload); // :02x could be :cbor
+    trace!("Processing authz_info {:?}", payload); // :? could go through something like ariel_os_debug_log::Cbor
 
     let decoded: UnprotectedAuthzInfoPost = minicbor::decode(payload)?;
     // FIXME: The `..` should be "all others are None"; se also comment on UnprotectedAuthzInfoPost
@@ -532,7 +532,7 @@ pub(crate) fn process_edhoc_token<GeneralClaims>(
         };
         buffer = heapless::Vec::new();
         minicbor::encode(&aad, minicbor_adapters::WriteToHeapless(&mut buffer))?;
-        trace!("Serialized AAD: {:#02x}", buffer);
+        trace!("Serialized AAD: {:#02x?}", buffer);
 
         authorities.verify_asymmetric_token(&headers, &buffer, sign1.signature, sign1.payload)?
     } else {

--- a/src/lib/coapcore/src/seccfg.rs
+++ b/src/lib/coapcore/src/seccfg.rs
@@ -363,7 +363,7 @@ impl ServerSecurityConfig for ConfigBuilder {
         id_cred_x: lakers::IdCred,
     ) -> Option<(lakers::Credential, Self::GeneralClaims)> {
         trace!(
-            "Evaluating peer's credential {=[u8]:02x}", // :02x could be :cbor
+            "Evaluating peer's credential {:?}", // :? could go through something like ariel_os_debug_log::Cbor
             id_cred_x.as_full_value()
         );
 
@@ -372,7 +372,7 @@ impl ServerSecurityConfig for ConfigBuilder {
             reason = "Expected to be extended to actual loop soon"
         )]
         for (credential, scope) in &[self.known_edhoc_clients.as_ref()?] {
-            trace!("Comparing to {=[u8]:02x}", credential.bytes.as_slice()); // :02x could be :cbor
+            trace!("Comparing to {:?}", credential.bytes.as_slice()); // :? could go through something like ariel_os_debug_log::Cbor
             if id_cred_x.reference_only() {
                 // ad Ok: If our credential has no KID, it can't be recognized in this branch
                 if credential.by_kid().as_ref() == Ok(&id_cred_x) {

--- a/src/lib/coapcore/src/seccontext.rs
+++ b/src/lib/coapcore/src/seccontext.rs
@@ -617,7 +617,7 @@ impl<
                 match crate::ace::process_edhoc_token(value.as_slice(), &self.authorities) {
                     Ok(ci_and_a) => cred_i_and_authorization = Some(ci_and_a),
                     Err(e) => {
-                        error!("Received unprocessable token {=[u8]:02x}, error: {}", value.as_slice(), Debug2Format(&e)); // :02x could be :cbor
+                        error!("Received unprocessable token {:?}, error: {:?}", value.as_slice(), Debug2Format(&e)); // First :? could go through something like ariel_os_debug_log::Cbor
                     }
                 }
             }
@@ -848,7 +848,7 @@ impl<
             })
             .map_err(|e| {
                 error!("Sending out error:");
-                error!("{}", Debug2Format(&e));
+                error!("{:?}", Debug2Format(&e));
                 e.position
                     // FIXME: Could also come from processing inner
                     .map_or(CoAPError::bad_request(), CoAPError::bad_request_with_rbep)


### PR DESCRIPTION
# Description

Logging in coapcore had a few defmt'isms in it and thus failed to build with the `log` feature.

Note that unlike most other places where we had these issues, coapcore goes through defmt-or-log rather than through Ariel's re-implementation thereof.

[edit:] Note that this is a stop-gap measure. Comments have been updated to a more proper solution, but right now, this fixes breakage at the acceptable cost of reducing prettiness of debug output everywhere.

## Issues/PRs references

See-Also: https://github.com/t-moe/defmt-or-log/issues/4 (which would catch this)
See-Also: https://github.com/ariel-os/ariel-os/pull/972 (which catches this in the rest of the code base)

CC @KiyoLelou10 who'll need that to use coapcore on RIOT.

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.
