### PR TITLE
refactor(network): clarify the names of IPv4-only laze modules

### DIFF
--- a/book/src/networking.md
+++ b/book/src/networking.md
@@ -31,7 +31,7 @@ CONFIG_WIFI_NETWORK=<ssid> CONFIG_WIFI_PASSWORD=<pwd> laze build ...
 ### Network Configuration
 
 DHCPv4 is used by default for network configuration, including for IP address allocation.
-This is enabled by the `network-config-dhcp` [laze module](./build-system.md#laze-modules), selected by default.
+This is enabled by the `network-config-ipv4-dhcp` [laze module](./build-system.md#laze-modules), selected by default.
 
 In order to provide a static configuration, select the `network-config-static` [laze module](./build-system.md#laze-modules), which will take precedence.
 The configuration can be customized with the following environment variables:

--- a/book/src/networking.md
+++ b/book/src/networking.md
@@ -33,7 +33,7 @@ CONFIG_WIFI_NETWORK=<ssid> CONFIG_WIFI_PASSWORD=<pwd> laze build ...
 DHCPv4 is used by default for network configuration, including for IP address allocation.
 This is enabled by the `network-config-ipv4-dhcp` [laze module](./build-system.md#laze-modules), selected by default.
 
-In order to provide a static configuration, select the `network-config-static` [laze module](./build-system.md#laze-modules), which will take precedence.
+In order to provide a static configuration, select the `network-config-ipv4-static` [laze module](./build-system.md#laze-modules), which will take precedence.
 The configuration can be customized with the following environment variables:
 
 | Variable                                 | Default      |

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1068,14 +1068,14 @@ modules:
   - name: network
     selects:
       - network_device
-      - network-config-default
+      - network-config-ipv4-default
 
-  - name: network-config-default
+  - name: network-config-ipv4-default
     help: use default network configuration method
     selects:
       - ?network-config-ipv4-dhcp
       - ?network-config-ipv4-static
-      - network-config
+      - network-config-ipv4
 
   - name: network-config-dhcp
     help: "deprecated: use `network-config-ipv4-dhcp` instead"
@@ -1089,7 +1089,7 @@ modules:
       # Needed for aliasing.
       - network-config-dhcp
     provides_unique:
-      - network-config
+      - network-config-ipv4
 
   - name: network-config-static
     help: "deprecated: use `network-config-ipv4-static` instead"
@@ -1103,7 +1103,7 @@ modules:
       # Needed for aliasing.
       - network-config-static
     provides_unique:
-      - network-config
+      - network-config-ipv4
     env:
       global:
         FEATURES:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1074,7 +1074,7 @@ modules:
     help: use default network configuration method
     selects:
       - ?network-config-ipv4-dhcp
-      - ?network-config-static
+      - ?network-config-ipv4-static
       - network-config
 
   - name: network-config-dhcp
@@ -1092,9 +1092,16 @@ modules:
       - network-config
 
   - name: network-config-static
-    help: use static IP network configuration
+    help: "deprecated: use `network-config-ipv4-static` instead"
+    selects:
+      - network-config-ipv4-static
+
+  - name: network-config-ipv4-static
+    help: use static IPv4 network configuration
     selects:
       - network
+      # Needed for aliasing.
+      - network-config-static
     provides_unique:
       - network-config
     env:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1073,14 +1073,21 @@ modules:
   - name: network-config-default
     help: use default network configuration method
     selects:
-      - ?network-config-dhcp
+      - ?network-config-ipv4-dhcp
       - ?network-config-static
       - network-config
 
   - name: network-config-dhcp
+    help: "deprecated: use `network-config-ipv4-dhcp` instead"
+    selects:
+      - network-config-ipv4-dhcp
+
+  - name: network-config-ipv4-dhcp
     help: use DHCPv4 for network configuration
     selects:
       - network
+      # Needed for aliasing.
+      - network-config-dhcp
     provides_unique:
       - network-config
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This renames laze modules that are actually IPv4-only to make room for the IPv6 modules that will be introduced by #915. This only renames laze modules for now and leaves Cargo features untouched.

This is not a breaking change as old modules are kept and only deprecated.

## How to review this PR

This PR is better reviewed commit by commit.

Check for forgotten occurrences in the codebase.

Test the `udp-echo` example (or any other network example):

```sh
laze -C examples/udp-echo/ build -s network-config-dhcp -b nrf52840dk
```

and pass `--disable network-config-dhcpv4` and `--disable network-config-dhcp` to it, possibly testing in hardware and/or checking the size of the binary to verify these are actually equivalent. The same can be done for `--select` to verify these indeed behave as aliases.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Extracted from #915.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
