### PR TITLE
chore(deps): remove `konst` from the workspace manifest as it is unused

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,6 @@ defmt = { version = "1.0.0" }
 document-features = "0.2.8"
 fugit = { version = "0.3.7", default-features = false }
 heapless = { version = "0.8.0", default-features = false }
-konst = { version = "0.3.8", default-features = false }
 ld-memory = { version = "0.2.9" }
 log = { version = "0.4.20", default-features = false }
 once_cell = { version = "=1.19.0", default-features = false, features = [


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This removes the `konst` dependency from the workspace manifest, as it is now unused since #1271.

`ci-build:skip` is enough as Clippy already checks the dependency graph and that the only remaining occurrences of the string `konst` in the codebase are in the demo SVG.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Closes #1286.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
