### PR TITLE
refactor(coap): avoid parsing a string to create a listening address

### DIFF
--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -14,6 +14,8 @@ mod udp_nal;
 #[cfg(feature = "coap-server-config-storage")]
 mod stored;
 
+use core::net::{Ipv6Addr, SocketAddr};
+
 use ariel_os_debug::log::info;
 use ariel_os_embassy::cell::SameExecutorCell;
 use coap_handler_implementations::ReportingHandlerBuilder;
@@ -142,7 +144,7 @@ async fn coap_run_impl(handler: impl coap_handler::Handler + coap_handler::Repor
 
     info!("Starting up CoAP server");
 
-    let local_any = "[::]:5683".parse().unwrap();
+    let local_any = SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 5683);
     let mut unconnected = udp_nal::UnconnectedUdp::bind_multiple(socket, local_any)
         .await
         .unwrap();


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This instantiates an `[::]:5683` `SocketAddr` directly instead of parsing a string at runtime, with the aim of reducing the binary size.

Measuring using the following command:

```sh
CONFIG_WIFI_NETWORK=<ssid> CONFIG_WIFI_PASSWORD=<pwd> laze -C tests/coap build -b rpi-pico-w size
```

this shaves around 800 bytes of text:

```
   text    data     bss     dec     hex filename
 539932       8   67804  607744   94600 build/bin/rpi-pico-w/test-coap/test-coap.elf
```

down from:

```
   text    data     bss     dec     hex filename
 540760       8   67804  608572   9493c build/bin/rpi-pico-w/test-coap/test-coap.elf
```

This is very likely because this was the only occurrence of the std's parsing logic in the whole binary.

## Testing

@chrysn Can you make sure this still works as expected? I'm not too sure which execution paths lead to this.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
