### PR TITLE
refactor: introduce the `ram-small` module for MCUs unable to do HTTP

### DIFF
--- a/examples/http-client/laze.yml
+++ b/examples/http-client/laze.yml
@@ -7,3 +7,5 @@ apps:
     selects:
       - network
       - random
+    conflicts:
+      - ram-small

--- a/examples/http-server/laze.yml
+++ b/examples/http-server/laze.yml
@@ -8,6 +8,7 @@ apps:
       - network
       - ?button-reading
     conflicts:
+      - ram-small
       # needs `feature(type_alias_impl_trait)`
       - stable
 

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -550,6 +550,7 @@ contexts:
     parent: stm32
     selects:
       - cortex-m0-plus
+      - ram-small
     disables:
       # TODO: not enough RAM for HTTP examples
       - network
@@ -856,6 +857,9 @@ modules:
       global:
         isr_stacksize_required_default: "512"
         executor_stacksize_required_default: "512"
+
+  - name: ram-small
+    help: This module marks MCUs with little RAM (currently, the ones which cannot run HTTP or CoAP)
 
   - name: stable
     help: build with stable Rust
@@ -1290,6 +1294,8 @@ modules:
       # unless provided by the context.
       - c-function-assert
       - c-function-abort
+    conflicts:
+      - ram-small
     env:
       global:
         FEATURES:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -551,9 +551,6 @@ contexts:
     selects:
       - cortex-m0-plus
       - ram-small
-    disables:
-      # TODO: not enough RAM for HTTP examples
-      - network
     provides:
       - has_hwrng
       - has_storage_support


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This introduces a `ram-small` laze module, similar to `ram-tiny` (#1053), for MCUs having more RAM than `ram-tiny` but still not enough to do HTTP or CoAP.

## How to review this PR

This PR is better reviewed commit by commit.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
