### PR TITLE
refactor(hal): split dummy module

### DIFF
--- a/src/ariel-os-hal/src/dummy/identity.rs
+++ b/src/ariel-os-hal/src/dummy/identity.rs
@@ -1,0 +1,3 @@
+use ariel_os_embassy_common::identity;
+
+pub type DeviceId = identity::NoDeviceId<identity::NotImplemented>;

--- a/src/ariel-os-hal/src/dummy/mod.rs
+++ b/src/ariel-os-hal/src/dummy/mod.rs
@@ -19,9 +19,7 @@ mod executor;
 pub mod gpio;
 
 #[doc(hidden)]
-pub mod peripheral {
-    pub use embassy_hal_internal::Peripheral;
-}
+pub mod peripheral;
 
 #[doc(hidden)]
 #[cfg(feature = "ble")]
@@ -36,11 +34,7 @@ pub mod hwrng;
 pub mod i2c;
 
 #[doc(hidden)]
-pub mod identity {
-    use ariel_os_embassy_common::identity;
-
-    pub type DeviceId = identity::NoDeviceId<identity::NotImplemented>;
-}
+pub mod identity;
 
 #[doc(hidden)]
 #[cfg(feature = "spi")]
@@ -55,22 +49,7 @@ pub mod storage;
 pub mod usb;
 
 pub use executor::{Executor, Spawner};
-
-#[doc(hidden)]
-/// Dummy type.
-///
-/// See the `OptionalPeripherals` type of your Embassy HAL crate instead.
-pub struct OptionalPeripherals;
-
-#[doc(hidden)]
-/// Dummy type.
-pub struct Peripherals;
-
-impl From<Peripherals> for OptionalPeripherals {
-    fn from(_peripherals: Peripherals) -> Self {
-        Self {}
-    }
-}
+pub use peripheral::{OptionalPeripherals, Peripheral};
 
 #[doc(hidden)]
 #[must_use]

--- a/src/ariel-os-hal/src/dummy/peripheral.rs
+++ b/src/ariel-os-hal/src/dummy/peripheral.rs
@@ -1,0 +1,17 @@
+pub use embassy_hal_internal::Peripheral;
+
+/// Dummy type.
+///
+/// See the `OptionalPeripherals` type of your Embassy HAL crate instead.
+#[doc(hidden)]
+pub struct OptionalPeripherals;
+
+/// Dummy type.
+#[doc(hidden)]
+pub struct Peripherals;
+
+impl From<Peripherals> for OptionalPeripherals {
+    fn from(_peripherals: Peripherals) -> Self {
+        Self {}
+    }
+}


### PR DESCRIPTION
This PR splits some of the `ariel-os-hal::dummy` modules in seperate files.
Will be used to selectively use them by #647.

Signed-off-by: Kaspar Schleiser <kaspar@schleiser.de># Description

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
