### PR TITLE
doc(api): fix typo in resource section

### DIFF
--- a/src/ariel-os/src/lib.rs
+++ b/src/ariel-os/src/lib.rs
@@ -8,7 +8,7 @@
 //! - ⚙️  The git repository is available on
 //!   [GitHub](https://github.com/ariel-os/ariel-os).
 //! - ✨ [Examples](https://github.com/ariel-os/ariel-os/tree/main/examples)
-//!   demonstrates various features of Ariel OS.
+//!   demonstrate various features of Ariel OS.
 //! - 🧪 A set of [test cases](https://github.com/ariel-os/ariel-os/tree/main/tests)
 //!   further verifies the capabilities of Ariel OS.
 //! - 🚧 The [roadmap](https://github.com/ariel-os/ariel-os/issues/242)


### PR DESCRIPTION
# Description

Fix a small typo in the resource section

## Issues/PRs references

Spotted by @ROMemories in #1352 

## Open Questions

None

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
