### PR TITLE
ci(lint): install `taplo-cli` without relying on `cargo-binstall`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -371,7 +371,8 @@ jobs:
       - name: Install taplo
         uses: taiki-e/install-action@v2
         with:
-          tool: taplo-cli
+          tool: taplo
+          fallback: none
 
       - name: Check toml formatting
         run: taplo fmt --check


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Now that [`taiki-e/install-action` supports `taplo-cli` directly](https://github.com/taiki-e/install-action/blob/main/TOOLS.md), we can avoid relying on it falling back on using `cargo-binstall`.
The correct name for `taiki-e/install-action` [is however `taplo`, not `taplo-cli`](https://github.com/taiki-e/install-action/issues/1100).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
