### PR TITLE
chore: remove rust-version manifest key from ariel-os-sensors

### DIFF
--- a/src/ariel-os-sensors/Cargo.toml
+++ b/src/ariel-os-sensors/Cargo.toml
@@ -3,7 +3,6 @@ name = "ariel-os-sensors"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
-rust-version = "1.85"
 repository.workspace = true
 
 [lints]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Remove `rust-version` key from `ariel-os-sensors` manifest

## Issues/PRs references
#1242 Seems to imply that there should only be one instance of `rust-version` across the workspace.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
