### PR TITLE
docs(gen-book): rewrite board page support matrix table in Markdown

### DIFF
--- a/book/src/boards/bbc-microbit-v1.md
+++ b/book/src/boards/bbc-microbit-v1.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|SPI Main Mode|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/bbc-microbit-v2.md
+++ b/book/src/boards/bbc-microbit-v2.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported">✅</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/espressif-esp32-c3-lcdkit.md
+++ b/book/src/boards/espressif-esp32-c3-lcdkit.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="supported with some caveats">☑️</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>|
+|Wi-Fi|<span title="supported with some caveats">☑️</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/espressif-esp32-c6-devkitc-1.md
+++ b/book/src/boards/espressif-esp32-c6-devkitc-1.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="supported with some caveats">☑️</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>|
+|Wi-Fi|<span title="supported with some caveats">☑️</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/espressif-esp32-s3-devkitc-1.md
+++ b/book/src/boards/espressif-esp32-s3-devkitc-1.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="needs testing">🚦</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="needs testing">🚦</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="needs testing">🚦</span>|
+|SPI Main Mode|<span title="needs testing">🚦</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Wi-Fi|<span title="supported">✅</span>|
+|Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/heltec-wifi-lora-32-v3.md
+++ b/book/src/boards/heltec-wifi-lora-32-v3.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="needs testing">🚦</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="needs testing">🚦</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="needs testing">🚦</span>|
+|SPI Main Mode|<span title="needs testing">🚦</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Wi-Fi|<span title="supported">✅</span>|
+|Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/nordic-thingy-91-x-nrf9151.md
+++ b/book/src/boards/nordic-thingy-91-x-nrf9151.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>|
+|Wi-Fi|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Hardware Random Number Generator|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Persistent Storage|<span title="supported">✅</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/nrf52840dk.md
+++ b/book/src/boards/nrf52840dk.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="supported">✅</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported">✅</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/nrf52dk.md
+++ b/book/src/boards/nrf52dk.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|SPI Main Mode|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported">✅</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/nrf5340dk.md
+++ b/book/src/boards/nrf5340dk.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="supported">✅</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
+|Hardware Random Number Generator|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Persistent Storage|<span title="supported">✅</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/nrf9160dk-nrf9160.md
+++ b/book/src/boards/nrf9160dk-nrf9160.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Hardware Random Number Generator|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Persistent Storage|<span title="supported">✅</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/rpi-pico-w.md
+++ b/book/src/boards/rpi-pico-w.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="supported">✅</span>|
+|Wi-Fi|<span title="supported">✅</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported">✅</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/rpi-pico.md
+++ b/book/src/boards/rpi-pico.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="supported">✅</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported">✅</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/rpi-pico2-w.md
+++ b/book/src/boards/rpi-pico2-w.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="supported">✅</span>|
+|Wi-Fi|<span title="supported">✅</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported">✅</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/rpi-pico2.md
+++ b/book/src/boards/rpi-pico2.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="supported">✅</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported">✅</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/seeedstudio-lora-e5-mini.md
+++ b/book/src/boards/seeedstudio-lora-e5-mini.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|SPI Main Mode|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported">✅</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/st-b-l475e-iot01a.md
+++ b/book/src/boards/st-b-l475e-iot01a.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="needs testing">🚦</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="needs testing">🚦</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported with some caveats">☑️</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="needs testing">🚦</span>|
+|SPI Main Mode|<span title="needs testing">🚦</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="supported">✅</span>|
+|Wi-Fi|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported with some caveats">☑️</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/st-nucleo-c031c6.md
+++ b/book/src/boards/st-nucleo-c031c6.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Hardware Random Number Generator|<span title="not available on this piece of hardware">–</span>|
+|Persistent Storage|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/st-nucleo-f042k6.md
+++ b/book/src/boards/st-nucleo-f042k6.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|SPI Main Mode|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Hardware Random Number Generator|<span title="not available on this piece of hardware">–</span>|
+|Persistent Storage|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/st-nucleo-f401re.md
+++ b/book/src/boards/st-nucleo-f401re.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="needs testing">🚦</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="needs testing">🚦</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="needs testing">🚦</span>|
+|SPI Main Mode|<span title="needs testing">🚦</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Hardware Random Number Generator|<span title="not available on this piece of hardware">–</span>|
+|Persistent Storage|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/st-nucleo-f411re.md
+++ b/book/src/boards/st-nucleo-f411re.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Hardware Random Number Generator|<span title="not available on this piece of hardware">–</span>|
+|Persistent Storage|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/st-nucleo-h755zi-q.md
+++ b/book/src/boards/st-nucleo-h755zi-q.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported with some caveats">☑️</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="supported">✅</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported with some caveats">☑️</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/st-nucleo-wb55.md
+++ b/book/src/boards/st-nucleo-wb55.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported with some caveats">☑️</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="supported">✅</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported with some caveats">☑️</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/st-nucleo-wba55.md
+++ b/book/src/boards/st-nucleo-wba55.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|SPI Main Mode|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/st-steval-mkboxpro.md
+++ b/book/src/boards/st-steval-mkboxpro.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="supported">✅</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported">✅</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/src/boards/stm32u083c-dk.md
+++ b/book/src/boards/stm32u083c-dk.md
@@ -13,64 +13,20 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>GPIO</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Debug Output</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>I2C Controller Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>SPI Main Mode</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Logging</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>User USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Wi-Fi</td>
-      <td class="support-cell" title="not available on this piece of hardware">–</td>
-    </tr>
-    <tr>
-      <td>Ethernet over USB</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Hardware Random Number Generator</td>
-      <td class="support-cell" title="supported">✅</td>
-    </tr>
-    <tr>
-      <td>Persistent Storage</td>
-      <td class="support-cell" title="supported with some caveats">☑️</td>
-    </tr>
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+|GPIO|<span title="supported">✅</span>|
+|Debug Output|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|User USB|<span title="supported">✅</span>|
+|Wi-Fi|<span title="not available on this piece of hardware">–</span>|
+|Ethernet over USB|<span title="supported">✅</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="supported with some caveats">☑️</span>|
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   <div>

