### PR TITLE
fix(debug): actually compare log level in `log` backend

### DIFF
--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -195,7 +195,7 @@ pub use backend::*;
 #[doc(hidden)]
 #[cfg(feature = "log")]
 mod logger {
-    use log::{Level, LevelFilter, Metadata, Record};
+    use log::{LevelFilter, Metadata, Record};
 
     static LOGGER: DebugLogger = DebugLogger;
 
@@ -258,11 +258,11 @@ mod logger {
     struct DebugLogger;
 
     impl log::Log for DebugLogger {
-        fn enabled(&self, metadata: &Metadata) -> bool {
-            metadata.level() <= Level::Info
+        fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+            metadata.level() <= MAX_LEVEL
         }
 
-        fn log(&self, record: &Record) {
+        fn log(&self, record: &Record<'_>) {
             if self.enabled(record.metadata()) {
                 crate::println!("[{}] {}", record.level(), record.args());
             }


### PR DESCRIPTION
# Description

Seems like the log backend didn't actually compare to the configured log level.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
