### PR TITLE
fix: warnings in dummy hal

### DIFF
--- a/src/ariel-os-hal/src/hal/dummy/executor.rs
+++ b/src/ariel-os-hal/src/hal/dummy/executor.rs
@@ -1,3 +1,5 @@
+#![allow(unused, reason = "used by documentation only")]
+
 use embassy_executor::SpawnToken;
 
 #[doc(hidden)]
@@ -30,5 +32,7 @@ impl Spawner {
     pub fn spawn<S>(&self, _token: SpawnToken<S>) -> Result<(), ()> {
         unimplemented!();
     }
+
+    #[allow(clippy::unused_self)]
     pub fn must_spawn<S>(&self, _token: SpawnToken<S>) {}
 }

--- a/src/ariel-os-hal/src/hal/dummy/identity.rs
+++ b/src/ariel-os-hal/src/hal/dummy/identity.rs
@@ -1,3 +1,4 @@
 use ariel_os_embassy_common::identity;
 
+#[allow(unused)]
 pub type DeviceId = identity::NoDeviceId<identity::NotImplemented>;

--- a/src/ariel-os-hal/src/hal/dummy/mod.rs
+++ b/src/ariel-os-hal/src/hal/dummy/mod.rs
@@ -12,6 +12,7 @@
     clippy::needless_pass_by_value,
     reason = "this dummy module mimics manufacturer-specific crates"
 )]
+#![allow(unused, reason = "used by native and documentation only")]
 
 mod executor;
 


### PR DESCRIPTION
# Description
These are the fixes I need to apply to have a build for native without warnings on a fairly basic out-of-tree application. 
- Removes 2 unused imports.
- Allows unused code to be unused. Most of these are explicitly marked as unimplemented.

## Testing

## Issues/PRs References

## Open Questions

## Changelog Entry

## Change Checklist

- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
