### PR TITLE
fix(doc): document storage support for nRF52832

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -76,7 +76,7 @@ chips:
       i2c_controller: not_currently_supported
       spi_main: not_currently_supported
       logging: supported
-      storage: not_currently_supported
+      storage: supported
       wifi: not_available
       user_usb: not_available
       ethernet_over_usb: not_available


### PR DESCRIPTION
# Description

Document storage support on nRF52832. The testing was done by successfully running the `storage` example on the IoT-LAB on a nRF52-DK board.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Closes #1178.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
