### PR TITLE
refactor(stm32): move the RCC config to a dedicated pure function

### DIFF
--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -82,18 +82,21 @@ pub fn init() -> OptionalPeripherals {
 }
 
 fn board_config(config: &mut Config) {
-    rcc_config(config);
+    config.rcc = rcc_config();
 }
 
 // TODO: find better place for this
 #[expect(clippy::too_many_lines)]
-fn rcc_config(config: &mut Config) {
+fn rcc_config() -> embassy_stm32::rcc::Config {
+    #[allow(unused_mut, reason = "conditional compilation")]
+    let mut rcc = embassy_stm32::rcc::Config::default();
+
     #[cfg(context = "st-b-l475e-iot01a")]
     {
         use embassy_stm32::rcc::*;
 
         // This board has an LSE clock, we can use it to calibrate the MSI clock
-        config.rcc.ls = LsConfig {
+        rcc.ls = LsConfig {
             rtc: RtcClockSource::LSE,
             lsi: false,
             lse: Some(LseConfig {
@@ -101,11 +104,11 @@ fn rcc_config(config: &mut Config) {
                 mode: LseMode::Oscillator(LseDrive::MediumHigh),
             }),
         };
-        config.rcc.hsi = false;
+        rcc.hsi = false;
         // Setting the MSI range to 48 MHz crashes the system. If the source of the issue is found,
         // we can use MSI as the clock source for the usb peripheral directly and avoid using more PLLs.
-        config.rcc.msi = Some(MSIRange::RANGE8M);
-        config.rcc.pll = Some(Pll {
+        rcc.msi = Some(MSIRange::RANGE8M);
+        rcc.pll = Some(Pll {
             source: PllSource::MSI,
             prediv: PllPreDiv::DIV1, // 8 Mhz
             mul: PllMul::MUL20,      // 160 MHz
@@ -113,8 +116,8 @@ fn rcc_config(config: &mut Config) {
             divq: None,
             divr: Some(PllRDiv::DIV2), // sysclk 80Mhz (8 / 1  * 20 / 2)
         });
-        config.rcc.sys = Sysclk::PLL1_R;
-        config.rcc.pllsai1 = Some(Pll {
+        rcc.sys = Sysclk::PLL1_R;
+        rcc.pllsai1 = Some(Pll {
             source: PllSource::MSI,
             prediv: PllPreDiv::DIV1,
             mul: PllMul::MUL12, // 8 MHz MSI * 12 = 96 MHz
@@ -124,23 +127,23 @@ fn rcc_config(config: &mut Config) {
         });
         // With a 32.768 kHz LSE, the MSI clock will be calibrated and considered accurate enough.
         // Embassy automatically enables MSIPLLEN if the LSE is configured.
-        config.rcc.mux.clk48sel = mux::Clk48sel::PLLSAI1_Q;
+        rcc.mux.clk48sel = mux::Clk48sel::PLLSAI1_Q;
     }
 
     #[cfg(context = "st-nucleo-wb55")]
     {
         use embassy_stm32::rcc::*;
 
-        config.rcc.hsi48 = Some(Hsi48Config {
+        rcc.hsi48 = Some(Hsi48Config {
             sync_from_usb: true,
         }); // needed for USB
-        config.rcc.sys = Sysclk::PLL1_R;
-        config.rcc.hse = Some(Hse {
+        rcc.sys = Sysclk::PLL1_R;
+        rcc.hse = Some(Hse {
             freq: embassy_stm32::time::Hertz(32000000),
             mode: HseMode::Oscillator,
             prescaler: HsePrescaler::DIV1,
         });
-        config.rcc.pll = Some(Pll {
+        rcc.pll = Some(Pll {
             source: PllSource::HSE,
             prediv: PllPreDiv::DIV2,
             mul: PllMul::MUL10,
@@ -148,61 +151,61 @@ fn rcc_config(config: &mut Config) {
             divq: None,
             divr: Some(PllRDiv::DIV2), // sysclk 80Mhz (32 / 2 * 10 / 2)
         });
-        config.rcc.mux.clk48sel = mux::Clk48sel::HSI48;
+        rcc.mux.clk48sel = mux::Clk48sel::HSI48;
     }
 
     #[cfg(context = "st-nucleo-f401re")]
     {
         use embassy_stm32::rcc::*;
-        config.rcc.hse = Some(Hse {
+        rcc.hse = Some(Hse {
             freq: embassy_stm32::time::Hertz(8000000),
             mode: HseMode::Bypass,
         });
-        config.rcc.pll_src = PllSource::HSE;
-        config.rcc.pll = Some(Pll {
+        rcc.pll_src = PllSource::HSE;
+        rcc.pll = Some(Pll {
             prediv: PllPreDiv::DIV4,
             mul: PllMul::MUL84,
             divp: Some(PllPDiv::DIV2),
             divq: None,
             divr: None,
         });
-        config.rcc.ahb_pre = AHBPrescaler::DIV1;
-        config.rcc.apb1_pre = APBPrescaler::DIV4;
-        config.rcc.apb2_pre = APBPrescaler::DIV2;
-        config.rcc.sys = Sysclk::PLL1_P;
+        rcc.ahb_pre = AHBPrescaler::DIV1;
+        rcc.apb1_pre = APBPrescaler::DIV4;
+        rcc.apb2_pre = APBPrescaler::DIV2;
+        rcc.sys = Sysclk::PLL1_P;
     }
 
     #[cfg(context = "st-nucleo-f767zi")]
     {
         use embassy_stm32::rcc::*;
-        config.rcc.hse = Some(Hse {
+        rcc.hse = Some(Hse {
             freq: embassy_stm32::time::Hertz(8000000),
             mode: HseMode::Bypass,
         });
-        config.rcc.pll_src = PllSource::HSE;
-        config.rcc.pll = Some(Pll {
+        rcc.pll_src = PllSource::HSE;
+        rcc.pll = Some(Pll {
             prediv: PllPreDiv::DIV4,
             mul: PllMul::MUL216,
             divp: Some(PllPDiv::DIV2),
             divq: None,
             divr: None,
         });
-        config.rcc.ahb_pre = AHBPrescaler::DIV1;
-        config.rcc.apb1_pre = APBPrescaler::DIV4;
-        config.rcc.apb2_pre = APBPrescaler::DIV2;
-        config.rcc.sys = Sysclk::PLL1_P;
+        rcc.ahb_pre = AHBPrescaler::DIV1;
+        rcc.apb1_pre = APBPrescaler::DIV4;
+        rcc.apb2_pre = APBPrescaler::DIV2;
+        rcc.sys = Sysclk::PLL1_P;
     }
 
     #[cfg(context = "stm32h755zi")]
     {
         use embassy_stm32::rcc::*;
 
-        config.rcc.hsi = Some(HSIPrescaler::DIV1);
-        config.rcc.csi = true;
-        config.rcc.hsi48 = Some(Hsi48Config {
+        rcc.hsi = Some(HSIPrescaler::DIV1);
+        rcc.csi = true;
+        rcc.hsi48 = Some(Hsi48Config {
             sync_from_usb: true,
         }); // needed for USB
-        config.rcc.pll1 = Some(Pll {
+        rcc.pll1 = Some(Pll {
             source: PllSource::HSI,
             prediv: PllPreDiv::DIV4,
             mul: PllMul::MUL50,
@@ -211,32 +214,32 @@ fn rcc_config(config: &mut Config) {
             divq: Some(PllDiv::DIV16), // FIXME: adjust this divider
             divr: None,
         });
-        config.rcc.sys = Sysclk::PLL1_P; // 400 Mhz
-        config.rcc.ahb_pre = AHBPrescaler::DIV2; // 200 Mhz
-        config.rcc.apb1_pre = APBPrescaler::DIV2; // 100 Mhz
-        config.rcc.apb2_pre = APBPrescaler::DIV2; // 100 Mhz
-        config.rcc.apb3_pre = APBPrescaler::DIV2; // 100 Mhz
-        config.rcc.apb4_pre = APBPrescaler::DIV2; // 100 Mhz
-        config.rcc.voltage_scale = VoltageScale::Scale1;
+        rcc.sys = Sysclk::PLL1_P; // 400 Mhz
+        rcc.ahb_pre = AHBPrescaler::DIV2; // 200 Mhz
+        rcc.apb1_pre = APBPrescaler::DIV2; // 100 Mhz
+        rcc.apb2_pre = APBPrescaler::DIV2; // 100 Mhz
+        rcc.apb3_pre = APBPrescaler::DIV2; // 100 Mhz
+        rcc.apb4_pre = APBPrescaler::DIV2; // 100 Mhz
+        rcc.voltage_scale = VoltageScale::Scale1;
         // Set SMPS power config otherwise MCU will not powered after next power-off
-        config.rcc.supply_config = SupplyConfig::DirectSMPS;
-        config.rcc.mux.usbsel = mux::Usbsel::HSI48;
+        rcc.supply_config = SupplyConfig::DirectSMPS;
+        rcc.mux.usbsel = mux::Usbsel::HSI48;
         // Select the clock signal used for SPI1, SPI2, and SPI3.
         // FIXME: what to do about SPI4, SPI5, and SPI6?
-        config.rcc.mux.spi123sel = mux::Saisel::PLL1_Q; // Reset value
+        rcc.mux.spi123sel = mux::Saisel::PLL1_Q; // Reset value
     }
 
     #[cfg(context = "stm32u083mc")]
     {
         use embassy_stm32::rcc::*;
 
-        config.rcc.hsi48 = Some(Hsi48Config {
+        rcc.hsi48 = Some(Hsi48Config {
             sync_from_usb: true,
         }); // needed for USB
         // No HSE fitted on the stm32u083c-dk board
-        config.rcc.hsi = true;
-        config.rcc.sys = Sysclk::PLL1_R;
-        config.rcc.pll = Some(Pll {
+        rcc.hsi = true;
+        rcc.sys = Sysclk::PLL1_R;
+        rcc.pll = Some(Pll {
             source: PllSource::HSI,
             prediv: PllPreDiv::DIV1,
             mul: PllMul::MUL7,
@@ -244,14 +247,14 @@ fn rcc_config(config: &mut Config) {
             divq: None,
             divr: Some(PllRDiv::DIV2), // sysclk 56Mhz
         });
-        config.rcc.mux.clk48sel = mux::Clk48sel::HSI48;
+        rcc.mux.clk48sel = mux::Clk48sel::HSI48;
     }
 
     #[cfg(context = "st-steval-mkboxpro")]
     {
         use embassy_stm32::rcc::*;
 
-        config.rcc.ls = LsConfig {
+        rcc.ls = LsConfig {
             rtc: RtcClockSource::LSE,
             lsi: true,
             lse: Some(LseConfig {
@@ -260,16 +263,16 @@ fn rcc_config(config: &mut Config) {
                 mode: LseMode::Oscillator(LseDrive::MediumHigh),
             }),
         };
-        config.rcc.hsi = true;
-        config.rcc.hsi48 = Some(Hsi48Config {
+        rcc.hsi = true;
+        rcc.hsi48 = Some(Hsi48Config {
             sync_from_usb: true,
         }); // needed for USB
-        config.rcc.sys = Sysclk::PLL1_R;
-        config.rcc.hse = Some(Hse {
+        rcc.sys = Sysclk::PLL1_R;
+        rcc.hse = Some(Hse {
             freq: embassy_stm32::time::Hertz(16_000_000),
             mode: HseMode::Oscillator,
         });
-        config.rcc.pll1 = Some(Pll {
+        rcc.pll1 = Some(Pll {
             source: PllSource::HSE,
             prediv: PllPreDiv::DIV1,
             mul: PllMul::MUL10,
@@ -277,20 +280,20 @@ fn rcc_config(config: &mut Config) {
             divq: None,
             divr: Some(PllDiv::DIV1), // sysclk 160Mhz (16 / 1 * 10 / 1)
         });
-        config.rcc.sys = Sysclk::PLL1_R;
-        config.rcc.mux.iclksel = mux::Iclksel::HSI48;
-        config.rcc.voltage_range = VoltageScale::RANGE1;
+        rcc.sys = Sysclk::PLL1_R;
+        rcc.mux.iclksel = mux::Iclksel::HSI48;
+        rcc.voltage_range = VoltageScale::RANGE1;
     }
 
     #[cfg(context = "stm32f042k6")]
     {
         use embassy_stm32::rcc::*;
 
-        config.rcc.hsi48 = Some(Hsi48Config {
+        rcc.hsi48 = Some(Hsi48Config {
             sync_from_usb: true,
         }); // needed for USB
-        config.rcc.sys = Sysclk::HSI48;
-        config.rcc.pll = Some(Pll {
+        rcc.sys = Sysclk::HSI48;
+        rcc.pll = Some(Pll {
             src: PllSource::HSI48,
             prediv: PllPreDiv::DIV2,
             mul: PllMul::MUL2,
@@ -301,14 +304,14 @@ fn rcc_config(config: &mut Config) {
     {
         use embassy_stm32::rcc::*;
 
-        config.rcc.hse = Some(Hse {
+        rcc.hse = Some(Hse {
             freq: embassy_stm32::time::Hertz(32_000_000),
             mode: HseMode::Bypass,
             prescaler: HsePrescaler::DIV1,
         });
-        config.rcc.ls = LsConfig::default_lse();
-        config.rcc.msi = None;
-        config.rcc.pll = Some(Pll {
+        rcc.ls = LsConfig::default_lse();
+        rcc.msi = None;
+        rcc.pll = Some(Pll {
             source: PllSource::HSE,
             prediv: PllPreDiv::DIV2,
             mul: PllMul::MUL6,
@@ -317,11 +320,10 @@ fn rcc_config(config: &mut Config) {
             divr: Some(PllRDiv::DIV2), // sysclk 48Mhz clock (32 / 2 * 6 / 2)
         });
 
-        config.rcc.sys = Sysclk::PLL1_R;
+        rcc.sys = Sysclk::PLL1_R;
     }
 
-    // mark used
-    let _ = config;
+    rcc
 }
 
 fn enable_flash_cache() {

--- a/src/ariel-os-stm32/src/lib.rs
+++ b/src/ariel-os-stm32/src/lib.rs
@@ -81,9 +81,13 @@ pub fn init() -> OptionalPeripherals {
     OptionalPeripherals::from(peripherals)
 }
 
+fn board_config(config: &mut Config) {
+    rcc_config(config);
+}
+
 // TODO: find better place for this
 #[expect(clippy::too_many_lines)]
-fn board_config(config: &mut Config) {
+fn rcc_config(config: &mut Config) {
     #[cfg(context = "st-b-l475e-iot01a")]
     {
         use embassy_stm32::rcc::*;


### PR DESCRIPTION
# Description

<!-- Please write a summary of your changes and why you made them.-->
This is just a small refactor to make future changes to the way the RCC configuration is provided easier, and in particular so that these changes do not constantly result in conflicts as we land support for other STM32 MCUs. Now is a good time to do this as we do not have any in-flight PRs that add support for STM32 MCUs (except for #1183, which I will handle).

## Testing

Successfully tested the `random` example (which is known to require proper clock configuration) on the stm32u083c-dk.

## How to review this PR

This PR is better reviewed commit by commit.

## Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
The aforementioned future changes are in #1389.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
