### PR TITLE
feat(stm32): add initial stm32u585 / steval-mkboxpro support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,7 @@ dependencies = [
  "ariel-os-embassy-common",
  "ariel-os-random",
  "ariel-os-stm32-mapping",
+ "ariel-os-utils",
  "cfg-if",
  "defmt 1.0.1",
  "embassy-embedded-hal",

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -322,6 +322,18 @@ chips:
           - removing items not supported
       wifi: not_available
 
+  stm32u585ai:
+    name: STM32U585AI
+    support:
+      gpio: supported
+      debug_output: supported
+      hwrng: supported
+      i2c_controller: supported
+      spi_main: supported
+      logging: supported
+      storage: supported
+      wifi: not_available
+
   stm32wb55rg:
     name: STM32WB55RG
     support:
@@ -556,6 +568,19 @@ boards:
     chip: stm32wba55cg
     tier: "3"
     support:
+
+  st-steval-mkboxpro:
+    name: STEVAL-MKBOXPRO
+    url: https://web.archive.org/web/20250507145935/https://www.st.com/en/evaluation-tools/steval-mkboxpro.html
+    chip: stm32u585ai
+    tier: "2"
+    support:
+      user_usb: supported
+      wifi: not_available
+      ethernet_over_usb:
+        status: not_currently_supported
+        comments:
+          - does not enumerate
 
   stm32u083c-dk:
     name: STM32U083C-DK

--- a/examples/blinky/laze.yml
+++ b/examples/blinky/laze.yml
@@ -21,4 +21,5 @@ apps:
       - st-nucleo-wb55
       - st-nucleo-wba55
       - st-nucleo-f767zi
+      - st-steval-mkboxpro
       - stm32u083c-dk

--- a/examples/blinky/src/pins.rs
+++ b/examples/blinky/src/pins.rs
@@ -66,5 +66,8 @@ ariel_os::hal::define_peripherals!(LedPeripherals { led: PB5 });
 #[cfg(context = "st-nucleo-wba55")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: PB4 });
 
+#[cfg(context = "st-steval-mkboxpro")]
+ariel_os::hal::define_peripherals!(LedPeripherals { led: PF6 });
+
 #[cfg(context = "stm32u083c-dk")]
 ariel_os::hal::define_peripherals!(LedPeripherals { led: PA5 });

--- a/examples/gpio/laze.yml
+++ b/examples/gpio/laze.yml
@@ -18,4 +18,5 @@ apps:
       - st-nucleo-f411re
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
+      - st-steval-mkboxpro
       - stm32u083c-dk

--- a/examples/gpio/src/pins.rs
+++ b/examples/gpio/src/pins.rs
@@ -104,3 +104,9 @@ ariel_os::hal::define_peripherals!(Peripherals {
     led1: PA5,
     btn1: PC2
 });
+
+#[cfg(context = "st-steval-mkboxpro")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    led1: PF6,
+    btn1: PC13
+});

--- a/examples/i2c-scanner/laze.yml
+++ b/examples/i2c-scanner/laze.yml
@@ -4,3 +4,4 @@ apps:
       # list of contexts that have an entry in `pins.rs`
       - bbc-microbit-v2
       - st-nucleo-f042k6
+      - st-steval-mkboxpro

--- a/examples/i2c-scanner/src/pins.rs
+++ b/examples/i2c-scanner/src/pins.rs
@@ -1,5 +1,13 @@
 use ariel_os::hal::{i2c, peripherals};
 
+#[cfg(any(context = "nrf52833", context = "nrf52840"))]
+pub type SensorI2c = i2c::controller::TWISPI0;
+#[cfg(context = "bbc-microbit-v2")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    i2c_sda: P0_16,
+    i2c_scl: P0_08,
+});
+
 #[cfg(context = "st-nucleo-f042k6")]
 pub type SensorI2c = i2c::controller::I2C1;
 #[cfg(context = "st-nucleo-f042k6")]
@@ -8,10 +16,11 @@ ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: PB7
 });
 
-#[cfg(any(context = "nrf52833", context = "nrf52840"))]
-pub type SensorI2c = i2c::controller::TWISPI0;
-#[cfg(context = "bbc-microbit-v2")]
+// This is the I2C bus that the onboard sensors are connected to.
+#[cfg(context = "st-steval-mkboxpro")]
+pub type SensorI2c = i2c::controller::I2C1;
+#[cfg(context = "st-steval-mkboxpro")]
 ariel_os::hal::define_peripherals!(Peripherals {
-    i2c_sda: P0_16,
-    i2c_scl: P0_08,
+    i2c_scl: PB6,
+    i2c_sda: PB7
 });

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -459,6 +459,11 @@ contexts:
       - sw/benchmark
     env:
       OPENOCD_ARGS: foo
