### PR TITLE
fix(lint): allow `crate_in_macro_def` Clippy lint

### DIFF
--- a/src/ariel-os-embassy-common/src/executor_swi.rs
+++ b/src/ariel-os-embassy-common/src/executor_swi.rs
@@ -25,6 +25,10 @@
 /// Note: this expects the `interrupt` to be present (e.g., "used") and that it contains the ISR
 /// type.
 #[macro_export]
+#[expect(
+    clippy::crate_in_macro_def,
+    reason = "crate::EXECUTOR comes from downstream crates"
+)]
 macro_rules! executor_swi {
     ($swi:ident) => {
         pub use interrupt::$swi as SWI;
@@ -36,13 +40,7 @@ macro_rules! executor_swi {
             //   (This macro just adds "only enable it after starting the executor" to the
             //   requirements of the unsafe interrupt starting; the safe start() function
             //    trusts the user to pass the right number.)
-            #[expect(
-                clippy::crate_in_macro_def,
-                reason = "crate::EXECUTOR comes from downstream crates"
-            )]
-            unsafe {
-                crate::EXECUTOR.on_interrupt()
-            }
+            unsafe { crate::EXECUTOR.on_interrupt() }
         }
     };
 }


### PR DESCRIPTION
# Description

This is a follow up to #1105 which did not actually allow the Clippy lint. The fix is to put the `#[expect]` above the `macro_rules!`.

## Issues/PRs references

## Open Questions


## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
