### PR TITLE
fix(examples): fix `threading-event` priorities for multi-core

### DIFF
--- a/examples/threading-event/src/main.rs
+++ b/examples/threading-event/src/main.rs
@@ -22,27 +22,27 @@ fn waiter() {
     }
 }
 
-#[ariel_os::thread(autostart, priority = 0)]
+#[ariel_os::thread(autostart, priority = 1)]
 fn thread0() {
     waiter();
 }
 
-#[ariel_os::thread(autostart, priority = 1)]
+#[ariel_os::thread(autostart, priority = 2)]
 fn thread1() {
     waiter();
 }
 
-#[ariel_os::thread(autostart, priority = 2)]
+#[ariel_os::thread(autostart, priority = 3)]
 fn thread2() {
     waiter();
 }
 
-#[ariel_os::thread(autostart, priority = 3)]
+#[ariel_os::thread(autostart, priority = 4)]
 fn thread3() {
     waiter();
 }
 
-#[ariel_os::thread(autostart, priority = 1)]
+#[ariel_os::thread(autostart, priority = 2)]
 fn thread4() {
     let my_id = ariel_os::thread::current_tid().unwrap();
     let my_prio = ariel_os::thread::get_priority(my_id).unwrap();


### PR DESCRIPTION
# Description

The current priorities expect one of the threads with priority 0 to be launched last. On multicore with two idle threads, that thread actually never gets scheduled.

This PR increments all test thread priorities by one, mitigating the issue.

(Let's find a more general solution elsewhere.)

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