+    tasks:
+      flash-dfu:
+        cmd:
+          - llvm-objcopy -O binary ${out} ${out}.bin
+          - 'dfu-util -d 0483:df11 -a 0 -s 0x08000000:leave -D ${out}.bin || echo "... Note: dfu-util sometimes fails despite the upload being correct."'
 
   - name: stm32c031c6
     parent: stm32

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -556,6 +556,23 @@ contexts:
         - --cfg capability=\"hw/stm32-rng-cryp\"
         - --cfg capability=\"hw/stm32-usb-drd-fs\"
 
+  - name: stm32u585ai
+    parent: stm32
+    selects:
+      - cortex-m33f
+    disables:
+      # for some reason, usb-ethernet doesn't enumerate. usb-serial seems to work
+      # fine.
+      - usb-ethernet
+    provides:
+      - has_hwrng
+      - has_storage_support
+    env:
+      PROBE_RS_CHIP: STM32U585AI
+      RUSTFLAGS:
+        - --cfg capability=\"hw/stm32-rng\"
+        - --cfg capability=\"hw/stm32-usb-synopsis\"
+
   - name: stm32wb55rg
     parent: stm32
     selects:
@@ -1777,6 +1794,18 @@ builders:
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.
         - CONFIG_SWI=LPUART1
