### PR TITLE
chore: specify the `rust-version` of each `ariel-os*` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ resolver = "3"
 [workspace.package]
 license = "MIT OR Apache-2.0"
 edition = "2024"
+# This should be the Ariel OS MSRV.
+# Some crates may have a different MSRV.
+rust-version = "1.85"
 repository = "https://github.com/ariel-os/ariel-os"
 
 [workspace.dependencies]

--- a/src/ariel-os-alloc/Cargo.toml
+++ b/src/ariel-os-alloc/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-alloc"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [lints]

--- a/src/ariel-os-bench/Cargo.toml
+++ b/src/ariel-os-bench/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-bench"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [lints]

--- a/src/ariel-os-boards/Cargo.toml
+++ b/src/ariel-os-boards/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-boards"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/src/ariel-os-buildinfo/Cargo.toml
+++ b/src/ariel-os-buildinfo/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-buildinfo"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [lints]

--- a/src/ariel-os-coap/Cargo.toml
+++ b/src/ariel-os-coap/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-coap"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/src/ariel-os-debug-log/Cargo.toml
+++ b/src/ariel-os-debug-log/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-debug-log"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [lints]

--- a/src/ariel-os-debug/Cargo.toml
+++ b/src/ariel-os-debug/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-debug"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/ariel-os-embassy-common/Cargo.toml
+++ b/src/ariel-os-embassy-common/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-embassy-common"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [lints]

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-embassy"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-esp"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [lints]

--- a/src/ariel-os-hal/Cargo.toml
+++ b/src/ariel-os-hal/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-hal"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/src/ariel-os-identity/Cargo.toml
+++ b/src/ariel-os-identity/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ariel-os-identity"
 version = "0.2.0"
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 license.workspace = true
 

--- a/src/ariel-os-macros/Cargo.toml
+++ b/src/ariel-os-macros/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-macros"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/ariel-os-native/Cargo.toml
+++ b/src/ariel-os-native/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-native"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [lints]

--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-nrf"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [lints]

--- a/src/ariel-os-power/Cargo.toml
+++ b/src/ariel-os-power/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-power"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [lints]

--- a/src/ariel-os-random/Cargo.toml
+++ b/src/ariel-os-random/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-random"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [lints]

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-rp"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [lints]

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-rt"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/src/ariel-os-runqueue/Cargo.toml
+++ b/src/ariel-os-runqueue/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-runqueue"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "Ariel OS runqueue implementation"
 
 [lints]

--- a/src/ariel-os-sensors/Cargo.toml
+++ b/src/ariel-os-sensors/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "ariel-os-sensors"
+# The sensor API is versioned separately from the rest of Ariel OS.
+# Introducing a breaking change fragments the ecosystem of sensor drivers.
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
+# This crate's MSRV is decoupled from Ariel OS's.
 rust-version = "1.85"
 repository.workspace = true
 

--- a/src/ariel-os-stm32-mapping/Cargo.toml
+++ b/src/ariel-os-stm32-mapping/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-stm32-mapping"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 # BEGIN AUTO-GENERATED STM32 MAPPING

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-stm32"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 
 [lints]

--- a/src/ariel-os-storage/Cargo.toml
+++ b/src/ariel-os-storage/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-storage"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "Ariel OS storage API"
 
 [lints]

--- a/src/ariel-os-threads/Cargo.toml
+++ b/src/ariel-os-threads/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ariel-os-threads"
 version = "0.2.0"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 description = "generic embedded scheduler & IPC"
 include = ["src/**/*", "README.md"]

--- a/src/ariel-os-utils/Cargo.toml
+++ b/src/ariel-os-utils/Cargo.toml
@@ -3,6 +3,7 @@ name = "ariel-os-utils"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -3,9 +3,7 @@ name = "ariel-os"
 version = "0.2.0"
 license.workspace = true
 edition.workspace = true
-
-# This should be the Ariel OS MSRV.
-rust-version = "1.85"
+rust-version.workspace = true
 
 [package.metadata.release]
 # We're using this crate to mangle our workspace level `CHANGELOG.md`.


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This specifies the `rust-version` (i.e., the MSRV) of each `ariel-os*` crate. Before that, only the one of `ariel-os` was specified for tools to use.
This also clarifies the versioning policy of the `ariel-os-sensors` crate.

---

Using `ci-build:skip` as manifests are checked by Clippy and CI builds with Rust 1.85, which is the specified MSRV.

## How to review this PR

This PR is better reviewed commit by commit.
All `ariel-os*` manifests must now have a `rust-version` key.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
