### PR TITLE
feat(prek): add prek.toml config

### DIFF
--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -208,7 +208,7 @@ chips:
           - only available through the CryptoCell
       i2c_controller: supported
       spi_main: supported
-      uart: needs_testing
+      uart: supported
       logging: supported
       storage: supported
       wifi: not_available

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,83 @@
+# List of global excludes is copied from .gitattributes
+exclude = { glob = [
+  "book/src/SUMMARY.md",
+  "book/src/boards/*.md",
+  "book/src/chips/*.md",
+  "book/src/support_matrix.html",
+  "src/ariel-os-boards/laze.yml",
+  "src/ariel-os-boards/build.rs",
+  "src/ariel-os-boards/src/*.rs",
+] }
+
+[[repos]]
+repo = "local"
+hooks = [
+  { id = "taplo", name = "taplo", language = "rust", entry = "taplo fmt", types = [
+    "toml",
+  ] },
+  { id = "cargo fmt", name = "cargo fmt", language = "system", entry = "cargo fmt", args = [
+    "--check",
+    "--all",
+    "--",
+    "--config",
+    "format_generated_files=false",
+  ], types = [
+    "rust",
+  ], pass_filenames = false },
+  { id = "yamllint", name = "yamllint", language = "system", entry = "yamllint", args = [
+    "--strict",
+  ], types = [
+    "yaml",
+  ] },
+]
+
+[[repos]]
+repo = "local"
+hooks = [
+  { id = "gen_book", name = "gen_book", language = "system", entry = "laze build update-book", pass_filenames = false, verbose = false, files = { glob = [
+    "doc/support_matrix.yml",
+    "book/templates/*",
+  ] } },
+  { id = "sbd-gen", name = "sbd-gen", language = "rust", entry = "sbd-gen", args = [
+    "generate-ariel",
+    "boards",
+    "-o",
+    "src/ariel-os-boards",
+    "--mode",
+    "update",
+  ], files = "^boards/", pass_filenames = false },
+]
+
+[[repos]]
+repo = "https://github.com/astral-sh/ruff-pre-commit"
+rev = "v0.14.14"
+hooks = [
+  { id = "ruff-format", priority = 0 },
+  { id = "ruff-check", args = [
+    "--fix",
+    "--exit-non-zero-on-fix",
+  ], types_or = [
+    "python",
+    "pyi",
+  ], require_serial = true, priority = 1 },
+]
+
+
+[[repos]]
+repo = "builtin"
+hooks = [
+  { id = "end-of-file-fixer", args = [
+    "--fix",
+  ] },
+  { id = "trailing-whitespace" },
+  { id = "check-case-conflict" },
+  { id = "mixed-line-ending", args = [
+    "--fix=lf",
+  ] },
+  { id = "no-commit-to-branch", args = [
+    "--branch",
+    "main",
+    "--pattern",
+    "v\\d+\\.\\d+.\\d+",
+  ] },
+]


### PR DESCRIPTION
# Description

This PR adds a [prek.toml](github.com/j178/prek) config to run a *decent* set of checks at the git pre-commit hook. The goal is to have prek signal and fix linting failures locally before a PR is submitted by the contributor, decreasing the friction and round-trip time.

At this time this requires a local install of taplo. I don't know yet if we can work around that easily via our own pre-commit repo with a dependency on taplo.

## Testing

- `cargo install prek`
- `prek install` / `prek run`

## TODO:

- [x] builtin checks
- [x] Taplo
- [x] cargo fmt 
- [x] Ruff
- [x] yamllint (the built-in might be okay here)
- [x] <del>spell</del>
- [x] gen-book
- [x] matrix

And document it in the contributing guide

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Closes #2169

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
