### PR TITLE
fix(threads): fix some warnings in cortex-m non-hardfault case

### DIFF
--- a/src/ariel-os-threads/src/arch/cortex_m.rs
+++ b/src/ariel-os-threads/src/arch/cortex_m.rs
@@ -1,5 +1,4 @@
 use crate::{Arch, SCHEDULER, Thread, cleanup};
-use cfg_if::cfg_if;
 use core::{arch::global_asm, ptr::write_volatile};
 use cortex_m::peripheral::{SCB, scb::SystemHandler};
 
@@ -8,6 +7,7 @@ compile_error!("no supported ARM variant selected");
 
 // Default EXC_RETURN value used for newly created threads when returning to
 // Thread mode. We know FPU hasn't been used because the thread hasn't run.
+#[cfg(any(armv7m_eabihf, armv8m_eabihf))]
 const EXC_RETURN_THREAD_NO_FPU: usize = 0xFFFFFFFD;
 
 pub struct Cpu;
@@ -209,7 +209,7 @@ macro_rules! define_pendsv_with_fpu {
 }
 
 #[cfg(any(armv7m, armv8m))]
-cfg_if! {
+cfg_if::cfg_if! {
     if #[cfg(armv7m_eabihf)] {
         define_pendsv_with_fpu!(".fpu fpv4-sp-d16");
     }


### PR DESCRIPTION
# Description

Fixes two warnings introduced by #1097:

```
   Compiling ariel-os-threads v0.2.0 (/home/kaspar/src/own/rust/ariel-os/src/ariel-os-threads)                                                                 
warning: unused import: `cfg_if::cfg_if`                                                                                                                       
 --> src/ariel-os-threads/src/arch/cortex_m.rs:2:5                                                                                                             
  |                                                                                                                                                            
2 | use cfg_if::cfg_if;                                                                                                                                        
  |     ^^^^^^^^^^^^^^                                                                                                                                         
  |                                                                                                                                                            
  = note: `#[warn(unused_imports)]` on by default                                                                                                              
                                                                                                                                                               
warning: constant `EXC_RETURN_THREAD_NO_FPU` is never used                                                                                                     
  --> src/ariel-os-threads/src/arch/cortex_m.rs:11:7                                                                                                           
   |                                                                                                                                                           
11 | const EXC_RETURN_THREAD_NO_FPU: usize = 0xFFFFFFFD;                                                                                                       
   |       ^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                            
   |                                                                                                                                                           
   = note: `#[warn(dead_code)]` on by default                                                                                                                  
```

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
