### PR TITLE
refactor(embassy-common): use the derived `Default` impl for enums

### DIFF
--- a/src/ariel-os-embassy-common/src/gpio.rs
+++ b/src/ariel-os-embassy-common/src/gpio.rs
@@ -86,7 +86,7 @@ macro_rules! define_from_pull {
 /// This enum allows to either use high-level, portable values, roughly normalized across
 /// HALs, or to use HAL-specific values if needed.
 // TODO: should this be marked non_exhaustive?
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DriveStrength<A> {
     /// HAL-specific drive strength setting.
@@ -94,6 +94,7 @@ pub enum DriveStrength<A> {
     /// Lowest drive strength available on this HAL.
     Lowest,
     /// Most common reset value of drive strength on this HAL.
+    #[default]
     Standard,
     /// Medium drive strength.
     Medium,
@@ -101,12 +102,6 @@ pub enum DriveStrength<A> {
     High,
     /// Highest drive strength available on this HAL.
     Highest,
-}
-
-impl<A> Default for DriveStrength<A> {
-    fn default() -> Self {
-        Self::Standard
-    }
 }
 
 // We introduce our own trait instead of using `From` because this conversion is not
@@ -126,13 +121,14 @@ pub trait FromDriveStrength {
 /// This enum allows to either use high-level, portable values, roughly normalized across
 /// HALs, or to use HAL-specific values if needed.
 #[doc(alias = "SlewRate")]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 // FIXME: should we call this slew rate instead?
 pub enum Speed<A> {
     /// HAL-specific speed setting.
     Hal(A),
     /// Low speed.
+    #[default]
     Low,
     /// Medium speed.
     Medium,
@@ -140,12 +136,6 @@ pub enum Speed<A> {
     High,
     /// Very high speed.
     VeryHigh,
-}
-
-impl<A> Default for Speed<A> {
-    fn default() -> Self {
-        Self::Low
-    }
 }
 
 // We introduce our own trait instead of using `From` because this conversion is not
@@ -213,17 +203,12 @@ impl FromSpeed for UnsupportedSpeed {
 /// Available drive strength settings.
 ///
 /// *Note: configuring the drive strength of outputs is not supported on this MCU family.*
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum UnsupportedDriveStrength {
     #[doc(hidden)]
+    #[default]
     UnsupportedByHardware,
-}
-
-impl Default for UnsupportedDriveStrength {
-    fn default() -> Self {
-        Self::UnsupportedByHardware
-    }
 }
 
 impl FromDriveStrength for UnsupportedDriveStrength {

--- a/src/ariel-os-embassy-common/src/spi/mod.rs
+++ b/src/ariel-os-embassy-common/src/spi/mod.rs
@@ -27,16 +27,11 @@ pub enum Mode {
 /// Note: configuring the bit order is not supported on all MCU families.
 // NOTE(hal): the RP2040 and RP2350 always send the MSb first
 #[doc(hidden)]
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Default)]
 pub enum BitOrder {
     /// Most significant bit first.
+    #[default]
     MsbFirst,
     /// Least significant bit first.
     LsbFirst,
-}
-
-impl Default for BitOrder {
-    fn default() -> Self {
-        Self::MsbFirst
-    }
 }


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
It is been possible to [derive `Default` impls for enums since 2022](https://blog.rust-lang.org/2022/06/30/Rust-1.62.0/#default-enum-variants) and Clippy now [complains about this](https://rust-lang.github.io/rust-clippy/master/index.html#derivable_impls) on the current nightly. It's also simply better that way.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
