### PR TITLE
chore: prevent matrix bot from reporting renovate PRs

### DIFF
--- a/.github/workflows/matrix-bot.yml
+++ b/.github/workflows/matrix-bot.yml
@@ -3,9 +3,12 @@ on:
   pull_request_target:
     types: [opened, ready_for_review, closed]
 
+
 jobs:
   new-pr:
-    if: github.event.action == 'opened' && github.repository == 'ariel-os/ariel-os'
+    if: |
+      github.event.action == 'opened' && github.repository == 'ariel-os/ariel-os' &&
+      !contains(github.even.pull_request.labels.*.name, 'renovate')
     runs-on: ubuntu-latest
     continue-on-error: true
     env:
@@ -21,7 +24,9 @@ jobs:
           message_type: "notice"
 
   ready-for-review-pr:
-    if: github.event.action == 'ready_for_review' && github.repository == 'ariel-os/ariel-os'
+    if: |
+      github.event.action == 'ready_for_review' && github.repository == 'ariel-os/ariel-os' &&
+      !contains(github.even.pull_request.labels.*.name, 'renovate')
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -35,7 +40,9 @@ jobs:
           message_type: "notice"
 
   merged-pr:
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true && github.repository == 'ariel-os/ariel-os'
+    if: |
+      github.event.action == 'closed' && github.event.pull_request.merged == true && github.repository == 'ariel-os/ariel-os' &&
+      !contains(github.even.pull_request.labels.*.name, 'renovate')
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -49,7 +56,9 @@ jobs:
           message_type: "notice"
 
   abandoned-pr:
-    if: github.event.action == 'closed' && github.event.pull_request.merged == false && github.repository == 'ariel-os/ariel-os'
+    if: |
+      github.event.action == 'closed' && github.event.pull_request.merged == false && github.repository == 'ariel-os/ariel-os' &&
+      !contains(github.even.pull_request.labels.*.name, 'renovate')
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/matrix-bot.yml
+++ b/.github/workflows/matrix-bot.yml
@@ -8,7 +8,7 @@ jobs:
   new-pr:
     if: |
       github.event.action == 'opened' && github.repository == 'ariel-os/ariel-os' &&
-      !contains(github.even.pull_request.labels.*.name, 'renovate')
+      !contains(github.event.pull_request.labels.*.name, 'renovate')
     runs-on: ubuntu-latest
     continue-on-error: true
     env:
@@ -26,7 +26,7 @@ jobs:
   ready-for-review-pr:
     if: |
       github.event.action == 'ready_for_review' && github.repository == 'ariel-os/ariel-os' &&
-      !contains(github.even.pull_request.labels.*.name, 'renovate')
+      !contains(github.event.pull_request.labels.*.name, 'renovate')
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -42,7 +42,7 @@ jobs:
   merged-pr:
     if: |
       github.event.action == 'closed' && github.event.pull_request.merged == true && github.repository == 'ariel-os/ariel-os' &&
-      !contains(github.even.pull_request.labels.*.name, 'renovate')
+      !contains(github.event.pull_request.labels.*.name, 'renovate')
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -58,7 +58,7 @@ jobs:
   abandoned-pr:
     if: |
       github.event.action == 'closed' && github.event.pull_request.merged == false && github.repository == 'ariel-os/ariel-os' &&
-      !contains(github.even.pull_request.labels.*.name, 'renovate')
+      !contains(github.event.pull_request.labels.*.name, 'renovate')
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/matrix-bot.yml
+++ b/.github/workflows/matrix-bot.yml
@@ -3,7 +3,6 @@ on:
   pull_request_target:
     types: [opened, ready_for_review, closed]
 
-
 jobs:
   new-pr:
     if: |


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
From what I understand from this [SO exchange](https://stackoverflow.com/a/59588725) this is how to restrict the bot from warning us about PRs with the label `renovate`. 
## Issues/PRs references

See also #1248 which makes the renovate bot add the aforementioned labels to every PR it raises
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
