### PR TITLE
feat: add slipmux CoAP support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,8 +208,11 @@ dependencies = [
 name = "ariel-os-coap"
 version = "0.3.0"
 dependencies = [
+ "ariel-os-boards",
+ "ariel-os-buildinfo",
  "ariel-os-debug",
  "ariel-os-embassy",
+ "ariel-os-hal",
  "ariel-os-macros",
  "ariel-os-random",
  "ariel-os-storage",
@@ -226,15 +229,19 @@ dependencies = [
  "embassy-net",
  "embassy-sync 0.7.2",
  "embedded-io-async 0.6.1",
+ "embedded-nal",
  "embedded-nal-async",
  "embedded-nal-coap",
+ "embedded-nal-minimal-coapserver",
  "heapless 0.8.0",
  "hexlit",
  "lakers",
  "lakers-crypto-rustcrypto",
  "minicbor",
+ "once_cell",
  "serde",
  "serde_yaml",
+ "slipmux",
  "static_cell",
 ]
 
@@ -2460,6 +2467,22 @@ dependencies = [
  "embedded-nal-async",
  "heapless 0.9.1",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "embedded-nal-minimal-coapserver"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93b7e44d01f417eb6c38a8cd14cf2fd929104f58f6db84841d850fa72d78fa78"
+dependencies = [
+ "coap-handler",
+ "coap-message",
+ "coap-message-implementations",
+ "coap-numbers",
+ "embedded-nal",
+ "heapless 0.8.0",
+ "num-derive",
+ "num-traits",
 ]
 
 [[package]]
@@ -5556,6 +5579,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial-line-ip"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a0b86bcdab6b15029ff7e37ae8acdadbf5d48e070ec5a067aa5c31e306f958"
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5620,6 +5649,15 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "slipmux"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c4f847abb1018cc9aa469625bdc7e699058f28d15e116d242ff35b88b23272"
+dependencies = [
+ "serial-line-ip",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ ariel-os-utils = { path = "src/ariel-os-utils", default-features = false }
 
 const-str = "0.7.0"
 const_panic = { version = "0.2.8", default-features = false }
-defmt = { version = "1.0.0" }
+defmt = { version = "1.0.0", features = ["ip_in_core"] }
 defmt-rtt = { version = "1.1.0" }
 document-features = "0.2.8"
 fugit = { version = "0.3.7", default-features = false }

--- a/boards/bbc-microbit-v2.yaml
+++ b/boards/bbc-microbit-v2.yaml
@@ -6,3 +6,14 @@ boards:
         pin: P0_14
       button1:
         pin: P0_23
+    uarts:
+      UART_INT:
+        # According to https://tech.microbit.org/hardware/schematic/, which
+        # explains that pins are labeled from the host point of view. In the
+        # schematics of the 2.0 and 2.2 versions, the opposite is shown and
+        # claimed.
+        rx_pin: P1_08 # UART_INT_TX
+        tx_pin: P0_06 # UART_INT_RX
+        # FIXME: Is this exhaustive? (Seems those are all we have in Ariel right now)
+        possible_peripherals: [UARTE0, UARTE1]
+        host_facing: true

--- a/boards/nrf9151-dk.yaml
+++ b/boards/nrf9151-dk.yaml
@@ -43,3 +43,20 @@ boards:
         active: low
         aliases:
           - Button 4
+    uarts:
+      VCOM0:
+        tx_pin: P0_27
+        rx_pin: P0_26
+        rts_pin: P0_14
+        cts_pin: P0_15
+        # FIXME: Is this exhaustive? (Seems those are all we have in Ariel right now)
+        possible_peripherals: [SERIAL3]
+        host_facing: true
+      VCOM1:
+        tx_pin: P0_29
+        rx_pin: P0_28
+        rts_pin: P0_16
+        cts_pin: P0_17
+        # FIXME: Is this exhaustive? (Seems those are all we have in Ariel right now)
+        possible_peripherals: [SERIAL3]
+        host_facing: true

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1527,6 +1527,26 @@ modules:
     selects:
       - coap-transport-slipmux-backend
 
+  - name: coap-transport-slipmux-usb
+    help: |
+      The slipmux CoAP transport goes over a single USB serial device created for this purpose.
+
+      As it is currently implemented, this uses up the complete USB device.
+
+      Note that for devices that are USB capable, creating a USB Ethernet interface is generally preferred.
+      Typical reasons to do this are:
+
+      * interaction with hosts where users or applications are authorized to interact with serial ports but not set even a link-local network,
+      * drop-in replacing devices that had a dedicated USB serial chip, and
+      * testing.
+    provides_unique: [coap-transport-slipmux-backend]
+    selects:
+      - usb
+    env:
+      global:
+        FEATURES:
+          - ariel-os/coap-transport-slipmux-usb
+
   - name: coap-transport-slipmux-uart
     help: |
       The slipmux CoAP transport goes over the board's designated host-side UART.

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1521,6 +1521,23 @@ modules:
         FEATURES:
           - ariel-os/coap-transport-udp
 
+  - name: coap-transport-slipmux
+    help: The transport of CoAP that uses the slipmux (CoAP multiplexed in SLIP) over some UART.
+    provides_unique: [coap-transport]
+    selects:
+      - coap-transport-slipmux-backend
+
+  - name: coap-transport-slipmux-uart
+    help: |
+      The slipmux CoAP transport goes over the board's designated host-side UART.
+    provides_unique: [coap-transport-slipmux-backend]
+    selects:
+      - has_host_facing_uart
+    env:
+      global:
+        FEATURES:
+          - ariel-os/coap-transport-slipmux-uart
+
   - name: coap-server
     help: Support for applications to set up CoAP server handlers.
 

--- a/src/ariel-os-boards/laze.yml
+++ b/src/ariel-os-boards/laze.yml
@@ -23,6 +23,7 @@ builders:
   parent: nrf52833
   provides:
   - has_buttons
+  - has_host_facing_uart
 - name: dfrobot-firebeetle2-esp32-c6
   parent: esp32c6fx4
   provides:
@@ -107,6 +108,7 @@ builders:
   parent: nrf9151
   provides:
   - has_buttons
+  - has_host_facing_uart
   - has_leds
 - name: nrf9160dk-nrf9160
   parent: nrf9160

--- a/src/ariel-os-boards/src/bbc-microbit-v2.rs
+++ b/src/ariel-os-boards/src/bbc-microbit-v2.rs
@@ -5,6 +5,9 @@ pub mod pins {
     ariel_os_hal::define_peripherals!(
         ButtonPeripherals { button0 : P0_14, button1 : P0_23, }
     );
+    ariel_os_hal::define_uarts![
+        { name : UART_INT, device : UARTE0, tx : P0_06, rx : P1_08, host_facing : true },
+    ];
 }
 #[allow(unused_variables)]
 pub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}

--- a/src/ariel-os-boards/src/nrf9151-dk.rs
+++ b/src/ariel-os-boards/src/nrf9151-dk.rs
@@ -9,6 +9,10 @@ pub mod pins {
         ButtonPeripherals { button0 : P0_08, button1 : P0_09, button2 : P0_18, button3 :
         P0_19, }
     );
+    ariel_os_hal::define_uarts![
+        { name : VCOM0, device : SERIAL3, tx : P0_27, rx : P0_26, host_facing : true }, {
+        name : VCOM1, device : SERIAL3, tx : P0_29, rx : P0_28, host_facing : true },
+    ];
 }
 #[allow(unused_variables)]
 pub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}

--- a/src/ariel-os-coap/Cargo.toml
+++ b/src/ariel-os-coap/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 
 [dependencies]
 ariel-os-boards = { workspace = true, optional = true }
+ariel-os-buildinfo = { workspace = true, optional = true }
 ariel-os-debug = { workspace = true }
 ariel-os-embassy = { workspace = true }
 ariel-os-hal = { path = "../ariel-os-hal", optional = true }
@@ -90,6 +91,10 @@ coap-transport-slipmux-uart = [
   "_coap-transport-slipmux",
   "ariel-os-boards",
   "ariel-os-hal/uart",
+]
+coap-transport-slipmux-usb = [
+  "dep:ariel-os-buildinfo",
+  "_coap-transport-slipmux",
 ]
 
 # Plain feature forwards and selected by laze to fill up the default features on demand.

--- a/src/ariel-os-coap/Cargo.toml
+++ b/src/ariel-os-coap/Cargo.toml
@@ -7,8 +7,10 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+ariel-os-boards = { workspace = true, optional = true }
 ariel-os-debug = { workspace = true }
 ariel-os-embassy = { workspace = true }
+ariel-os-hal = { path = "../ariel-os-hal", optional = true }
 ariel-os-macros = { path = "../ariel-os-macros" }
 ariel-os-random = { workspace = true, features = ["csprng"], optional = true }
 ariel-os-storage = { workspace = true, optional = true }
@@ -28,9 +30,13 @@ embassy-net = { workspace = true, features = [
 ], optional = true }
 embassy-sync = { workspace = true }
 embedded-nal-async = { version = "0.8", optional = true }
+embedded-nal-minimal-coapserver = { version = "0.5.0", optional = true }
+embedded-nal = { version = "0.9.0", optional = true }
 embedded-nal-coap = { workspace = true }
 lakers = { version = "0.8.0", default-features = false }
 lakers-crypto-rustcrypto = "0.8.0"
+once_cell = { workspace = true }
+slipmux = { version = "0.4.0", optional = true, default-features = false }
 static_cell = { workspace = true }
 
 # Used for constructing credentials
@@ -74,6 +80,16 @@ coap-transport-udp = [
   "dep:embassy-net",
   "dep:embedded-nal-async",
   "ariel-os-embassy/net",
+]
+_coap-transport-slipmux = [
+  "dep:embedded-nal-minimal-coapserver",
+  "dep:embedded-nal",
+  "dep:slipmux",
+]
+coap-transport-slipmux-uart = [
+  "_coap-transport-slipmux",
+  "ariel-os-boards",
+  "ariel-os-hal/uart",
 ]
 
 # Plain feature forwards and selected by laze to fill up the default features on demand.

--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -18,6 +18,9 @@ mod stored;
 #[cfg(feature = "coap-transport-udp")]
 mod transport_udp;
 
+#[cfg(feature = "_coap-transport-slipmux")]
+mod transport_slipmux;
+
 use ariel_os_embassy::cell::SameExecutorCell;
 #[cfg(feature = "coap-server")]
 use coap_handler_implementations::ReportingHandlerBuilder as _;
@@ -156,6 +159,8 @@ async fn coap_run_impl(handler: impl coap_handler::Handler + coap_handler::Repor
     cfg_if::cfg_if! {
         if #[cfg(feature = "coap-transport-udp")] {
             transport_udp::coap_run_udp(handler).await
+        } else if #[cfg(feature = "_coap-transport-slipmux")] {
+            transport_slipmux::coap_run_slipmux(handler).await
         } else if #[cfg(feature = "doc")] {
             loop {}
         } else {

--- a/src/ariel-os-coap/src/transport_slipmux.rs
+++ b/src/ariel-os-coap/src/transport_slipmux.rs
@@ -1,0 +1,292 @@
+// FIXME: This does not populate coap_client; probably it even could (but only with weird IP
+// address semantics).
+
+use ariel_os_debug::log::{Hex, debug, warn};
+use embassy_sync::once_lock::OnceLock;
+
+mod over_uart {
+    use ariel_os_embassy::cell::SameExecutorCell;
+    use static_cell::ConstStaticCell;
+
+    use super::*;
+
+    type UartAssignment = ariel_os_boards::pins::HOST_FACING_UART;
+
+    // FIXME There has to be a better idiom for a function deep down to take peripherals that does
+    // not involve spawning a task that terminates at startup?
+    //
+    // (Therefore, not bothering with optimizing any of its access)
+    static TAKE_THIS: OnceLock<SameExecutorCell<core::cell::RefCell<Option<UartAssignment>>>> =
+        OnceLock::new();
+
+    #[ariel_os_macros::task(autostart, peripherals)]
+    async fn pass_on_uart(peripherals: UartAssignment) {
+        TAKE_THIS
+            .init(SameExecutorCell::new_async(Some(peripherals).into()).await)
+            .ok()
+            .expect("Autostart is only called once");
+    }
+
+    // FIXME: Move to BufRead once <https://github.com/ariel-os/ariel-os/pull/1600> is resolved.
+    pub(super) async fn take() -> impl embedded_io_async::Read + embedded_io_async::Write {
+        let peripherals: UartAssignment = TAKE_THIS
+            .try_get()
+            .unwrap()
+            .get_async()
+            .await
+            .unwrap()
+            .take()
+            .unwrap();
+
+        static RX_BUF: ConstStaticCell<[u8; 16]> = ConstStaticCell::new([0; 16]);
+        static TX_BUF: ConstStaticCell<[u8; 16]> = ConstStaticCell::new([0; 16]);
+        let rx_buf = RX_BUF.take();
+        let tx_buf = TX_BUF.take();
+
+        let mut config = ariel_os_hal::hal::uart::Config::default();
+        config.baudrate = ariel_os_hal::uart::Baudrate::_115200;
+
+        use ariel_os_hal::uart::Assignment;
+        let (tx, rx) = peripherals.into_pins();
+
+        <UartAssignment as Assignment>::Device::new(rx, tx, rx_buf, tx_buf, config)
+            .expect("Invalid UART configuration")
+    }
+}
+
+pub(crate) async fn coap_run_slipmux(mut handler: impl coap_handler::Handler) -> ! {
+    use embedded_io_async::{Read, Write};
+    use slipmux::DecodeStatus;
+
+    // For the time being we play the simple game, where we just have a server, and can afford to
+    // read until something has arrived, then write out what has been written, and continue.
+    //
+    // This will not be sustainable with the next generation coap-handler, and then we may need to
+    // split the UARTs.
+
+    let mut uart = over_uart::take().await;
+
+    let mut decoder = slipmux::Decoder::new();
+    let mut slipmux = SingleFrameDecoder::default();
+    loop {
+        // FIXME: This is an ugly reading mechanism, made just slightly more tolerable by
+        // decoder.decode() taking things bytewise anyway.
+        //
+        // Once <https://github.com/ariel-os/ariel-os/pull/1600> is resolved, this paragraph should
+        // be replaced by the `//BR` comments, which avoid going back and forth with the
+        // peripheral.
+        let mut bytebuf = [0];
+        let read = uart.read(&mut bytebuf).await.unwrap();
+        assert_eq!(read, 1);
+        let byte = bytebuf[0];
+
+        //BR let mut buffer = uart.fill_buf().await.unwrap();
+        //BR let mut consume = 0;
+
+        let mut coap_ready = false;
+
+        //BR while let Some(&byte) = buffer.split_off_first() {
+        //BR consume += 1;
+
+        // Ignoring the return value; handling everything inside the decoder.
+        match decoder.decode(byte, &mut slipmux) {
+            Err(_) => {
+                warn!("Decoding error; trying at the next byte.");
+                //BR consume = 1;
+                //BR break;
+            }
+            Ok(DecodeStatus::Incomplete) => {
+                //BR continue
+            }
+            Ok(DecodeStatus::FrameCompleteDiagnostic) => {
+                // Use up to the cursor, and silently ignore overflows.
+                let (Ok(buffer) | Err(buffer)) = slipmux.data();
+                let text = core::str::from_utf8(buffer);
+                warn!(
+                    "Peer sent diagnostic data. This will no be forwarded; content was {:?}{}",
+                    text.map_err(|_| &buffer),
+                    if slipmux.data().is_err() { "..." } else { "" },
+                );
+                //BR break;
+            }
+            Ok(DecodeStatus::FrameCompleteIp) => {
+                warn!("Peer sent network data, which is unsupported.",);
+                //BR break;
+            }
+            Ok(DecodeStatus::FrameCompleteConfiguration) => {
+                coap_ready = true;
+                //BR break;
+            }
+        }
+
+        //BR }
+
+        //BR uart.consume(consume);
+
+        if coap_ready {
+            if slipmux.data().is_err() {
+                warn!("Ignoring overly long CoAP request.");
+                // FIXME: Respond accordingly (Request Entity Too Large and size1)
+                continue;
+            };
+            // Reaching into raw value rather than through accessor because we need it mutable for
+            // the pseudostack.
+            let buffer = &mut slipmux.buffer;
+            // Compensate for checksum -- FIXME: where should this best be done?
+            let Some(actual_length) = buffer.len().checked_sub(2) else {
+                warn!("Ignoring overly short CoAP request.");
+                continue;
+            };
+            buffer.truncate(actual_length);
+
+            debug!("Sending into CoAP stack: {}", Hex(&buffer));
+            let mut pseudostack = PseudoStack(buffer);
+            embedded_nal_minimal_coapserver::poll(
+                &mut pseudostack,
+                &mut PseudoSocket,
+                &mut handler,
+            )
+            .unwrap(); // No `let Ok(()) = `, because there's the unavoidable nb::Error case.
+
+            debug!("Taking out of CoAP stack: {}", Hex(&buffer));
+
+            if buffer.len() == 0 {
+                // FIXME: Send RST if parsable to that point (or make
+                // embedded_nal_minimal_coapserver emit one
+                warn!("Request was completely unparsable, ignoring.");
+            } else {
+                let mut outbuf = [0; 16];
+                let mut encoder =
+                    slipmux::ChunkedEncoder::new(slipmux::FrameType::Configuration, &buffer);
+                loop {
+                    let size = encoder.encode_chunk(&mut outbuf);
+                    if size == 0 {
+                        break;
+                    }
+                    uart.write_all(&outbuf[..size]).await.unwrap();
+                }
+            }
+        }
+    }
+}
+
+struct SingleFrameDecoder {
+    // See https://github.com/t2trg/slipmux/issues/1 for expectations on how big this should be
+    buffer: heapless::Vec<u8, 1280>,
+    overflow: bool,
+}
+
+impl SingleFrameDecoder {
+    /// Returns the decoded data if complete.
+    ///
+    /// # Errors
+    ///
+    /// If the buffer overflew, it returns the initial decoded bytes.
+    fn data(&self) -> Result<&[u8], &[u8]> {
+        if self.overflow {
+            Err(&self.buffer)
+        } else {
+            Ok(&self.buffer)
+        }
+    }
+}
+
+impl Default for SingleFrameDecoder {
+    fn default() -> Self {
+        SingleFrameDecoder {
+            buffer: Default::default(),
+            overflow: false,
+        }
+    }
+}
+
+impl slipmux::FrameHandler for SingleFrameDecoder {
+    fn begin_frame(&mut self, _: slipmux::FrameType) {
+        self.buffer.clear();
+        self.overflow = false;
+    }
+    fn write_byte(&mut self, byte: u8) {
+        if self.buffer.push(byte).is_err() {
+            self.overflow = true;
+        }
+    }
+    fn end_frame(&mut self, _: Option<slipmux::Error>) {}
+}
+
+/// The CoAP items in slipmux behave 1:1 like in CoAP-over-UDP. Emulating an embedded-nal stack to
+/// exchange them so we can funnel the traffic into a CoAP server.
+///
+/// As CoAP is currently not async and we don't send messages on our own, this now goes into the
+/// simpler embedded-nal rather than embedded-nal-async.
+struct PseudoStack<'a>(&'a mut heapless::Vec<u8, 1280>);
+
+struct PseudoSocket;
+
+#[derive(Debug)]
+struct DoesNotFit;
+
+use core::net::SocketAddr;
+
+impl embedded_nal::UdpClientStack for PseudoStack<'_> {
+    type UdpSocket = PseudoSocket;
+    type Error = DoesNotFit;
+    fn socket(&mut self) -> Result<PseudoSocket, DoesNotFit> {
+        panic!("Unused");
+    }
+    fn connect(&mut self, _: &mut PseudoSocket, _: SocketAddr) -> Result<(), DoesNotFit> {
+        panic!("Unused");
+    }
+    fn send(
+        &mut self,
+        _: &mut PseudoSocket,
+        _: &[u8],
+    ) -> Result<(), embedded_nal::nb::Error<DoesNotFit>> {
+        panic!("Unused");
+    }
+    fn receive(
+        &mut self,
+        _: &mut PseudoSocket,
+        outbuf: &mut [u8],
+    ) -> Result<(usize, SocketAddr), embedded_nal::nb::Error<DoesNotFit>> {
+        let len = self.0.len();
+        let outslice = outbuf.get_mut(0..len).ok_or(DoesNotFit)?;
+        outslice.copy_from_slice(self.0);
+
+        // Mostly a precaution against sending the request back if ever the minimal CoAP server
+        // should *not* send a single response.
+        self.0.truncate(0);
+
+        Ok((
+            len,
+            SocketAddr::V6(core::net::SocketAddrV6::new(
+                core::net::Ipv6Addr::UNSPECIFIED,
+                0,
+                0,
+                0,
+            )),
+        ))
+    }
+    fn close(&mut self, _: PseudoSocket) -> Result<(), DoesNotFit> {
+        panic!("Unused");
+    }
+}
+
+impl embedded_nal::UdpFullStack for PseudoStack<'_> {
+    fn bind(&mut self, _: &mut PseudoSocket, _: u16) -> Result<(), Self::Error> {
+        panic!("Unused")
+    }
+    fn send_to(
+        &mut self,
+        _: &mut PseudoSocket,
+        _: SocketAddr,
+        data: &[u8],
+    ) -> Result<(), embedded_nal::nb::Error<Self::Error>> {
+        // FIXME: Abusing the configuration buffer seems like a convenient thing to do, given we're
+        // in full control of .0 for the duration of processing the request -- anything more
+        // elegant?
+
+        self.0.clear();
+        self.0.extend_from_slice(data).map_err(|_| DoesNotFit)?;
+        Ok(())
+    }
+}

