### PR TITLE
chore: reconfigure renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,11 +38,6 @@
       ],
       "enabled": false
     },
-    // Attach ci-build:native to changes relating to github-actions
-    {
-      "matchManagers": ["github-actions"],
-      "labels": ["ci-build:native"]
-    },
     // Packages that contain nrf will get a ci-build:nrf label
     {
       "matchPackageNames" : [ "/^.*nrf.*/i" ],
@@ -63,7 +58,9 @@
       "matchPackageNames" : [ "/^.*-rp$/i" ],
       "labels": ["ci-build:rp"]
     }
-  ]
+  ],
+  // Add a 'renovate' label to every PR for the matrix bot
+  "addLabels": ["renovate"]
   // TODO: uncomment once confident that renovates works properly
   // "patch": {
   //   "automerge": true


### PR DESCRIPTION
# Description

This PR reconfigures renovate to add `renovate` labels to every PR raised by Renovate. It also removes the `ci-build:native` rule for actions because in the case that other packages (i.e. dev dependencies) need to be pinned this leads to the PR having two build labels which fails the CI
<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
