### PR TITLE
refactor(docs): move support matrix schema in external module

### DIFF
--- a/doc/gen_support_matrix_html.rs
+++ b/doc/gen_support_matrix_html.rs
@@ -12,6 +12,8 @@ serde_yaml = { version = "0.9.34" } # TODO: use a maintained crate instead
 thiserror = { version = "1.0.61" }
 ---
 
+mod schema;
+
 use std::{fs, io, path::{Path, PathBuf}};
 
 use serde::Serialize;
@@ -465,75 +467,4 @@ enum Error {
     ExistingHtmlNotUpToDate {
         path: PathBuf,
     },
-}
-
-mod schema {
-    use std::collections::HashMap;
-
-    use serde::{Deserialize, Serialize};
-
-    #[derive(Debug, Serialize, Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct Matrix {
-        pub support_keys: Vec<SupportKeyInfo>,
-        pub functionalities: Vec<FunctionalityInfo>,
-        pub chips: HashMap<String, ChipInfo>,
-        pub boards: HashMap<String, BoardInfo>,
-    }
-
-    #[derive(Debug, Serialize, Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct SupportKeyInfo {
-        pub name: String,
-        pub icon: String,
-        pub description: String,
-    }
-
-    #[derive(Debug, Serialize, Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct FunctionalityInfo {
-        pub name: String,
-        pub title: String, // FIXME: rename this
-        pub description: String,
-    }
-
-    #[derive(Debug, Serialize, Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct ChipInfo {
-        pub name: String,
-        pub description: Option<String>,
-        pub support: HashMap<String, SupportInfo>,
-    }
-
-    #[derive(Debug, Serialize, Deserialize)]
-    #[serde(deny_unknown_fields)]
-    pub struct BoardInfo {
-        pub name: String,
-        pub description: Option<String>,
-        pub url: String,
-        pub chip: String,
-        pub tier: String,
-        pub support: HashMap<String, SupportInfo>,
-    }
-
-    #[derive(Debug, Serialize, Deserialize)]
-    #[serde(deny_unknown_fields)]
-    #[serde(untagged)]
-    pub enum SupportInfo {
-        StatusOnly(String),
-        Details {
-            status: String,
-            comments: Option<Vec<String>>,
-            link: Option<String>,
-        },
-    }
-
-    impl SupportInfo {
-        pub fn status(&self) -> &str {
-            match self {
-                SupportInfo::StatusOnly(status) => status,
-                SupportInfo::Details { status, .. } => status,
-            }
-        }
-    }
 }

--- a/doc/schema.rs
+++ b/doc/schema.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Matrix {
+    pub support_keys: Vec<SupportKeyInfo>,
+    pub functionalities: Vec<FunctionalityInfo>,
+    pub chips: HashMap<String, ChipInfo>,
+    pub boards: HashMap<String, BoardInfo>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SupportKeyInfo {
+    pub name: String,
+    pub icon: String,
+    pub description: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FunctionalityInfo {
+    pub name: String,
+    pub title: String, // FIXME: rename this
+    pub description: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChipInfo {
+    pub name: String,
+    pub description: Option<String>,
+    pub support: HashMap<String, SupportInfo>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BoardInfo {
+    pub name: String,
+    pub description: Option<String>,
+    pub url: String,
+    pub chip: String,
+    pub tier: String,
+    pub support: HashMap<String, SupportInfo>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(untagged)]
+pub enum SupportInfo {
+    StatusOnly(String),
+    Details {
+        status: String,
+        comments: Option<Vec<String>>,
+        link: Option<String>,
+    },
+}
+
+impl SupportInfo {
+    pub fn status(&self) -> &str {
+        match self {
+            SupportInfo::StatusOnly(status) => status,
+            SupportInfo::Details { status, .. } => status,
+        }
+    }
+}


### PR DESCRIPTION
# Description

This PR moves the schema definition structs for the `gen_support_matrix_html.rs` script in an external module.

## Issues/PRs references



## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
