### PR TITLE
 feat(support-matrix): collect all errors instead of one 

### DIFF
--- a/doc/gen_support_matrix_html.rs
+++ b/doc/gen_support_matrix_html.rs
@@ -175,6 +175,25 @@ struct SubCommandCheck {
     output_file: PathBuf,
 }
 
+#[derive(Debug, Serialize)]
+struct BoardSupport {
+    chip: String,
+    chip_technical_name: String,
+    url: String,
+    technical_name: String,
+    name: String,
+    tier: String,
+    functionalities: Vec<FunctionalitySupport>,
+}
+
+#[derive(Debug, Serialize)]
+struct FunctionalitySupport {
+    icon: String,
+    description: String,
+    // TODO: add comments
+    // TODO: add the PR link
+}
+
 fn main() -> miette::Result<()> {
     let args: Args = argh::from_env();
 
@@ -264,24 +283,6 @@ fn validate_input(matrix: &schema::Matrix) -> Result<(), Error> {
 fn render_html(matrix: &schema::Matrix, board_support_tier: &SupportTier) -> Result<String, Error> {
     use minijinja::{Environment, context};
 
-    #[derive(Debug, Serialize)]
-    struct BoardSupport {
-        chip: String,
-        chip_technical_name: String,
-        url: String,
-        technical_name: String,
-        name: String,
-        tier: String,
-        functionalities: Vec<FunctionalitySupport>,
-    }
-
-    #[derive(Debug, Serialize)]
-    struct FunctionalitySupport {
-        icon: String,
-        description: String,
-        // TODO: add comments
-        // TODO: add the PR link
-    }
 
     let mut boards = matrix.boards.iter().map(|(board_technical_name, board_info)| {
         let board_name = &board_info.name;


### PR DESCRIPTION
# Description

This pr changes the validation and functionality mapping by collecting all errors into one if there are any errors during the process. This has the advantage that all errors are printed during a single execution instead of only one at a time.

So far it is still split into validation errors and board mapping errors, printing only validation errors if there are some, and omitting any board mapping errors.

The goal is to make the generator a bit more user friendly and prevent CI whack-a-mole when adding a new feature

The generated output should not have changed

## Issues/PRs references

None

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
