### PR TITLE
feat: add TemporarilyUnavailable variant to sensor Accuracy

### DIFF
--- a/src/ariel-os-sensors/src/sample.rs
+++ b/src/ariel-os-sensors/src/sample.rs
@@ -96,6 +96,9 @@ pub enum Accuracy {
         /// [`bias`](Accuracy::SymmetricalError::bias).
         scaling: i8,
     },
+    /// Indicate that the value in this channel is temporarily unavailable and the value in the sample should be ignored.
+    /// Happens when parts of a sensor aren't ready yet, but data is already available for other channels.
+    TemporarilyUnavailable,
 }
 
 /// Implemented on [`Samples`](crate::sensor::Samples), returned by


### PR DESCRIPTION
# Description

This adds a way to indicate the current sample should be ignored because this channel of the sensor isn't sending valid data yet. 

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

Is this the right place to put the indication that the data should be ignored ?
The alternative would be to split one sensor into multiple sensors and have the ones that need more time to initialize/produce a value make the user wait on `Sensor::wait_for_reading()`  

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
