### PR TITLE
docs(book): add urls to other doc resources

### DIFF
--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -8,6 +8,19 @@ based on 32-bit microcontroller architectures (Cortex-M, RISC-V, and Xtensa).
 Many features provided by Ariel OS can individually be enabled or disabled at build time
 in order to minimize resource consumption.
 
+This is the manual of Ariel OS. Other resources available are:
+
+- 🛠️ Reference documentation for Ariel OS can be found in the
+  [API documentation](https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/).
+- ⚙️  The git repository is available on
+  [GitHub](https://github.com/ariel-os/ariel-os).
+- ✨ [Examples](https://github.com/ariel-os/ariel-os/tree/main/examples)
+  demonstrate various features of Ariel OS.
+- 🧪 A set of [test cases](https://github.com/ariel-os/ariel-os/tree/main/tests)
+  further verifies the capabilities of Ariel OS.
+- 🚧 The [roadmap](https://github.com/ariel-os/ariel-os/issues/242)
+  shows the planned features for Ariel OS.
+
 ## Goals and Design
 
 Ariel OS builds on top of existing projects from the Embedded Rust ecosystem, including


### PR DESCRIPTION
# Description

This adds a set of urls to other helpful resources almost identical to what we have in the [api documentations](https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/). I've kept the format and the set of resources identical, swapping the link to the book with the link to the api documentation.

## Issues/PRs references


## Open Questions / Testing

Line 15 through 12 is identical to what we have in [the api docs](https://github.com/ariel-os/ariel-os/blob/main/src/ariel-os/src/lib.rs#L8-L15).

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
