### PR TITLE
chore(ariel-os-coap): remove the unused `embassy-futures` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,6 @@ dependencies = [
  "coap-numbers",
  "coapcore",
  "critical-section",
- "embassy-futures",
  "embassy-net",
  "embassy-sync 0.6.2",
  "embedded-io-async",

--- a/src/ariel-os-coap/Cargo.toml
+++ b/src/ariel-os-coap/Cargo.toml
@@ -10,7 +10,6 @@ coapcore = { path = "../lib/coapcore", default-features = false }
 coap-handler = "0.2.0"
 coap-handler-implementations = "0.5.0"
 critical-section.workspace = true
-embassy-futures = { workspace = true }
 # These features should be more selective and not enabled here, but as things
 # stand, this modules also contains the embedded-nal implementation for
 # embassy-net, and that needs its features in sync; enabling them all ensures a


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This removes the `embassy-futures` dependency from `ariel-os-coap`, which seems unused (grepping for `embassy_futures` returns no matches). It seems I did not bother checking whether it was used in #793. 

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
