### PR TITLE
fix(stm32u083mc): disable networking again to accommodate HTTP examples

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -550,6 +550,9 @@ contexts:
     parent: stm32
     selects:
       - cortex-m0-plus
+    disables:
+      # TODO: not enough RAM for HTTP examples
+      - network
     provides:
       - has_hwrng
       - has_storage_support


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Following #1176 which focused too much on the `tcp-echo` example, the HTTP examples are still not able to link properly because of lack of RAM. This disables networking on that chip again, as a temporary measure, until we decide how to only disable the HTTP examples on that chip.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