+
+  - name: st-steval-mkboxpro
+    parent: stm32u585ai
+    provides:
+      - has_swi
+      - has_usb_device_port
+    env:
+      CARGO_ENV:
+        # This ISR is unused on the eval board.
+        - CONFIG_SWI=USART2
+        # This board needs to disable vbus_detection for USB to work.
+        - CONFIG_VBUS_DETECTION=false
 
   - name: stm32u083c-dk
     parent: stm32u083mc

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -26,6 +26,7 @@ embassy-stm32 = { workspace = true, default-features = false, features = [
 embedded-hal-async = { workspace = true }
 paste = { workspace = true }
 portable-atomic = { workspace = true }
+ariel-os-utils = { workspace = true }
 ariel-os-embassy-common = { workspace = true }
 ariel-os-random = { workspace = true, optional = true }
 static_cell = { workspace = true }

--- a/src/ariel-os-stm32/src/i2c/controller/mod.rs
+++ b/src/ariel-os-stm32/src/i2c/controller/mod.rs
@@ -240,6 +240,13 @@ define_i2c_drivers!(
     I2C2_EV + I2C2_ER => I2C2,
     I2C3_EV + I2C3_ER => I2C3,
 );
+#[cfg(context = "stm32u585ai")]
+define_i2c_drivers!(
+   I2C1_EV + I2C1_ER => I2C1,
+   I2C2_EV + I2C2_ER => I2C2,
+   I2C3_EV + I2C3_ER => I2C3,
+   I2C4_EV + I2C4_ER => I2C4,
+);
 #[cfg(context = "stm32u083mc")]
 define_i2c_drivers!(
    I2C1 => I2C1,

--- a/src/ariel-os-stm32/src/i2c/mod.rs
+++ b/src/ariel-os-stm32/src/i2c/mod.rs
@@ -28,6 +28,8 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
             take_all_i2c_peripherals!(I2C1, I2C2, I2C3);
         } else if #[cfg(context = "stm32u083mc")] {
             take_all_i2c_peripherals!(I2C1, I2C2, I2C3, I2C4);
+        } else if #[cfg(context = "stm32u585ai")] {
+            take_all_i2c_peripherals!(I2C1, I2C2, I2C3, I2C4);
         } else if #[cfg(context = "stm32wb55rg")] {
             take_all_i2c_peripherals!(I2C1, I2C3);
         } else {

--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -220,6 +220,41 @@ fn board_config(config: &mut Config) {
         config.rcc.mux.clk48sel = mux::Clk48sel::HSI48;
     }
 
+    #[cfg(context = "st-steval-mkboxpro")]
+    {
+        use embassy_stm32::rcc::*;
+
+        config.rcc.ls = LsConfig {
+            rtc: RtcClockSource::LSE,
+            lsi: true,
+            lse: Some(LseConfig {
+                peripherals_clocked: true,
+                frequency: embassy_stm32::time::Hertz(32768),
+                mode: LseMode::Oscillator(LseDrive::MediumHigh),
+            }),
+        };
+        config.rcc.hsi = true;
+        config.rcc.hsi48 = Some(Hsi48Config {
+            sync_from_usb: true,
+        }); // needed for USB
+        config.rcc.sys = Sysclk::PLL1_R;
+        config.rcc.hse = Some(Hse {
+            freq: embassy_stm32::time::Hertz(16_000_000),
+            mode: HseMode::Oscillator,
+        });
+        config.rcc.pll1 = Some(Pll {
+            source: PllSource::HSE,
+            prediv: PllPreDiv::DIV1,
+            mul: PllMul::MUL10,
+            divp: None,
+            divq: None,
+            divr: Some(PllDiv::DIV1), // sysclk 160Mhz (16 / 1 * 10 / 1)
+        });
+        config.rcc.sys = Sysclk::PLL1_R;
+        config.rcc.mux.iclksel = mux::Iclksel::HSI48;
+        config.rcc.voltage_range = VoltageScale::RANGE1;
+    }
+
     #[cfg(context = "stm32f042k6")]
     {
         use embassy_stm32::rcc::*;

--- a/src/ariel-os-stm32/src/spi/main/mod.rs
+++ b/src/ariel-os-stm32/src/spi/main/mod.rs
@@ -28,6 +28,10 @@ const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(150);
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(40);
 #[cfg(context = "stm32u083mc")]
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(32);
+// TODO: verify, datasheet says "Baud rate prescaler up to kernel frequency/2 or bypass from RCC in
+// master mode", core freq is 160MHz
+#[cfg(context = "stm32u585ai")]
+const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(80);
 #[cfg(context = "stm32wb55rg")]
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(32);
 
@@ -178,6 +182,12 @@ define_spi_drivers!(
 define_spi_drivers!(
    SPI1 => SPI1,
    // FIXME: the other two SPI peripherals share the same interrupt
+);
+#[cfg(context = "stm32u585ai")]
+define_spi_drivers!(
+   SPI1 => SPI1,
+   SPI2 => SPI2,
+   SPI3 => SPI3,
 );
 #[cfg(context = "stm32wb55rg")]
 define_spi_drivers!(

--- a/src/ariel-os-stm32/src/spi/mod.rs
+++ b/src/ariel-os-stm32/src/spi/mod.rs
@@ -46,6 +46,8 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3);
         } else if #[cfg(context = "stm32u083mc")] {
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3);
+        } else if #[cfg(context = "stm32u585ai")] {
+            take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3);
         } else if #[cfg(context = "stm32wb55rg")] {
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2);
         } else {

--- a/src/ariel-os-stm32/src/usb.rs
+++ b/src/ariel-os-stm32/src/usb.rs
@@ -70,7 +70,8 @@ pub fn driver(peripherals: Peripherals) -> UsbDriver {
     // See https://embassy.dev/book/dev/faq.html#_the_usb_examples_are_not_working_on_my_board_is_there_anything_else_i_need_to_configure
     // for more information
     // NOTE(board-config)
-    config.vbus_detection = true;
+    config.vbus_detection =
+        ariel_os_utils::bool_from_env_or!("CONFIG_VBUS_DETECTION", true, "Enable vbus_detection");
 
     #[cfg(feature = "executor-interrupt")]
     {

--- a/src/ariel-os-storage/build.rs
+++ b/src/ariel-os-storage/build.rs
@@ -12,6 +12,8 @@ fn main() {
             (4 * KIBIBYTES, 2 * KIBIBYTES)
         } else if is_in_current_contexts(&["nrf52", "nrf5340", "nrf91", "rp", "stm32wb55rg"]) {
             (8 * KIBIBYTES, 4 * KIBIBYTES)
+        } else if is_in_current_contexts(&["stm32u585ai"]) {
+            (16 * KIBIBYTES, 8 * KIBIBYTES)
         } else if is_in_current_contexts(&["stm32h755zi"]) {
             (256 * KIBIBYTES, 128 * KIBIBYTES)
         } else if !is_in_current_contexts(&["ariel-os"]) {

--- a/src/ariel-os-utils/src/env.rs
+++ b/src/ariel-os-utils/src/env.rs
@@ -31,6 +31,7 @@ macro_rules! define_env_with_default_macro {
 
 define_env_with_default_macro!(usize_from_env_or, parse_usize, "a usize");
 define_env_with_default_macro!(u8_from_env_or, parse_u8, "a u8");
+define_env_with_default_macro!(bool_from_env_or, parse_bool, "a bool");
 
 /// Reads a value at compile time from the given environment variable, with a default.
 ///

--- a/tests/spi-loopback/laze.yml
+++ b/tests/spi-loopback/laze.yml
@@ -14,4 +14,5 @@ apps:
       - st-nucleo-f411re
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
+      - st-steval-mkboxpro
       - stm32u083c-dk

--- a/tests/spi-loopback/src/pins.rs
+++ b/tests/spi-loopback/src/pins.rs
@@ -103,6 +103,17 @@ ariel_os::hal::define_peripherals!(Peripherals {
     spi_cs: PA15,
 });
 
+// DIL24 pin 21/22
+#[cfg(context = "st-steval-mkboxpro")]
+pub type SensorSpi = spi::main::SPI3;
+#[cfg(context = "st-steval-mkboxpro")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    spi_sck: PG9,
+    spi_miso: PG10,
+    spi_mosi: PB5,
+    spi_cs: PG12,
+});
+
 // Side SPI of Arduino v3 connector
 #[cfg(context = "stm32wb55rg")]
 pub type SensorSpi = spi::main::SPI1;

--- a/tests/spi-main/laze.yml
+++ b/tests/spi-main/laze.yml
@@ -13,4 +13,5 @@ apps:
       - st-nucleo-f411re
       - st-nucleo-h755zi-q
       - st-nucleo-wb55
+      - st-steval-mkboxpro
       - stm32u083c-dk

--- a/tests/spi-main/src/main.rs
+++ b/tests/spi-main/src/main.rs
@@ -25,15 +25,15 @@ use embassy_sync::mutex::Mutex;
 use embedded_hal_async::spi::{Operation, SpiDevice as _};
 
 // WHO_AM_I register of the sensor
-#[cfg(not(context = "nordic-thingy-91-x-nrf9151"))]
+#[cfg(not(any(context = "nordic-thingy-91-x-nrf9151", context = "st-steval-mkboxpro")))]
 const WHO_AM_I_REG_ADDR: u8 = 0x0f;
-#[cfg(context = "nordic-thingy-91-x-nrf9151")]
-const WHO_AM_I_REG_ADDR: u8 = 0x00;
+#[cfg(any(context = "nordic-thingy-91-x-nrf9151", context = "st-steval-mkboxpro"))]
+use pins::WHO_AM_I_REG_ADDR;
 
-#[cfg(not(context = "nordic-thingy-91-x-nrf9151"))]
+#[cfg(not(any(context = "nordic-thingy-91-x-nrf9151", context = "st-steval-mkboxpro")))]
 const DEVICE_ID: u8 = 0x33;
-#[cfg(context = "nordic-thingy-91-x-nrf9151")]
-const DEVICE_ID: u8 = 0x24;
+#[cfg(any(context = "nordic-thingy-91-x-nrf9151", context = "st-steval-mkboxpro"))]
+use pins::DEVICE_ID;
 
 pub static SPI_BUS: once_cell::sync::OnceCell<
     Mutex<embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex, hal::spi::main::Spi>,

--- a/tests/spi-main/src/pins.rs
+++ b/tests/spi-main/src/pins.rs
@@ -17,6 +17,10 @@ ariel_os::hal::define_peripherals!(Peripherals {
     spi_mosi: P0_14,
     spi_cs: P0_10,
 });
+#[cfg(context = "nordic-thingy-91-x-nrf9151")]
+pub const WHO_AM_I_REG_ADDR: u8 = 0x00;
+#[cfg(context = "nordic-thingy-91-x-nrf9151")]
+pub const DEVICE_ID: u8 = 0x24;
 
 // Side SPI of Arduino v3 connector
 #[cfg(context = "nrf52840")]
@@ -100,6 +104,21 @@ ariel_os::hal::define_peripherals!(Peripherals {
     spi_mosi: PA7,
     spi_cs: PA15,
 });
+
+// Onboard LIS2DU12
+#[cfg(context = "st-steval-mkboxpro")]
+pub type SensorSpi = spi::main::SPI2;
+#[cfg(context = "st-steval-mkboxpro")]
+ariel_os::hal::define_peripherals!(Peripherals {
+    spi_sck: PI1,
+    spi_miso: PI2,
+    spi_mosi: PI3,
+    spi_cs: PI7,
+});
+#[cfg(context = "st-steval-mkboxpro")]
+pub const WHO_AM_I_REG_ADDR: u8 = 0x43;
+#[cfg(context = "st-steval-mkboxpro")]
+pub const DEVICE_ID: u8 = 0x45;
 
 // Side SPI of Arduino v3 connector
 #[cfg(context = "stm32wb55rg")]


### PR DESCRIPTION
# Description

This adds initial support for the stm32u585ai, and the STEVAL-MKBOXPRO board.

~~Marking as draft as this was blind-ported.~~

~~Compiling~~ Tested working so far:

- [x] gpio
- [x] i2c (i2c-scanner shows onboard sensors)
- [x] spi (spi loopback succeeded)
- [x] hwrng
- [x] identity
- [x] USB
  - [ ] usb-ethernet doesn't enumerate
- [x] device matrix entry
- [x] storage

This PR is not tackling drivers for now.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
