### PR TITLE
refactor(sensors): make `Sensors` and `ReadingChannels` structs instead

### DIFF
--- a/src/ariel-os-macros/src/define_count_adjusted_sensor_enums.rs
+++ b/src/ariel-os-macros/src/define_count_adjusted_sensor_enums.rs
@@ -4,6 +4,7 @@
 /// One single type must be defined so that it can be used in the Future returned by sensor
 /// drivers, which must be the same for every sensor driver so it can be part of the `Sensor`
 /// trait.
+#[expect(clippy::too_many_lines)]
 #[proc_macro]
 pub fn define_count_adjusted_sensor_enums(_item: TokenStream) -> TokenStream {
     use quote::quote;
@@ -23,7 +24,7 @@ pub fn define_count_adjusted_sensor_enums(_item: TokenStream) -> TokenStream {
             quote! {
                 impl From<[Sample; #i]> for Samples {
                     fn from(value: [Sample; #i]) -> Self {
-                        Self::#variant(value)
+                        Self { samples: InnerSamples::#variant(value) }
                     }
                 }
             }
@@ -31,7 +32,7 @@ pub fn define_count_adjusted_sensor_enums(_item: TokenStream) -> TokenStream {
     let samples_first_sample = (1..=count).map(|i| {
         let variant = variant_name(i);
         quote! {
-            Self::#variant(samples) => {
+            InnerSamples::#variant(samples) => {
                 if let Some(sample) = samples.first() {
                     *sample
                 } else {
@@ -61,9 +62,13 @@ pub fn define_count_adjusted_sensor_enums(_item: TokenStream) -> TokenStream {
     let samples_iter = (1..=count)
         .map(|i| {
             let variant = variant_name(i);
-            quote! { Self::#variant(samples) => samples.iter().copied() }
-        })
-        .collect::<Vec<_>>();
+            quote! { InnerSamples::#variant(samples) => samples.into_iter() }
+        });
+    let reading_channels_iter = (1..=count)
+        .map(|i| {
+            let variant = variant_name(i);
+            quote! { ReadingChannels::#variant(samples) => samples.iter().copied() }
+        });
 
     let expanded = quote! {
         /// Samples returned by a sensor driver.
@@ -75,27 +80,29 @@ pub fn define_count_adjusted_sensor_enums(_item: TokenStream) -> TokenStream {
         /// This type is automatically generated, the number of [`Sample`]s that can be stored is
         /// automatically adjusted.
         #[derive(Debug, Copy, Clone)]
-        pub enum Samples {
-            #(
-                #[doc(hidden)]
-                #samples_variants
-            ),*
+        pub struct Samples {
+            samples: InnerSamples,
         }
 
         #(#samples_from_impls)*
 
         impl Reading for Samples {
             fn sample(&self) -> Sample {
-                match self {
+                match self.samples {
                     #(#samples_first_sample),*
                 }
             }
 
             fn samples(&self) -> impl ExactSizeIterator<Item = Sample> + core::iter::FusedIterator {
-                match self {
+                match self.samples {
                     #(#samples_iter),*
                 }
             }
+        }
+
+        #[derive(Debug, Copy, Clone)]
+        enum InnerSamples {
+            #(#samples_variants),*
         }
 
         /// Metadata required to interpret samples returned by [`Sensor::wait_for_reading()`].
@@ -123,7 +130,7 @@ pub fn define_count_adjusted_sensor_enums(_item: TokenStream) -> TokenStream {
             /// obtained with [`Reading::samples()`].
             pub fn iter(&self) -> impl ExactSizeIterator<Item = ReadingChannel> + core::iter::FusedIterator + '_ {
                 match self {
-                    #(#samples_iter),*,
+                    #(#reading_channels_iter),*
                 }
             }
 


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
Following #1355, this makes these types structs instead of enums, to give us more flexibility in the future if we wanted to transparently swap their implementations. The existing enums are kept but moved into the one field these structs now contain.

## How to review this PR

This PR is better reviewed commit by commit.

Compiling #1363 with the following command should help show this works:

```sh
laze -C examples/sensors-debug/ build -b stm32u083c-dk
```

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Depends on #1355.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
