### PR TITLE
fix(nrf-ble): restrict the `has_nrf_ble` laze module to `nrf`

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1144,6 +1144,8 @@ modules:
 
   - name: has_nrf_ble
     help: Marks an incompatibility of nrf devices with the interrupt executor (MPSL crashing)
+    context:
+      - nrf52
     selects:
       - hwrng
     provides:


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This makes sure the `has_nrf_ble` laze module introduced in #1074 can only be enabled on `nrf`, instead of being enabled by any laze module that merely selects it.

## Testing

When combined with #1088, this reduces the number of tasks ran by laze with:

```
laze -C examples/ble-scanner build -m
```

from 24 to 8.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
