### PR TITLE
fix(threads): fix `current_tid()`

### DIFF
--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -168,7 +168,7 @@ impl Scheduler {
     #[allow(clippy::unnecessary_wraps, reason = "only unnecessary in clippy path")]
     fn current_tid(&self) -> Option<ThreadId> {
         cfg_if::cfg_if! {
-            if #[cfg(context = "single-core")] {
+            if #[cfg(feature = "single-core")] {
                 self.current_thread
             }
             else if #[cfg(feature = "multi-core")] {
@@ -178,9 +178,8 @@ impl Scheduler {
                 ThreadData::ID.get()
             }
             else {
-                // makes clippy happy
                 let _ = self;
-                Some(ThreadId::new(0))
+                unreachable!();
             }
         }
     }


### PR DESCRIPTION
# Description

#647 broke the scheduler in single-core mode by using a wrong comparison and insufficient clippy fallback.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
