### PR TITLE
fix(esp-wifi): `isr_stacksize_required` is a list

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1412,7 +1412,8 @@ modules:
     env:
       global:
         # esp-wifi needs a lot of ISR stack.
-        isr_stacksize_required: "32768"
+        isr_stacksize_required:
+          - "32768"
         # esp-wifi needs 72KiB
         heapsize_required:
           - $(72*1024)


### PR DESCRIPTION
# Description

`isr_stacksize_required` must be a list for the `max(...)` machinery to work.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
