### PR TITLE
docs(stm32u083c-dk): document network support

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -590,7 +590,4 @@ boards:
     support:
       user_usb: supported
       wifi: not_available
-      ethernet_over_usb:
-        status: not_currently_supported
-        comments:
-          - not enough RAM
+      ethernet_over_usb: supported


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Following #1176, networking can be marked as supported on the STM32U08MC, which allows to document support for Ethernet over USB on the STM32U083C-DK.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #1176.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
