### PR TITLE
feat(stm32): add support for the STM32U073KC

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -325,6 +325,21 @@ chips:
           - removing items not supported
       wifi: not_available
 
+  stm32u073kc:
+    name: STM32U073KC
+    support:
+      gpio: supported
+      debug_output: supported
+      hwrng: supported
+      i2c_controller: needs_testing
+      spi_main: needs_testing
+      logging: supported
+      storage:
+        status: supported_with_caveats
+        comments:
+          - removing items not supported
+      wifi: not_available
+
   stm32u083mc:
     name: STM32U083MC
     support:

--- a/examples/gpio/src/pins.rs
+++ b/examples/gpio/src/pins.rs
@@ -111,7 +111,7 @@ ariel_os::hal::define_peripherals!(Peripherals {
     btn1: PC4
 });
 
-#[cfg(context = "stm32u083mc")]
+#[cfg(any(context = "stm32u073kc", context = "stm32u083mc"))]
 ariel_os::hal::define_peripherals!(Peripherals {
     led1: PA5,
     btn1: PC2

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -546,6 +546,20 @@ contexts:
         - --cfg capability=\"hw/stm32-rng\"
         - --cfg capability=\"hw/stm32-usb-synopsis\" # Needs an external 32.768 kHz crystal to have a stable clock
 
+  - name: stm32u073kc
+    parent: stm32
+    selects:
+      - cortex-m0-plus
+      - ram-small
+    provides:
+      - has_hwrng
+      - has_storage_support
+    env:
+      PROBE_RS_CHIP: STM32U073KC
+      RUSTFLAGS:
+        - --cfg capability=\"hw/stm32-rng-cryp\"
+        - --cfg capability=\"hw/stm32-usb-drd-fs\"
+
   - name: stm32u083mc
     parent: stm32
     selects:

--- a/src/ariel-os-stm32/src/i2c/controller/mod.rs
+++ b/src/ariel-os-stm32/src/i2c/controller/mod.rs
@@ -247,7 +247,7 @@ define_i2c_drivers!(
    I2C3_EV + I2C3_ER => I2C3,
    I2C4_EV + I2C4_ER => I2C4,
 );
-#[cfg(context = "stm32u083mc")]
+#[cfg(any(context = "stm32u073kc", context = "stm32u083mc"))]
 define_i2c_drivers!(
    I2C1 => I2C1,
    // FIXME: the other three I2C peripherals share the same interrupt

--- a/src/ariel-os-stm32/src/i2c/mod.rs
+++ b/src/ariel-os-stm32/src/i2c/mod.rs
@@ -26,7 +26,7 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
             take_all_i2c_peripherals!(I2C1, I2C2, I2C3, I2C4);
         } else if #[cfg(context = "stm32l475vg")]{
             take_all_i2c_peripherals!(I2C1, I2C2, I2C3);
-        } else if #[cfg(context = "stm32u083mc")] {
+        } else if #[cfg(any(context = "stm32u073kc", context = "stm32u083mc"))] {
             take_all_i2c_peripherals!(I2C1, I2C2, I2C3, I2C4);
         } else if #[cfg(context = "stm32u585ai")] {
             take_all_i2c_peripherals!(I2C1, I2C2, I2C3, I2C4);

--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -222,7 +222,7 @@ fn board_config(config: &mut Config) {
         config.rcc.mux.spi123sel = mux::Saisel::PLL1_Q; // Reset value
     }
 
-    #[cfg(context = "stm32u083mc")]
+    #[cfg(any(context = "stm32u073kc", context = "stm32u083mc"))]
     {
         use embassy_stm32::rcc::*;
 

--- a/src/ariel-os-stm32/src/spi/main/mod.rs
+++ b/src/ariel-os-stm32/src/spi/main/mod.rs
@@ -26,7 +26,7 @@ const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(25);
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(150);
 #[cfg(context = "stm32l475vg")]
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(40);
-#[cfg(context = "stm32u083mc")]
+#[cfg(any(context = "stm32u073kc", context = "stm32u083mc"))]
 const MAX_FREQUENCY: Kilohertz = Kilohertz::MHz(32);
 // TODO: verify, datasheet says "Baud rate prescaler up to kernel frequency/2 or bypass from RCC in
 // master mode", core freq is 160MHz
@@ -178,7 +178,7 @@ define_spi_drivers!(
    SPI2 => SPI2,
    SPI3 => SPI3,
 );
-#[cfg(context = "stm32u083mc")]
+#[cfg(any(context = "stm32u073kc", context = "stm32u083mc"))]
 define_spi_drivers!(
    SPI1 => SPI1,
    // FIXME: the other two SPI peripherals share the same interrupt

--- a/src/ariel-os-stm32/src/spi/mod.rs
+++ b/src/ariel-os-stm32/src/spi/mod.rs
@@ -44,7 +44,7 @@ pub fn init(peripherals: &mut crate::OptionalPeripherals) {
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3, SPI4, SPI5, SPI6);
         }else if #[cfg(context= "stm32l475vg")]{
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3);
-        } else if #[cfg(context = "stm32u083mc")] {
+        } else if #[cfg(any(context = "stm32u073kc", context = "stm32u083mc"))] {
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3);
         } else if #[cfg(context = "stm32u585ai")] {
             take_all_spi_peripherals!(Peripherals, SPI1, SPI2, SPI3);

