### PR TITLE
docs(book): update the installation command for `espup`

### DIFF
--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -26,7 +26,7 @@ It explains how to compile and run the `hello-word` example to verify your setup
 1. Only for using ESP devices, install [espup](https://github.com/esp-rs/espup) and related tools:
 
    ```sh
-   cargo install espup
+   cargo install espup --locked
    espup install
    cargo install espflash
    ```


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Using `--locked` for installing `espup` is now the [recommended way](https://github.com/esp-rs/espup/pull/488), and installation currently fails without it.

**Note:** this PR doubles as a test for the `ci-build:skip` PR label, so do *not* merge it for now.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #1135.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
