### PR TITLE
docs(book): pin espflash to 3.3.0

### DIFF
--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -28,7 +28,7 @@ It explains how to compile and run the `hello-word` example to verify your setup
    ```sh
    cargo install espup --locked
    espup install
-   cargo install espflash --locked
+   cargo install espflash@3.3.0 --locked
    ```
 
    There is no need to actively source the `~/export-esp.sh` file which `espup` produces:


### PR DESCRIPTION
# Description

There is no support for the ESP-IDF app descriptor yet. Pinning the espflash to a version before the app descriptor check was enabled.


This doesn't fix the underlying issue, newer esp bootloaders require the app descriptor. Boards with a more recent bootloader on them might no longer boot our builds.

## Issues/PRs references

Identified by #1149
See also #1150 

## Open Questions


## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