--- a/src/ariel-os-storage/build.rs
+++ b/src/ariel-os-storage/build.rs
@@ -7,21 +7,26 @@ fn main() {
     // Important: only homogeneous flash organizations are currently supported.
     // Trying to restrict the storage size to the subset of homogeneous flash would not work as it
     // could be pushed out of it by a large enough binary.
-    let (storage_size_total, flash_page_size) =
-        if is_in_current_contexts(&["stm32u083mc", "stm32l475vg", "nrf5340-net", "stm32wle5jc"]) {
-            (4 * KIBIBYTES, 2 * KIBIBYTES)
-        } else if is_in_current_contexts(&["nrf52", "nrf5340", "nrf91", "rp", "stm32wb55rg"]) {
-            (8 * KIBIBYTES, 4 * KIBIBYTES)
-        } else if is_in_current_contexts(&["stm32u585ai"]) {
-            (16 * KIBIBYTES, 8 * KIBIBYTES)
-        } else if is_in_current_contexts(&["stm32h755zi"]) {
-            (256 * KIBIBYTES, 128 * KIBIBYTES)
-        } else if !is_in_current_contexts(&["ariel-os"]) {
-            // Dummy value for platform-independent tooling.
-            (8 * KIBIBYTES, 4 * KIBIBYTES)
-        } else {
-            panic!("MCU not supported");
-        };
+    let (storage_size_total, flash_page_size) = if is_in_current_contexts(&[
+        "stm32u073kc",
+        "stm32u083mc",
+        "stm32l475vg",
+        "nrf5340-net",
+        "stm32wle5jc",
+    ]) {
+        (4 * KIBIBYTES, 2 * KIBIBYTES)
+    } else if is_in_current_contexts(&["nrf52", "nrf5340", "nrf91", "rp", "stm32wb55rg"]) {
+        (8 * KIBIBYTES, 4 * KIBIBYTES)
+    } else if is_in_current_contexts(&["stm32u585ai"]) {
+        (16 * KIBIBYTES, 8 * KIBIBYTES)
+    } else if is_in_current_contexts(&["stm32h755zi"]) {
+        (256 * KIBIBYTES, 128 * KIBIBYTES)
+    } else if !is_in_current_contexts(&["ariel-os"]) {
+        // Dummy value for platform-independent tooling.
+        (8 * KIBIBYTES, 4 * KIBIBYTES)
+    } else {
+        panic!("MCU not supported");
+    };
 
     // `sequential-storage` needs at least two flash pages.
     assert!(storage_size_total / flash_page_size >= 2);

--- a/tests/i2c-controller/src/pins.rs
+++ b/tests/i2c-controller/src/pins.rs
@@ -79,9 +79,9 @@ ariel_os::hal::define_peripherals!(Peripherals {
     i2c_scl: PB8,
 });
 
-#[cfg(context = "stm32u083mc")]
+#[cfg(any(context = "stm32u073kc", context = "stm32u083mc"))]
 pub type SensorI2c = i2c::controller::I2C1;
-#[cfg(context = "stm32u083mc")]
+#[cfg(any(context = "stm32u073kc", context = "stm32u083mc"))]
 ariel_os::hal::define_peripherals!(Peripherals {
     i2c_sda: PB7,
     i2c_scl: PB8,

--- a/tests/spi-loopback/src/pins.rs
+++ b/tests/spi-loopback/src/pins.rs
@@ -93,9 +93,9 @@ ariel_os::hal::define_peripherals!(Peripherals {
 });
 
 // Side SPI of Arduino v3 connector
-#[cfg(context = "stm32u083mc")]
+#[cfg(any(context = "stm32u073kc", context = "stm32u083mc"))]
 pub type SensorSpi = spi::main::SPI1;
-#[cfg(context = "stm32u083mc")]
+#[cfg(any(context = "stm32u073kc", context = "stm32u083mc"))]
 ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: PA5,
     spi_miso: PA6,

--- a/tests/spi-main/src/pins.rs
+++ b/tests/spi-main/src/pins.rs
@@ -95,9 +95,9 @@ ariel_os::hal::define_peripherals!(Peripherals {
 });
 
 // Side SPI of Arduino v3 connector
-#[cfg(context = "stm32u083mc")]
+#[cfg(any(context = "stm32u073kc", context = "stm32u083mc"))]
 pub type SensorSpi = spi::main::SPI1;
-#[cfg(context = "stm32u083mc")]
+#[cfg(any(context = "stm32u073kc", context = "stm32u083mc"))]
 ariel_os::hal::define_peripherals!(Peripherals {
     spi_sck: PA5,
     spi_miso: PA6,


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This adds support for the STM32U073KC MCU: the STM32U073 is the same as the STM32U083 we already support, the only difference being it does not have an AES accelerator. Adding support for it is useful because it is slightly cheaper and, maybe more importantly for now, is more stocked by PCBA manufacturers.

There is no official development kit with that MCU (the closest one is the STM32U083C-DK which we do support), so this does not add a board in the support matrix (nor to the CI), only the MCU. How we render support for MCUs without a board is part of #1182.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
