### PR TITLE
ci(build): fix `check-labels` succeeding on PRs with many commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,11 @@ jobs:
             'ci-build:stm32')
               echo "LAZE_BUILDERS=st-b-l475e-iot01a,st-steval-mkboxpro,st-nucleo-c031c6,st-nucleo-f042k6,st-nucleo-f401re,st-nucleo-f411re,st-nucleo-f767zi,st-nucleo-h755zi-q,st-nucleo-wb55,st-nucleo-wba55,stm32u083c-dk" >> "$GITHUB_ENV"
               ;;
+            *)
+              # Can happen if `check-labels` finds no labels but still completes
+              # successfully because of a bug.
+              exit 1
+              ;;
           esac
 
       - name: Run sccache-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
             for (const pr of items) {
               const prNumber = pr.number;
               const { data: commits } = await github.rest.pulls.listCommits({ owner: 'ariel-os', repo: 'ariel-os', pull_number: prNumber });
+              // TODO: handle pagination
               const tipCommitId = commits[commits.length - 1].sha;
               if (tipCommitId != commitId) {
                 console.log(`Wrong PR: tip is ${tipCommitId}`);
@@ -70,6 +71,8 @@ jobs:
               console.log(`The build label is ${buildLabel}`);
               return buildLabel;
             }
+            // This can happen because the API is paginated.
+            throw 'Did not find the PR; maybe it has more than 30 commits?';
 
   build:
     needs: check-labels


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Fixes an issue with the `check-labels` job introduced in #843 which could arise when the PR has more commits than the pagination limit of GitHub's API (30 commits). It would then incorrectly succeed, which would result in the `Build` workflow running for the entire set of builders, as the build would then not be restricted.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
