### PR TITLE
fix(build): enable no-catch-reset option for probe-rs

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -349,7 +349,7 @@ contexts:
     tasks:
       debug-rs:
         cmd:
-          - probe-rs debug --chip ${PROBE_RS_CHIP} --exe ${out} $@
+          - probe-rs debug --chip ${PROBE_RS_CHIP} --exe ${out} --no-catch-reset $@
 
   - name: rp235xa
     parent: rp
@@ -1000,7 +1000,7 @@ modules:
 
     env:
       global:
-        CARGO_RUNNER: "'probe-rs run ${PROBE_RS_PROTOCOL} --chip ${PROBE_RS_CHIP} --preverify'"
+        CARGO_RUNNER: "'probe-rs run ${PROBE_RS_PROTOCOL} --chip ${PROBE_RS_CHIP} --preverify --no-catch-reset'"
 
     tasks:
       flash-erase-all:


### PR DESCRIPTION
This adds the `--no-catch-reset` option to probe-rs run and debug commands. This prevents recent versions of probe-rs from stopping when a soft reset happens, keeping the same behaviour as v0.27.

# Description

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

Probe-rs issue: https://github.com/probe-rs/probe-rs/issues/3469

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
