### PR TITLE
fix(clippy): allow the `collapsible_if` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ unexpected_cfgs = "allow"
 
 [workspace.lints.clippy]
 # Clippy lints are documented here: https://rust-lang.github.io/rust-clippy/master/index.html
+collapsible_if = "allow"                     # We can remove this when we bump the MSRV to 1.89 or higher.
 indexing_slicing = "deny"
 missing_safety_doc = { level = "warn" }
 pedantic = { level = "warn", priority = -1 }


### PR DESCRIPTION
# Description

This PR allows the `collapsible_if` Clippy lint which triggered new lint errors due to the new `if let` chains introduced in 1.89. We allow this lint since we do not want to bump the MSRV to 1.89 yet.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
