### PR TITLE
fix(ble): propagate the `defmt` feature to `trouble-host` when enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5579,6 +5579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b31abacc7bd8bc686160f6de3347a3b7669ae4a31e4eef9a306466e97d297cea"
 dependencies = [
  "bt-hci",
+ "defmt 0.3.100",
  "embassy-futures",
  "embassy-sync 0.6.2",
  "embassy-time",

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -149,6 +149,7 @@ defmt = [
   "embassy-usb?/defmt",
   "ariel-os-hal/defmt",
   "ariel-os-embassy-common/defmt",
+  "trouble-host?/defmt",
   "usbd-hid?/defmt",
 ]
 log = ["ariel-os-hal/log"]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This PR propagates the `defmt` Cargo feature to `trouble-host` when enabled, to make debugging easier in some cases.

## Testing

Successfully tested on nrf52840dk, `trouble-host` log lines start with `[host]`. We might want to tune its log level down, but this can be done later (if not already resolved by updating to `trouble-host` v0.2 in #1307).

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
