### PR TITLE
fix(ci): enable `defmt` Cargo feature in main Clippy action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,6 +112,7 @@ jobs:
                 ble,
                 coap,
                 csprng,
+                defmt,
                 dns,
                 external-interrupts,
                 hwrng,

--- a/src/ariel-os-debug-log/src/lib.rs
+++ b/src/ariel-os-debug-log/src/lib.rs
@@ -227,8 +227,8 @@ impl<T: AsRef<[u8]>> core::fmt::Display for Hex<T> {
 
 #[cfg(feature = "defmt")]
 impl<T: AsRef<[u8]>> defmt::Format for Hex<T> {
-    fn format(&self, f: defmt::Formatter) {
-        ::defmt::write!(f, "{=[u8]:02x}", self.0.as_ref())
+    fn format(&self, f: defmt::Formatter<'_>) {
+        ::defmt::write!(f, "{=[u8]:02x}", self.0.as_ref());
     }
 }
 
@@ -253,7 +253,7 @@ impl<T: AsRef<[u8]>> core::fmt::Display for Cbor<T> {
 
 #[cfg(feature = "defmt")]
 impl<T: AsRef<[u8]>> defmt::Format for Cbor<T> {
-    fn format(&self, f: defmt::Formatter) {
-        ::defmt::write!(f, "{=[u8]:cbor}", self.0.as_ref())
+    fn format(&self, f: defmt::Formatter<'_>) {
+        ::defmt::write!(f, "{=[u8]:cbor}", self.0.as_ref());
     }
 }


### PR DESCRIPTION
# Description

Enable the `defmt` Cargo feature in the main Clippy action, and fix some lints it found in the `ariel-os-debug-log` crate.

## Issues/PRs references



## Open Questions



## Change checklist


- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
