### PR TITLE
refactor(i2c): replace `embassy-futures`'s `select` with `with_timeout`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,6 @@ dependencies = [
  "ariel-os-utils",
  "const-sha1",
  "defmt 1.0.1",
- "embassy-futures",
  "embassy-time",
  "embedded-hal 1.0.0",
  "embedded-hal-async",

--- a/src/ariel-os-embassy-common/Cargo.toml
+++ b/src/ariel-os-embassy-common/Cargo.toml
@@ -13,7 +13,6 @@ ariel-os-buildinfo = { workspace = true }
 ariel-os-utils = { workspace = true }
 defmt = { workspace = true, optional = true }
 fugit = { workspace = true, optional = true }
-embassy-futures = { workspace = true }
 embassy-time = { workspace = true }
 embedded-hal = { workspace = true }
 embedded-hal-async = { workspace = true }

--- a/src/ariel-os-embassy-common/src/i2c/controller/mod.rs
+++ b/src/ariel-os-embassy-common/src/i2c/controller/mod.rs
@@ -171,13 +171,13 @@ macro_rules! impl_async_i2c_for_driver_enum {
 #[macro_export]
 macro_rules! handle_i2c_timeout_res {
     ($i2c:ident, $op:ident, $address:ident, $( $param:ident ),+) => {{
-        let res = $crate::reexports::embassy_futures::select::select(
+        let res = $crate::reexports::embassy_time::with_timeout(
+            $crate::i2c::controller::I2C_TIMEOUT,
             // Disambiguate between the trait methods and the direct methods.
             $crate::reexports::embedded_hal_async::i2c::I2c::$op(&mut $i2c.twim, $address, $( $param ),+),
-            $crate::reexports::embassy_time::Timer::after($crate::i2c::controller::I2C_TIMEOUT),
         ).await;
 
-        if let $crate::reexports::embassy_futures::select::Either::First(op) = res {
+        if let Ok(op) = res {
             // `from_error` is defined in each HAL
             op.map_err(from_error)
         } else {

--- a/src/ariel-os-embassy-common/src/lib.rs
+++ b/src/ariel-os-embassy-common/src/lib.rs
@@ -27,7 +27,6 @@ pub mod reexports {
     //! Crate re-exports.
 
     // Used by macros provided by this crate.
-    pub use embassy_futures;
     pub use embassy_time;
     pub use embedded_hal_async;
 }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This leverages `embassy_time::with_timeout()` to replace a construct using `embassy_futures`'s `select()` combined with a `Timer` to implement I2C communication timeouts. This makes the implementation a bit simpler and easier to parse, and allows removing `embassy_futures` as a dependency of the internal `ariel-os-embassy-common`.

## Testing

The happy path can be tested on an stm32u083c-dk or an bbc-microbit-v2 (as they both have an onboard I2C sensor) with the `tests/i2c-controller` test, and the failing/timeout path on an nrf52840dk with that same test (as it does *not* have any I2C device on board): it should panic with an `I2c(NoAcknowledge(Unknown))` error.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
