### PR TITLE
test(sensors): make host tests run for `ariel-os-sensors` as well

### DIFF
--- a/src/ariel-os-sensors/Cargo.toml
+++ b/src/ariel-os-sensors/Cargo.toml
@@ -32,3 +32,5 @@ max-sample-min-count-7 = ["ariel-os-macros/max-sample-min-count-7"]
 max-sample-min-count-8 = ["ariel-os-macros/max-sample-min-count-8"]
 max-sample-min-count-9 = ["ariel-os-macros/max-sample-min-count-9"]
 max-sample-min-count-12 = ["ariel-os-macros/max-sample-min-count-12"]
+
+_test = []

--- a/src/ariel-os-sensors/laze.yml
+++ b/src/ariel-os-sensors/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: crates/ariel-os-sensors
+    selects:
+      - host-test-only

--- a/src/laze.yml
+++ b/src/laze.yml
@@ -9,6 +9,7 @@ subdirs:
   - ariel-os-nrf
   - ariel-os-rp
   - ariel-os-runqueue
+  - ariel-os-sensors
   - ariel-os-stm32
   - ariel-os-threads
   - lib


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This makes host tests actually run for the `ariel-os-sensors` crate.

Using `ci-build:skip` as that still allows host tests to run in CI.

## How to review this PR

To test this, introduce a syntax error in the doc test in `src/ariel-os-sensors/src/sample.rs` for instance, and then run the following command, which runs the host tests for every properly set-up crate:

```sh
laze build --builders host --multiple-tasks --global test
```

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
