### PR TITLE
feat(time): provide a `with_timeout()` helper by re-exporting Embassy's

### DIFF
--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -71,7 +71,9 @@ pub mod api {
 
         // NOTE: we may want to re-export more items in the future, but not re-export the whole
         // crate.
-        pub use embassy_time::{Delay, Duration, Instant, TICK_HZ, Timer};
+        pub use embassy_time::{
+            Delay, Duration, Instant, TICK_HZ, TimeoutError, Timer, with_timeout,
+        };
     }
 
     #[cfg(feature = "ble")]


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This re-exports `with_timeout()` as implementing timeouts is very common and otherwise users need to rely on `embassy-futures`'s `select()`. By exposing this we only commit to its API, not the fact that it is currently an `embassy-time` re-export, thanks to #1321.

## How to review this PR

Browse the rendered docs and make sure none of the types newly exposed (including as function parameters and return types) refer to types from `ariel_os::reexports`.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
