### PR TITLE
feat(stm32): add initial stm32wle5jc

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -601,6 +601,13 @@ contexts:
       PROBE_RS_CHIP: STM32WBA55CG
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
+  
+  - name: stm32wle5jc
+    parent: stm32
+    selects:
+      - cortex-m4f
+    env:
+      PROBE_RS_CHIP: STM32WLE5JC
 
 modules:
   - name: thumbv6m-none-eabi
@@ -1825,6 +1832,16 @@ builders:
       CARGO_ENV:
         # This ISR is unused on a naked board. Configured here for testing.
         - CONFIG_SWI=USART2_LPUART2
+
+  - name: lora-e5-mini
+    parent: stm32wle5jc
+    provides:
+      - has_swi
+      - has_usb_device_port
+    env:
+      CARGO_ENV:
+        # This ISR is unused on a naked board. Configured here for testing.
+        - CONFIG_SWI=USART2
 
 apps:
   # define a dummy host application so the host tasks work


### PR DESCRIPTION
# Description
- Add stm32wle5jc mcu and board config to `laze-project.yml`

## Issues/PRs references
Inspired by #1117 

## TODO
- [x ] [./examples/hello_world(./examples/hello_world)
- [ ] [./examples/uart_serial](./examples/uart_serial)
- [ ] [./examples/gpio](./examples/gpio)
## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
