### PR TITLE
fix(vscode-config): copy RUSTFLAGS

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -199,7 +199,7 @@ contexts:
           - CARGO_ARGS
           - CARGO_ENV
         cmd: # We have to obfuscate the variables to avoid cargo interpreting them since we're running a rust script
-          - _CARGO_TOOLCHAIN='${CARGO_TOOLCHAIN}' ${relroot}/${root}/scripts/vscode.rs
+          - _CARGO_TOOLCHAIN='${CARGO_TOOLCHAIN}' _RUSTFLAGS="${RUSTFLAGS}" ${relroot}/${root}/scripts/vscode.rs
 
   - name: nrf
     help: Nordic MCU support (based on embassy-nrf)

--- a/scripts/vscode.rs
+++ b/scripts/vscode.rs
@@ -133,6 +133,11 @@ fn main() -> miette::Result<()> {
     let toolchain = toolchain[1..].to_string(); // Remove the leading '+' character
     extra_env.insert("RUSTUP_TOOLCHAIN".to_string(), Value::String(toolchain));
 
+    // Copy the RUSTFLAGS environment variable, without the target prefix
+    if let Ok(rustflags_env) = std::env::var("_RUSTFLAGS") {
+        extra_env.insert("RUSTFLAGS".to_string(), Value::String(rustflags_env));
+    }
+
     if !extra_env.is_empty() {
         settings_json.insert(
             "rust-analyzer.server.extraEnv".to_string(),


### PR DESCRIPTION
# Description

This copies the RUSTFLAGS environment variable into the environment of rust-analyzer, without the target prefix. This solves a problem where some of the tools used by rust-analyzer do not read the RUSTFLAGS of the target, resulting in situations where jumping to definition would lead to the dummy implementation.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Related to #942 

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
