### PR TITLE
fix(coap): use unmaintained `serde_yaml` instead of unsound `serde_yml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
  "lakers-crypto-rustcrypto",
  "minicbor 0.26.5",
  "serde",
- "serde_yml",
+ "serde_yaml",
  "static_cell",
 ]
 
@@ -3681,16 +3681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linked_list_allocator"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5006,18 +4996,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap 2.9.0",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -5680,6 +5668,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/src/ariel-os-coap/Cargo.toml
+++ b/src/ariel-os-coap/Cargo.toml
@@ -46,7 +46,7 @@ hexlit = "0.5.5"
 embedded-io-async = { workspace = true }
 
 [build-dependencies]
-serde_yml = "0.0.12"
+serde_yaml = "0.9.34"
 serde = "1"
 # "blessed" by Cargo basing its build script API on it <https://blog.rust-lang.org/inside-rust/2024/12/13/this-development-cycle-in-cargo-1.84.html#build-script-api>
 build-rs = "0.3.0"

--- a/src/ariel-os-coap/build.rs
+++ b/src/ariel-os-coap/build.rs
@@ -88,7 +88,7 @@ fn main() {
         })
         .expect("no peers.yml usable in specified location");
 
-    let peers: Vec<Peer> = serde_yml::from_reader(peers_file).expect("failed to parse peers.yml");
+    let peers: Vec<Peer> = serde_yaml::from_reader(peers_file).expect("failed to parse peers.yml");
 
     let mut unauthenticated_scope = None;
     let mut chain_once_per_kccs = String::new();


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This replaces `serde_yml`, an LLM-"maintained", unsound fork of the unmaintained `serde_yaml`, for which a [security advisory has been issued last week](https://rustsec.org/advisories/RUSTSEC-2025-0068.html).

I plan to add a `cargo-deny`'s ban as a follow-up so it doesn't creep in in the future. #1344

## Testing

I only tested that the `coap-client` example compiles properly. @chrysn can you do more through testing if needed? 

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
