### PR TITLE
fix(gen-book): add `ExistingMarkdownNotUpToDate` error variant

### DIFF
--- a/doc/gen_book.rs
+++ b/doc/gen_book.rs
@@ -207,7 +207,7 @@ impl SubCommandList {
                 })?;
 
             if existing_board_index_md != board_index_md {
-                return Err(Error::ExistingHtmlNotUpToDate {
+                return Err(Error::ExistingMarkdownNotUpToDate {
                     path: self.output_path.clone(),
                 }
                 .into());
@@ -275,7 +275,7 @@ impl SubCommandSummary {
             })?;
 
             if existing_summary_md != summary_md {
-                return Err(Error::ExistingHtmlNotUpToDate {
+                return Err(Error::ExistingMarkdownNotUpToDate {
                     path: self.output_path.clone(),
                 }
                 .into());
@@ -347,7 +347,7 @@ impl SubCommandPages {
                     })?;
 
                 if existing_board_page != board_page {
-                    return Err(Error::ExistingHtmlNotUpToDate {
+                    return Err(Error::ExistingMarkdownNotUpToDate {
                         path: board_page_path.clone(),
                     }
                     .into());
@@ -587,4 +587,6 @@ enum Error {
     ReadingExistingFile { path: PathBuf, source: io::Error },
     #[error("existing HTML file `{path}` is not up to date")]
     ExistingHtmlNotUpToDate { path: PathBuf },
+    #[error("existing Markdown file `{path}` is not up to date")]
+    ExistingMarkdownNotUpToDate { path: PathBuf },
 }


### PR DESCRIPTION
# Description

This PR adds a new `ExistingMarkdownNotUpToDate` error variant for the `doc/gen_book.rs` script. Currently, there is only a `ExistingHtmlNotUpToDate` variant.

## Issues/PRs references

Linked to #1327.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [X] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
