### PR TITLE
ci: relax `rust-version` key check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Check for missing `rust-version` keys in `ariel-os*` crates
         run: |
           find src -iwholename 'src/ariel-os*/Cargo.toml' -exec sh -c \
-            'grep -q --with-filename '^rust-version' "$0" || (echo "$0 is missing a rust-version key"; kill $PPID)' \{\} \;
+            'grep -q --with-filename 'rust-version' "$0" || (echo "$0 is missing a rust-version key"; kill $PPID)' \{\} \;
 
       - id: get_toolchain
         run: echo "toolchain=$(scripts/rust-toolchain.sh)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Description

The [generated `Cargo.toml` from #1282](https://github.com/ariel-os/ariel-os/pull/1282/files#diff-1a22d55f98c7cc4e31569d42dd1b6c424ecb496bb35584d341d6d2dce3da6dcb) contains `^[package.rust-version]\nworkspace = true\n`, which fails the simple `^rust-version` check.
This PR simply relaxes the check to just look for `rust-version`.

<!-- Please write a summary of your changes and why you made them.-->

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [ ] I have cleaned up my commit history and squashed fixup commits.
- [ ] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
