### PR TITLE
docs(config-macro): correct `reexports` module name

### DIFF
--- a/src/ariel-os-macros/src/config.rs
+++ b/src/ariel-os-macros/src/config.rs
@@ -9,11 +9,11 @@
 ///
 /// - The name of the driver the constant provides configuration for.
 ///
-/// | Driver    | Expected type                     | Cargo feature to enable   |
-/// | --------- | --------------------------------- | ------------------------- |
-// | `ble`     | `ariel_os::reexport::ble::Config` | `ble-config-override`     |
-/// | `network` | `embassy_net::Config`             | `network-config-override` |
-/// | `usb`     | `embassy_usb::Config`             | `override-usb-config`     |
+/// | Driver    | Expected type                      | Cargo feature to enable   |
+/// | --------- | ---------------------------------- | ------------------------- |
+// | `ble`     | `ariel_os::reexports::ble::Config` | `ble-config-override`     |
+/// | `network` | `embassy_net::Config`              | `network-config-override` |
+/// | `usb`     | `embassy_usb::Config`              | `override-usb-config`     |
 ///
 /// # Note
 ///


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Fixes a misspelling in a non-rustdoc-checked module name. It is currently commented out, but will be made user-visible when BLE is officially supported.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
