### PR TITLE
feat(build): shallow clone git dependencies

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,3 +6,7 @@ features = ['all']
 
 # This is needed so the "include" statement above works.
 config-include = true
+
+[unstable.git]
+shallow_index = true
+shallow_deps = true


### PR DESCRIPTION
# Description

This allows to reduce the time and space needed when cloning dependencies, notably the submodules of nrf-sdc.

## Issues/PRs references

Fixes #1155.

## Open Questions

This is an unstable feature, with the [documentation here](https://doc.rust-lang.org/cargo/reference/unstable.html#git) but I don't see tradeoffs listed.

When changing revision: 

> Even with the presence of Cargo.lock or specifying a commit { rev = "…" }, gitoxide and libgit2 are still smart enough to shallow fetch without unshallowing the existing repository.


## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