--- a/book/templates/board-page.md.tmpl
+++ b/book/templates/board-page.md.tmpl
@@ -13,30 +13,13 @@
 
 ## Support Matrix
 
-<table>
-  <thead>
-    <tr>
-      <th>Functionality</th>
-      <th>Support Status</th>
-    </tr>
-  </thead>
-  <tbody>
-    {%- for functionality in board_info.functionalities %}
-    <tr>
-      <td>{{ functionality.title }}</td>
-      <td class="support-cell" title="{{ functionality.description }}">{{ functionality.icon }}</td>
-    </tr>
-    {%- endfor %}
-  </tbody>
-</table>
+|Functionality|Support Status|
+|---|:---:|
+{%- for functionality in board_info.functionalities %}
+|{{ functionality.title }}|<span title="{{ functionality.description }}">{{ functionality.icon }}</span>|
+{%- endfor %}
 
-<style>
-.support-cell {
-  text-align: center;
-}
-</style>
-
-Legend:
+<p>Legend:</p>
 
 <dl>
   {%- for support_key in support_keys %}


### PR DESCRIPTION
# Description

This PR rewrite the support matrix table found in the board pages in Markdown to make it easier to use Markdown features, such as footnotes.

The rendered output should be the same.

## Issues/PRs references

Extracted from #1403.

## Open Questions

<!-- Unresolved questions, if any. -->

## Change checklist

<!--
We don't enforce a strict convention for commit messages,
but please make sure that:
- the commit history is clear and informative.
- the Developer Certificate of Origin (DCO) Sign-off is present
  in your commits. 
  - See https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin
-->
- [x] I have cleaned up my commit history and squashed fixup commits.
- [x] I have followed the [Coding Conventions](https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html).
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
