### PR TITLE
docs(tcp-example): use smaller buffers

### DIFF
--- a/examples/tcp-echo/laze.yml
+++ b/examples/tcp-echo/laze.yml
@@ -3,6 +3,6 @@ apps:
     env:
       global:
         executor_stacksize_required:
-          - "32768"
+          - "16384"
     selects:
       - network

--- a/examples/tcp-echo/src/main.rs
+++ b/examples/tcp-echo/src/main.rs
@@ -5,13 +5,21 @@ use ariel_os::{debug::log::*, net, reexports::embassy_net, time::Duration};
 use embassy_net::tcp::TcpSocket;
 use embedded_io_async::Write;
 
+// Setting this to a small value would make packet handling slow and choppy, but would not cause
+// packets to be dropped.
+const RX_BUFFER_SIZE: usize = 128;
+// There is a memory–performance trade-off with these, but small values seem to be working fine for
+// this example.
+const TX_BUFFER_SIZE: usize = 8;
+const RW_BUFFER_SIZE: usize = 8;
+
 #[ariel_os::task(autostart)]
 async fn tcp_echo() {
     let stack = net::network_stack().await.unwrap();
 
-    let mut rx_buffer = [0; 4096];
-    let mut tx_buffer = [0; 4096];
-    let mut buf = [0; 4096];
+    let mut rx_buffer = [0; RX_BUFFER_SIZE];
+    let mut tx_buffer = [0; TX_BUFFER_SIZE];
+    let mut buf = [0; RW_BUFFER_SIZE];
 
     loop {
         let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -550,9 +550,6 @@ contexts:
     parent: stm32
     selects:
       - cortex-m0-plus
-    disables:
-      # TODO: not enough RAM
-      - network
     provides:
       - has_hwrng
       - has_storage_support


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This follows #1048 and does the same for the buffers of the `tcp-echo` example. It allows un-disabling networking on the STM32U083MC.

## Testing

Tested successfully the `tcp-echo` example on:

- espressif-esp32-c6-devkitc-1
- nrf52840dk
- rpi-pico-w
- stm32u083c-dk

Testing on the other MCUs was to make sure it still worked fine with the change of `executor_stacksize_required`.
It was tested with Wi-Fi on the board featuring it, and with DHCP disabled when using Ethernet over USB.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
