### PR TITLE
refactor(sensors): make appropriate iterators `ExactSizeIterator`s

### DIFF
--- a/src/ariel-os-macros/src/define_count_adjusted_sensor_enums.rs
+++ b/src/ariel-os-macros/src/define_count_adjusted_sensor_enums.rs
@@ -106,7 +106,7 @@ pub fn define_count_adjusted_sensor_enums(_item: TokenStream) -> TokenStream {
             /// [`Samples`].
             /// [`Iterator::zip()`] can be useful to zip the returned iterator with the one
             /// obtained with [`Reading::samples()`].
-            pub fn iter(&self) -> impl Iterator<Item = ReadingChannel> + '_ {
+            pub fn iter(&self) -> impl ExactSizeIterator<Item = ReadingChannel> + '_ {
                 match self {
                     #(#samples_iter),*,
                 }

--- a/src/ariel-os-sensors/src/registry.rs
+++ b/src/ariel-os-sensors/src/registry.rs
@@ -33,7 +33,8 @@ impl Registry {
     }
 
     /// Returns an iterator over registered sensor driver instances.
-    pub fn sensors(&self) -> impl Iterator<Item = &'static dyn Sensor> {
+    #[must_use]
+    pub fn sensors(&self) -> impl ExactSizeIterator<Item = &'static dyn Sensor> {
         // Returning an iterator instead of the distributed slice directly would allow us to chain
         // another source of sensor driver instances in the future, if we decided to support
         // dynamically-allocated sensor driver instances.


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
These iterators are constructed from arrays, so it makes sense to guarantee that they impl `ExactSizeIterator` so that consumers can rely on it.

This is not a breaking change as these items are not yet documented.

## How to review this PR

With #1219 in, the `ariel-os-sensors` crate's documentation can be generated with:

```sh
cargo +nightly doc -p ariel-os-sensors
```

---

`ci-build:skip` is enough because there is currently no implementors and Clippy and rustdoc make sure the rest is fine. 

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Mostly extracted from #1191.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
