### PR TITLE
fix(threads): fix second core stack initialization

### DIFF
--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -533,7 +533,7 @@ pub unsafe fn start_threading() {
 
         smp::isr_stack_core1_set_limits(isr_stack_core1);
 
-        smp::Chip::startup_other_cores(ISR_STACK_CORE1.take());
+        smp::Chip::startup_other_cores(isr_stack_core1);
     }
     Cpu::start_threading();
 }


### PR DESCRIPTION
# Description

Multicore startup currently always crashes due to a double `take()` on a `ConstStaticCell`. This was probably introduced in #977 already.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
