### PR TITLE
refactor(threads): use pointer for thread function

### DIFF
--- a/src/ariel-os-threads/src/arch/cortex_m.rs
+++ b/src/ariel-os-threads/src/arch/cortex_m.rs
@@ -50,7 +50,7 @@ impl Arch for Cpu {
     /// |   PC    |
     /// |   PSR   |
     /// +---------+
-    fn setup_stack(thread: &mut Thread, stack: &mut [u8], func: usize, arg: usize) {
+    fn setup_stack(thread: &mut Thread, stack: &mut [u8], func: fn(), arg: Option<usize>) {
         let stack_start = stack.as_ptr() as usize;
 
         // 1. The stack starts at the highest address and grows downwards.
@@ -62,13 +62,13 @@ impl Arch for Cpu {
         let stack_pos = (stack_highest - 32) as *mut usize;
 
         unsafe {
-            write_volatile(stack_pos.offset(0), arg); // -> R0
+            write_volatile(stack_pos.offset(0), arg.unwrap_or_default()); // -> R0
             write_volatile(stack_pos.offset(1), 1); // -> R1
             write_volatile(stack_pos.offset(2), 2); // -> R2
             write_volatile(stack_pos.offset(3), 3); // -> R3
             write_volatile(stack_pos.offset(4), 12); // -> R12
             write_volatile(stack_pos.offset(5), cleanup as usize); // -> LR
-            write_volatile(stack_pos.offset(6), func); // -> PC
+            write_volatile(stack_pos.offset(6), func as usize); // -> PC
             write_volatile(stack_pos.offset(7), 0x01000000); // -> APSR
         }
 

--- a/src/ariel-os-threads/src/arch/mod.rs
+++ b/src/ariel-os-threads/src/arch/mod.rs
@@ -15,7 +15,7 @@ pub trait Arch {
     /// it starts executing `func` with argument `arg`.
     /// Furthermore, it sets up the link-register with the [`crate::cleanup`] function that
     /// will be executed after the thread function returned.
-    fn setup_stack(thread: &mut Thread, stack: &mut [u8], func: usize, arg: usize);
+    fn setup_stack(thread: &mut Thread, stack: &mut [u8], func: fn(), arg: Option<usize>);
 
     /// Trigger a context switch.
     fn schedule();
@@ -44,7 +44,7 @@ cfg_if::cfg_if! {
             type ThreadData = ();
             const DEFAULT_THREAD_DATA: Self::ThreadData = ();
 
-            fn setup_stack( _: &mut Thread, _: &mut [u8], _: usize, _: usize) {
+            fn setup_stack( _: &mut Thread, _: &mut [u8], _: fn(), _: Option<usize>) {
                 unimplemented!()
             }
             fn start_threading() {

--- a/src/ariel-os-threads/src/arch/riscv.rs
+++ b/src/ariel-os-threads/src/arch/riscv.rs
@@ -27,15 +27,15 @@ impl Arch for Cpu {
 
     /// On RISC-V (ESP32), the stack doesn't need to be set up with any register values since
     /// they are restored from the stored [`TrapFrame`].
-    fn setup_stack(thread: &mut Thread, stack: &mut [u8], func: usize, arg: usize) {
+    fn setup_stack(thread: &mut Thread, stack: &mut [u8], func: fn(), arg: Option<usize>) {
         let stack_start = stack.as_ptr() as usize;
         // 16 byte alignment.
         let stack_pos = (stack_start + stack.len()) & 0xFFFFFFE0;
         // Set up PC, SP, RA and first argument for function.
         thread.data.sp = stack_pos;
-        thread.data.a0 = arg;
+        thread.data.a0 = arg.unwrap_or_default();
         thread.data.ra = cleanup as usize;
-        thread.data.pc = func;
+        thread.data.pc = func as usize;
 
         thread.stack_lowest = stack_start;
         thread.stack_highest = stack_pos;

--- a/src/ariel-os-threads/src/arch/xtensa.rs
+++ b/src/ariel-os-threads/src/arch/xtensa.rs
@@ -23,14 +23,19 @@ impl Arch for Cpu {
         crate::smp::schedule_on_core(crate::core_id())
     }
 
-    fn setup_stack(thread: &mut crate::thread::Thread, stack: &mut [u8], func: usize, arg: usize) {
+    fn setup_stack(
+        thread: &mut crate::thread::Thread,
+        stack: &mut [u8],
+        func: fn(),
+        arg: Option<usize>,
+    ) {
         let stack_start = stack.as_ptr() as usize;
         let task_stack_ptr = stack_start + stack.len();
         // 16 byte alignment.
         let stack_pos = task_stack_ptr - (task_stack_ptr % 0x10);
 
         thread.data.A1 = stack_pos as u32;
-        thread.data.A6 = arg as u32;
+        thread.data.A6 = arg.unwrap_or_default() as u32;
         // Usually A0 holds the return address.
         // However, xtensa features so-called Windowed registers, which allow
         // to shift the used registers when calling procedure.


### PR DESCRIPTION
# Description

Use function pointers in API and move cast to register sized integer into arches.
Also, make `arg` an Option.

https://doc.rust-lang.org/stable/core/primitive.fn.html#casting-to-and-from-integers
https://doc.rust-lang.org/stable/core/ptr/index.html#provenance

## Issues/PRs references

#647 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