--- a/src/ariel-os-coap/src/transport_slipmux.rs
+++ b/src/ariel-os-coap/src/transport_slipmux.rs
@@ -2,42 +2,17 @@
 // address semantics).
 
 use ariel_os_debug::log::{Hex, debug, warn};
-use embassy_sync::once_lock::OnceLock;
+use embassy_sync::signal::Signal;
 
 mod over_uart {
-    use ariel_os_embassy::cell::SameExecutorCell;
     use static_cell::ConstStaticCell;
 
     use super::*;
 
     type UartAssignment = ariel_os_boards::pins::HOST_FACING_UART;
 
-    // FIXME There has to be a better idiom for a function deep down to take peripherals that does
-    // not involve spawning a task that terminates at startup?
-    //
-    // (Therefore, not bothering with optimizing any of its access)
-    static TAKE_THIS: OnceLock<SameExecutorCell<core::cell::RefCell<Option<UartAssignment>>>> =
-        OnceLock::new();
-
     #[ariel_os_macros::task(autostart, peripherals)]
-    async fn pass_on_uart(peripherals: UartAssignment) {
-        TAKE_THIS
-            .init(SameExecutorCell::new_async(Some(peripherals).into()).await)
-            .ok()
-            .expect("Autostart is only called once");
-    }
-
-    // FIXME: Move to BufRead once <https://github.com/ariel-os/ariel-os/pull/1600> is resolved.
-    pub(super) async fn take() -> impl embedded_io_async::Read + embedded_io_async::Write {
-        let peripherals: UartAssignment = TAKE_THIS
-            .try_get()
-            .unwrap()
-            .get_async()
-            .await
-            .unwrap()
-            .take()
-            .unwrap();
-
+    async fn pass_on_uart(peripherals: UartAssignment) -> ! {
         static RX_BUF: ConstStaticCell<[u8; 16]> = ConstStaticCell::new([0; 16]);
         static TX_BUF: ConstStaticCell<[u8; 16]> = ConstStaticCell::new([0; 16]);
         let rx_buf = RX_BUF.take();
@@ -49,13 +24,52 @@ mod over_uart {
         use ariel_os_hal::uart::Assignment;
         let (tx, rx) = peripherals.into_pins();
 
-        <UartAssignment as Assignment>::Device::new(rx, tx, rx_buf, tx_buf, config)
-            .expect("Invalid UART configuration")
+        let uart = <UartAssignment as Assignment>::Device::new(rx, tx, rx_buf, tx_buf, config)
+            .expect("Invalid UART configuration");
+
+        serve_slipmux(uart).await
     }
 }
 
-pub(crate) async fn coap_run_slipmux(mut handler: impl coap_handler::Handler) -> ! {
-    use embedded_io_async::{Read, Write};
+/// Signal in which [`server_slipmux`] places the decoder buffer if it contains anything which CoAP
+/// should process. The buffer is returned through `COAP2SLIPMUX` to avoid that the task that
+/// places the buffer takes it back immediately without waiting for the other task.
+///
+/// For optimization, we could look into whether there is a way to yield to that other task, but
+/// then we'd have to handle the case when that other task is not active yet, and just
+/// yielding-for-everyone-else still returns us the unmodified buffer.
+///
+/// As there is only a single `&'static mut SingleFrameDecoder`, Signal's overwrite semantics don't
+/// concern us: We don't have anything to overwrite the latest value with, unless it was taken out
+/// and returned before.
+static SLIPMUX2COAP: Signal<
+    embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex,
+    &'static mut SingleFrameDecoder,
+> = Signal::new();
+/// See [`SLIPMUX2COAP`]; this works the same, just in the opposite direction.
+static COAP2SLIPMUX: Signal<
+    embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex,
+    &'static mut SingleFrameDecoder,
+> = Signal::new();
+
+/// Decodes frames from a slipmux peer, and sends them to the relevant tasks for further
+/// processing, receiving frames in return.
+///
+/// In particular, whenever a CoAP frame is ready, it is signaled in [`SLIPMUX2COAP`] (to be
+/// picked up by [`coap_run_slipmux()`], however that is called (autostarted or by the user once
+/// the handler is ready), and this task is then idle until the CoAP response is returned through
+/// [`COAP2SLIPMUX`].
+///
+/// When this module starts doing SLIP as well, the task will treat the network stack as a
+/// signaling peer just like the CoAP stack.
+///
+/// This is auto-started by whichever module provides the slipmux back-end from that module's
+/// autostart task, and…
+///
+/// # Panics
+///
+/// … if called more than once.
+async fn serve_slipmux(mut uart: impl embedded_io_async::Read + embedded_io_async::Write) -> ! {
     use slipmux::DecodeStatus;
 
     // For the time being we play the simple game, where we just have a server, and can afford to
@@ -64,10 +78,10 @@ pub(crate) async fn coap_run_slipmux(mut handler: impl coap_handler::Handler) ->
     // This will not be sustainable with the next generation coap-handler, and then we may need to
     // split the UARTs.
 
-    let mut uart = over_uart::take().await;
+    static SLIPMUX: static_cell::StaticCell<SingleFrameDecoder> = static_cell::StaticCell::new();
+    let mut slipmux = SLIPMUX.init_with(Default::default);
 
     let mut decoder = slipmux::Decoder::new();
-    let mut slipmux = SingleFrameDecoder::default();
     loop {
         // FIXME: This is an ugly reading mechanism, made just slightly more tolerable by
         // decoder.decode() taking things bytewise anyway.
@@ -89,7 +103,7 @@ pub(crate) async fn coap_run_slipmux(mut handler: impl coap_handler::Handler) ->
         //BR consume += 1;
 
         // Ignoring the return value; handling everything inside the decoder.
-        match decoder.decode(byte, &mut slipmux) {
+        match decoder.decode(byte, slipmux) {
             Err(_) => {
                 warn!("Decoding error; trying at the next byte.");
                 //BR consume = 1;
@@ -124,31 +138,18 @@ pub(crate) async fn coap_run_slipmux(mut handler: impl coap_handler::Handler) ->
         //BR uart.consume(consume);
 
         if coap_ready {
-            if slipmux.data().is_err() {
-                warn!("Ignoring overly long CoAP request.");
-                // FIXME: Respond accordingly (Request Entity Too Large and size1)
-                continue;
-            };
-            // Reaching into raw value rather than through accessor because we need it mutable for
-            // the pseudostack.
-            let buffer = &mut slipmux.buffer;
-            // Compensate for checksum -- FIXME: where should this best be done?
-            let Some(actual_length) = buffer.len().checked_sub(2) else {
-                warn!("Ignoring overly short CoAP request.");
-                continue;
-            };
-            buffer.truncate(actual_length);
+            // If SLIP support is added, and CoAP becomes optional, this might detect at build time
+            // that there is no CoAP that we should wait (indefinitely) for, and instead just send
+            // the courtesy RSTs.
+            //
+            // If setting up the CoAP stack ever takes long (and maybe will even deadlock with
+            // networking), this might start issuing RSTs (meh: peer might think they're permanent)
+            // or 5.03 Max-Age: 1 responses.
 
-            debug!("Sending into CoAP stack: {}", Hex(&buffer));
-            let mut pseudostack = PseudoStack(buffer);
-            embedded_nal_minimal_coapserver::poll(
-                &mut pseudostack,
-                &mut PseudoSocket,
-                &mut handler,
-            )
-            .unwrap(); // No `let Ok(()) = `, because there's the unavoidable nb::Error case.
+            SLIPMUX2COAP.signal(slipmux);
+            slipmux = COAP2SLIPMUX.wait().await;
 
-            debug!("Taking out of CoAP stack: {}", Hex(&buffer));
+            let buffer = &slipmux.buffer;
 
             if buffer.len() == 0 {
                 // FIXME: Send RST if parsable to that point (or make
@@ -167,6 +168,37 @@ pub(crate) async fn coap_run_slipmux(mut handler: impl coap_handler::Handler) ->
                 }
             }
         }
+    }
+}
+
+pub(crate) async fn coap_run_slipmux(mut handler: impl coap_handler::Handler) -> ! {
+    loop {
+        let slipmux: &'static mut SingleFrameDecoder = SLIPMUX2COAP.wait().await;
+
+        if slipmux.data().is_err() {
+            warn!("Ignoring overly long CoAP request.");
+            // FIXME: Respond accordingly (Request Entity Too Large and size1)
+            continue;
+        };
+        // Reaching into raw value rather than through accessor because we need it mutable for
+        // the pseudostack.
+        let buffer = &mut slipmux.buffer;
+        // Compensate for checksum -- FIXME: where should this best be done?
+        let Some(actual_length) = buffer.len().checked_sub(2) else {
+            warn!("Ignoring overly short CoAP request.");
+            continue;
+        };
+        buffer.truncate(actual_length);
+
+        debug!("Sending into CoAP stack: {}", Hex(&buffer));
+        let mut pseudostack = PseudoStack(buffer);
+        embedded_nal_minimal_coapserver::poll(&mut pseudostack, &mut PseudoSocket, &mut handler)
+            // No `let Ok(()) = `, because there's the unavoidable nb::Error case.
+            .unwrap();
+
+        debug!("Taking out of CoAP stack: {}", Hex(&buffer));
+
+        COAP2SLIPMUX.signal(slipmux);
     }
 }
 

--- a/src/ariel-os-hal/src/hal.rs
+++ b/src/ariel-os-hal/src/hal.rs
@@ -28,6 +28,8 @@ pub mod define_peripherals;
 
 // these macros need explicit export from crate root in order to re-export them.
 pub use crate::define_peripherals;
+pub use crate::define_uart;
+pub use crate::define_uarts;
 pub use crate::group_peripherals;
 
 pub use define_peripherals::*;

--- a/src/ariel-os-hal/src/hal/define_peripherals.rs
+++ b/src/ariel-os-hal/src/hal/define_peripherals.rs
@@ -144,6 +144,7 @@ macro_rules! group_peripherals {
 /// While usable for applications just as well (to set up custom UARTs), it is most useful in board
 /// descriptions, because in addition to the individual exposed UARTs, it can also provide extra
 /// functionalities that take all UARTs into account.
+#[cfg(feature = "uart")]
 #[macro_export]
 macro_rules! define_uarts {
     ( $( { $($args:tt)+ } ),* $(,)? ) => {
@@ -161,6 +162,12 @@ macro_rules! define_uarts {
     }
 }
 
+#[cfg(not(feature = "uart"))]
+#[macro_export]
+macro_rules! define_uarts {
+    ( $($_:tt)+ ) => {};
+}
+
 /// Creates a struct of the given `name`, containing everything needed to set up a UART.
 ///
 /// It holds the TX and RX pins, and can be taken through the same mechanism as those defined using
@@ -170,6 +177,7 @@ macro_rules! define_uarts {
 /// The struct also implement [`ariel_os::uart::Assignment`], and by that carries a type with the
 /// (not trait-backed) promise that it is something that can be initialized through the
 /// [`ariel_os::uart`] APIs.
+#[cfg(feature = "uart")]
 #[macro_export]
 macro_rules! define_uart {
     ( name: $name:ident, device: $device:ident, tx: $tx:ident, rx: $rx:ident, host_facing: $_host_facing:literal ) => {
@@ -201,6 +209,12 @@ macro_rules! define_uart {
             }
         }
     };
+}
+
+#[cfg(not(feature = "uart"))]
+#[macro_export]
+macro_rules! define_uart {
+    ( $($_:tt)+ ) => {};
 }
 
 #[macro_export]

--- a/src/ariel-os-hal/src/hal/define_peripherals.rs
+++ b/src/ariel-os-hal/src/hal/define_peripherals.rs
@@ -161,9 +161,11 @@ macro_rules! define_uarts {
     }
 }
 
-/// Creates a struct of the given `name` that holds the TX and RX pins, and can be taken through
-/// the same mechanism as those defined using [`ariel_os::hal::define_peripherals!`] (that is, by
-/// using [`ariel_os::task(autostart, peripherals)`] or the underlying `TakePeripherals` trait).
+/// Creates a struct of the given `name`, containing everything needed to set up a UART.
+///
+/// It holds the TX and RX pins, and can be taken through the same mechanism as those defined using
+/// [`ariel_os::hal::define_peripherals!`] (that is, by using [`ariel_os::task(autostart,
+/// peripherals)`] or the underlying `TakePeripherals` trait).
 ///
 /// The struct also implement [`ariel_os::uart::Assignment`], and by that carries a type with the
 /// (not trait-backed) promise that it is something that can be initialized through the

--- a/src/ariel-os-hal/src/hal/define_peripherals.rs
+++ b/src/ariel-os-hal/src/hal/define_peripherals.rs
@@ -131,6 +131,105 @@ macro_rules! group_peripherals {
     }
 }
 
+/// This macro defines a `uarts` module that gives access to UARTs by various accessors (currently:
+/// through accessor types, which can be used as peripherals in autostart tasks).
+///
+/// Its argument is a comma-separated list of items that mostly go into repeated [`define_uart!`] calls
+/// (which define a struct type); see there.
+///
+/// In addition to that, type aliases are created for easier access; currently, that is only
+/// `HOST_FACING_UART` (an alias to the type of the host facing port, on boards with
+/// `has_host_facing_uart`).
+///
+/// While usable for applications just as well (to set up custom UARTs), it is most useful in board
+/// descriptions, because in addition to the individual exposed UARTs, it can also provide extra
+/// functionalities that take all UARTs into account.
+#[macro_export]
+macro_rules! define_uarts {
+    ( $( { $($args:tt)+ } ),* $(,)? ) => {
+        $(
+            $crate::define_uart!{ $($args)+ }
+        )*
+
+        $crate::_define_host_facing_uarts!{
+            // Note that this does *not* create an outer separator; instead, the inner macro
+            // creates a trailing comma for each item.
+            $(
+                $crate::_uart_get_host_facing_names!{ $($args)+ }
+            ),*
+        }
+    }
+}
+
+/// Creates a struct of the given `name` that holds the TX and RX pins, and can be taken through
+/// the same mechanism as those defined using [`ariel_os::hal::define_peripherals!`] (that is, by
+/// using [`ariel_os::task(autostart, peripherals)`] or the underlying `TakePeripherals` trait).
+///
+/// The struct also implement [`ariel_os::uart::Assignment`], and by that carries a type with the
+/// (not trait-backed) promise that it is something that can be initialized through the
+/// [`ariel_os::uart`] APIs.
+#[macro_export]
+macro_rules! define_uart {
+    ( name: $name:ident, device: $device:ident, tx: $tx:ident, rx: $rx:ident, host_facing: $_host_facing:literal ) => {
+        // Rather than define_peripherals!'ing here, we define our type manually, because we also
+        // have to carry the device type, and that's not coming through TakePeripherals.
+
+        #[allow(non_snake_case)]
+        pub struct $name {
+            tx: $crate::hal::peripheral::Peri<'static, peripherals::$tx>,
+            rx: $crate::hal::peripheral::Peri<'static, peripherals::$rx>,
+        }
+
+        impl $crate::hal::TakePeripherals<$name> for &mut $crate::hal::OptionalPeripherals {
+            fn take_peripherals(&mut self) -> $name {
+                $name {
+                    tx: self.$tx.take().unwrap(),
+                    rx: self.$rx.take().unwrap(),
+                }
+            }
+        }
+
+        impl $crate::uart::Assignment for $name {
+            type Device<'a> = $crate::hal::uart::$device<'a>;
+            type Tx = $crate::hal::peripheral::Peri<'static, peripherals::$tx>;
+            type Rx = $crate::hal::peripheral::Peri<'static, peripherals::$rx>;
+
+            fn into_pins(self) -> (Self::Tx, Self::Rx) {
+                (self.tx, self.rx)
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! _uart_get_host_facing_names {
+    ( name: $name:ident, device: $_device:ident, tx: $_tx:ident, rx: $_rx:ident, host_facing: true ) => {
+        $name
+    };
+    ( name: $_name:ident, device: $_device:ident, tx: $_tx:ident, rx: $_rx:ident, host_facing: false ) => {};
+}
+
+#[macro_export]
+macro_rules! _define_host_facing_uarts {
+    () => {};
+    ( $name:ty ) => {
+        pub type HOST_FACING_UART = $name;
+    };
+    ( $name:ty, $name2:ty $(, $($_:ty),+)? ) => {
+        pub type HOST_FACING_UART = $name;
+        // FIXME: This can only be accessed by application that have some prior knowledge of
+        // multiple UARTs being available, and, more importantly, has negotiated between its
+        // components which one takes which. Once any future mechanism enables that negotiation,
+        // these types will need to be advertised to this mechanism.
+        pub type HOST_FACING_UART_2 = $name2;
+    };
+    ( $name:ty, $name2:ty $(, $($_:ty),+)? ) => {
+        compile_error!(
+            "Larger numbers of host facing UARTs can be supported by expanding the `_define_host_facing_uarts` macro of ariel-os-hal to more cases."
+            );
+    };
+}
+
 #[doc(hidden)]
 pub trait TakePeripherals<T> {
     fn take_peripherals(&mut self) -> T;

--- a/src/ariel-os-hal/src/hal/define_peripherals.rs
+++ b/src/ariel-os-hal/src/hal/define_peripherals.rs
@@ -184,7 +184,7 @@ macro_rules! define_uart {
         // Rather than define_peripherals!'ing here, we define our type manually, because we also
         // have to carry the device type, and that's not coming through TakePeripherals.
 
-        #[allow(non_snake_case)]
+        #[allow(nonstandard_style)]
         pub struct $name {
             tx: $crate::hal::peripheral::Peri<'static, peripherals::$tx>,
             rx: $crate::hal::peripheral::Peri<'static, peripherals::$rx>,

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -98,6 +98,7 @@ coap-server-config-unprotected = [
   "ariel-os-coap/coap-server-config-unprotected",
 ]
 coap-transport-udp = ["ariel-os-coap/coap-transport-udp"]
+coap-transport-slipmux-uart = ["ariel-os-coap/coap-transport-slipmux-uart"]
 # Forwarded features that are not even user selected, but influenced by the
 # build system that knows who provides an abort and assert handler.
 liboscore-provide-abort = ["ariel-os-coap/liboscore-provide-abort"]

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -98,6 +98,7 @@ coap-server-config-unprotected = [
   "ariel-os-coap/coap-server-config-unprotected",
 ]
 coap-transport-udp = ["ariel-os-coap/coap-transport-udp"]
+coap-transport-slipmux-usb = ["ariel-os-coap/coap-transport-slipmux-usb"]
 coap-transport-slipmux-uart = ["ariel-os-coap/coap-transport-slipmux-uart"]
 # Forwarded features that are not even user selected, but influenced by the
 # build system that knows who provides an abort and assert handler.

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -63,6 +63,11 @@ criteria = "safe-to-deploy"
 delta = "0.1.2 -> 0.1.3"
 notes = "Changes affect only a dependency version, whose safety is out of scope (vetted independently), and will not affect the operation of this crate."
 
+[[audits.serial-line-ip]]
+who = "chrysn <chrysn@fsfe.org>"
+criteria = "safe-to-deploy"
+version = "0.5.0"
+
 [[audits.slab]]
 who = "chrysn <chrysn@fsfe.org>"
 criteria = "safe-to-deploy"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -68,6 +68,11 @@ who = "chrysn <chrysn@fsfe.org>"
 criteria = "safe-to-deploy"
 delta = "0.4.8 -> 0.4.11"
 
+[[audits.slipmux]]
+who = "chrysn <chrysn@fsfe.org>"
+criteria = "safe-to-deploy"
+version = "0.4.0"
+
 [[audits.tee-embedded-io]]
 who = "chrysn <chrysn@fsfe.org>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -610,6 +610,10 @@ criteria = "safe-to-deploy"
 version = "0.1.0-alpha.5"
 criteria = "safe-to-deploy"
 
+[[exemptions.embedded-nal-minimal-coapserver]]
+version = "0.5.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.embedded-storage]]
 version = "0.3.1"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
# Description

slipmux is a means by which IP, direct CoAP and debug messages can be sent over a serial line (based on SLIP). It is mostly aimed at devices that can not use a more structured form of communication with the host such as USB Ethernet, or where that structured form is inaccessible to the user (eg. because they are not authorized on their PC to set up Ethernet connections).

For example, it enables devices with hard-wired serial adapters such as older ESP32, the microbit-v2 or nRF9151-DK, to serve as network border routers (once we have routing functionality), and allows CoAP traffic into them even without any network setup whatsoever.

The present implementation discards any actual network messages and only deals in CoAP; this can be extended later. It runs either over actual UART or over USB serial; <del>the latter is vastly incomplete</del>. (It is of somewhat questionable utility, but there are cases when it does make sense, eg. when using a WebSerial connection into a webapp, which then enables end-to-end ACE/EDHOC/OSCORE security from the Internet into that device).

The main contribution of this PR is initially not the slipmux integration itself, but setting sbd up in such a way that a selectable module can require there to be a suitable UART in the first place; this is acting in tandem with https://github.com/ariel-os/sbd/pull/68. Consequentially, this avoids the need for any `pin.rs` module with a large ifdef sequence, and runs from descriptive data instead.

## Testing

Send CoAP requests via slipmux, eg. using Jelly.

Current invocations are:
* Real UART:
  * `laze build -b bbc-microbit-v2 -C examples/coap-server -s coap-transport-slipmux run`
  * `laze build -b nrf9151-dk -C examples/coap-server -s coap-transport-slipmux -s coap-server-config-unprotected run` (disabling CoAP security so that it can run on a board without an RNG)
* USB:
  * `laze build -b nrf9151-dk -particle-xenon -C tests/coap -D LOG=debug -s coap-transport-slipmux -s coap-server-config-unprotected run`

In all cases, it's best used with the [Jelly crate](https://github.com/Teufelchen1/jelly) provided by Teufelchen, who also wrote the slipmux implementation used for this port. Launch `Jelly /dev/ttyACM0` (or whichever port it is connected to), and observe that a green (successful) response comes back to the /.well-known/core request on the right side.

[edit, added]: Note that if you send raw commands (like, entering foobar / return in the user input), that shows in the debug logs, as we don't have a shell or a virtual UART.

## Issues/PRs References

- Builds on https://github.com/ariel-os/sbd/pull/68.
- Depends on #2181

Over time it may make sense to split the slip and UART aspects.

## Change Checklist

- [ ] I have cleaned up my [commit history][conventional-commits] and squashed fixup commits.
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
