### PR TITLE
feat(coapcore): Use defmt_or_log's enhanced hex and CBOR outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,11 +1528,11 @@ dependencies = [
 
 [[package]]
 name = "defmt-or-log"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8370630b4dee85ab47d9087813771c5c7fe88d24fdd48649bbdfe6089da4c53a"
+checksum = "4439fab1ae9faccf0f69cdf2671989ba40f246e178c7f87d6e4fd5270e53a979"
 dependencies = [
- "defmt 0.3.100",
+ "defmt 1.0.1",
  "defmt-or-log-macros",
  "log",
 ]
@@ -3718,9 +3718,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "managed"

--- a/src/lib/coapcore/Cargo.toml
+++ b/src/lib/coapcore/Cargo.toml
@@ -31,7 +31,7 @@ liboscore = { version = "0.2.4", default-features = false }
 minicbor = { version = "0.26.0", features = ["derive"] }
 minicbor-adapters = "0.0.4"
 heapless = "0.8.0"
-defmt-or-log = { version = "0.2.1", default-features = false }
+defmt-or-log = { version = "0.2.2", default-features = false }
 defmt = { workspace = true, optional = true }
 log = { version = "0.4", optional = true }
 

--- a/src/lib/coapcore/src/seccfg.rs
+++ b/src/lib/coapcore/src/seccfg.rs
@@ -363,8 +363,8 @@ impl ServerSecurityConfig for ConfigBuilder {
         id_cred_x: lakers::IdCred,
     ) -> Option<(lakers::Credential, Self::GeneralClaims)> {
         trace!(
-            "Evaluating peer's credential {=[u8]:02x}", // :02x could be :cbor
-            id_cred_x.as_full_value()
+            "Evaluating peer's credential {}",
+            defmt_or_log::wrappers::Cbor(id_cred_x.as_full_value())
         );
 
         #[expect(
@@ -372,7 +372,10 @@ impl ServerSecurityConfig for ConfigBuilder {
             reason = "Expected to be extended to actual loop soon"
         )]
         for (credential, scope) in &[self.known_edhoc_clients.as_ref()?] {
-            trace!("Comparing to {=[u8]:02x}", credential.bytes.as_slice()); // :02x could be :cbor
+            trace!(
+                "Comparing to {}",
+                defmt_or_log::wrappers::Cbor(credential.bytes.as_slice())
+            );
             if id_cred_x.reference_only() {
                 // ad Ok: If our credential has no KID, it can't be recognized in this branch
                 if credential.by_kid().as_ref() == Ok(&id_cred_x) {

--- a/src/lib/coapcore/src/seccontext.rs
+++ b/src/lib/coapcore/src/seccontext.rs
@@ -617,7 +617,7 @@ impl<
                 match crate::ace::process_edhoc_token(value.as_slice(), &self.authorities) {
                     Ok(ci_and_a) => cred_i_and_authorization = Some(ci_and_a),
                     Err(e) => {
-                        error!("Received unprocessable token {=[u8]:02x}, error: {}", value.as_slice(), Debug2Format(&e)); // :02x could be :cbor
+                        error!("Received unprocessable token {}, error: {:?}", defmt_or_log::wrappers::Cbor(value.as_slice()), Debug2Format(&e));
                     }
                 }
             }
@@ -848,7 +848,7 @@ impl<
             })
             .map_err(|e| {
                 error!("Sending out error:");
-                error!("{}", Debug2Format(&e));
+                error!("{:?}", Debug2Format(&e));
                 e.position
                     // FIXME: Could also come from processing inner
                     .map_or(CoAPError::bad_request(), CoAPError::bad_request_with_rbep)


### PR DESCRIPTION
## Issues/PRs references

In https://github.com/ariel-os/ariel-os/pull/1111, we fixed an issue.

The proper fix is https://github.com/t-moe/defmt-or-log/pull/8, which gets pulled in by this PR -- but as an unmergable draft until that PR is merged (and possibly released).

## Change checklist

- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.
