### PR TITLE
fix(sensors): enable `defmt` on `ariel-os-sensors` when needed

### DIFF
--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -165,6 +165,7 @@ defmt = [
   "ariel-os-coap?/defmt",
   "ariel-os-debug/defmt",
   "ariel-os-embassy/defmt",
+  "ariel-os-sensors?/defmt",
   "ariel-os-threads?/defmt",
   "ariel-os-bench?/defmt",
 ]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
The `defmt` Cargo feature needs to be propagated to the `ariel-os-sensors` crate, otherwise its types are not printable with `defmt`.

---

`ci-build:skip` is enough because there is currently no implementors and Clippy and rustdoc make sure the rest is fine.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Extracted from #1191.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
