### PR TITLE
ci(build): install the Xtensa toolchain only when needed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
           components: rust-src, rustfmt
 
       - name: Install Rust for Xtensa
-        if: steps.should-skip.outputs.result != 'true'
+        if: steps.should-skip.outputs.result != 'true' && (env.LAZE_BUILDERS == null || contains(env.LAZE_BUILDERS, 'esp32-s3'))
         # No tag yet after https://github.com/esp-rs/xtensa-toolchain/pull/38 (will probably be @v1.5.5)
         uses: esp-rs/xtensa-toolchain@main
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,34 @@ jobs:
           echo "${result}"
           echo "${result}" >> $GITHUB_OUTPUT
 
+      - name: "limit build unless nightly build"
+        if: github.event_name != 'schedule' && steps.should-skip.outputs.result != 'true'
+        run: |
+          case '${{ needs.check-labels.outputs.label }}' in
+            'ci-build:esp')
+              echo "LAZE_BUILDERS=ai-c3,espressif-esp32-c3-lcdkit,espressif-esp32-c6-devkitc-1,espressif-esp32-devkitc,espressif-esp32-s3-devkitc-1" >> "$GITHUB_ENV"
+              ;;
+            'ci-build:full')
+              # Not setting `LAZE_BUILDERS` so that the build is not limited
+              ;;
+            'ci-build:native')
+              echo "LAZE_BUILDERS=native" >> "$GITHUB_ENV"
+              ;;
+            'ci-build:nrf')
+              # Purely redundant boards are excluded for now.
+              echo "LAZE_BUILDERS=bbc-microbit-v1,bbc-microbit-v2,nordic-thingy-91-x-nrf9151,nrf52840dk,nrf52dk,nrf5340dk,nrf5340dk-net,nrf9160dk-nrf9160" >> "$GITHUB_ENV"
+              ;;
+            'ci-build:rp')
+              echo "LAZE_BUILDERS=rpi-pico,rpi-pico2,rpi-pico2-w,rpi-pico-w" >> "$GITHUB_ENV"
+              ;;
+            'ci-build:small')
+              echo "LAZE_BUILDERS=ai-c3,espressif-esp32-devkitc,espressif-esp32-c6-devkitc-1,espressif-esp32-s3-devkitc-1,bbc-microbit-v2,native,nrf52840dk,nrf5340dk,rpi-pico,rpi-pico-w,st-nucleo-c031c6,st-nucleo-h755zi-q,st-nucleo-wb55" >> "$GITHUB_ENV"
+              ;;
+            'ci-build:stm32')
+              echo "LAZE_BUILDERS=st-b-l475e-iot01a,st-steval-mkboxpro,st-nucleo-c031c6,st-nucleo-f042k6,st-nucleo-f401re,st-nucleo-f411re,st-nucleo-f767zi,st-nucleo-h755zi-q,st-nucleo-wb55,st-nucleo-wba55,stm32u083c-dk" >> "$GITHUB_ENV"
+              ;;
+          esac
+
       - name: Run sccache-cache
         if: steps.should-skip.outputs.result != 'true'
         uses: mozilla-actions/sccache-action@v0.0.8
@@ -193,34 +221,6 @@ jobs:
           IFS=":"; for p in $PATH; do ls $p/llvm-config-* $p/clang-* 2>/dev/null; done
           sha256sum /usr/lib/llvm-*/lib/clang/*/include/stdint.h
           true
-
-      - name: "limit build unless nightly build"
-        if: github.event_name != 'schedule' && steps.should-skip.outputs.result != 'true'
-        run: |
-          case '${{ needs.check-labels.outputs.label }}' in
-            'ci-build:esp')
-              echo "LAZE_BUILDERS=ai-c3,espressif-esp32-c3-lcdkit,espressif-esp32-c6-devkitc-1,espressif-esp32-devkitc,espressif-esp32-s3-devkitc-1" >> "$GITHUB_ENV"
-              ;;
-            'ci-build:full')
-              # Not setting `LAZE_BUILDERS` so that the build is not limited
-              ;;
-            'ci-build:native')
-              echo "LAZE_BUILDERS=native" >> "$GITHUB_ENV"
-              ;;
-            'ci-build:nrf')
-              # Purely redundant boards are excluded for now.
-              echo "LAZE_BUILDERS=bbc-microbit-v1,bbc-microbit-v2,nordic-thingy-91-x-nrf9151,nrf52840dk,nrf52dk,nrf5340dk,nrf5340dk-net,nrf9160dk-nrf9160" >> "$GITHUB_ENV"
-              ;;
-            'ci-build:rp')
-              echo "LAZE_BUILDERS=rpi-pico,rpi-pico2,rpi-pico2-w,rpi-pico-w" >> "$GITHUB_ENV"
-              ;;
-            'ci-build:small')
-              echo "LAZE_BUILDERS=ai-c3,espressif-esp32-devkitc,espressif-esp32-c6-devkitc-1,espressif-esp32-s3-devkitc-1,bbc-microbit-v2,native,nrf52840dk,nrf5340dk,rpi-pico,rpi-pico-w,st-nucleo-c031c6,st-nucleo-h755zi-q,st-nucleo-wb55" >> "$GITHUB_ENV"
-              ;;
-            'ci-build:stm32')
-              echo "LAZE_BUILDERS=st-b-l475e-iot01a,st-steval-mkboxpro,st-nucleo-c031c6,st-nucleo-f042k6,st-nucleo-f401re,st-nucleo-f411re,st-nucleo-f767zi,st-nucleo-h755zi-q,st-nucleo-wb55,st-nucleo-wba55,stm32u083c-dk" >> "$GITHUB_ENV"
-              ;;
-          esac
 
       - name: "ariel-os compilation test (default toolchain)"
         if: steps.should-skip.outputs.result != 'true'


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This relies on the set of builders from `LAZE_BUILDERS` to determine whether installing the Xtensa toolchain is needed. Installing it takes a least one minute in CI, for each job, and sometimes takes much longer due to network fluctuations, so this should improve the performance and reliability of the CI a bit.

## How to review this PR

This PR is much better reviewed commit by commit.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Made possible by #1158.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
