### PR TITLE
feat(debug-log): Add custom log handler

### DIFF
--- a/book/src/debug-console.md
+++ b/book/src/debug-console.md
@@ -8,6 +8,65 @@ The [`ariel_os::debug::println!()`][println-macro-rustdoc] macro is used to prin
 When the debug console is enabled, panic messages are automatically printed to it.
 If this is unwanted, the `panic-printing` [laze module][laze-modules-book] can be disabled.
 
+## Debug Output Backends
+
+The debug console backend determines where `ariel_os::debug::println!()`
+output, panic messages, and `log` output are sent.
+This is a separate choice from selecting the logging facade (`defmt` or `log`).
+
+In typical Ariel OS builds, the backend is usually selected by laze as part of
+the target and runner setup, and can be overridden through laze modules when
+needed.
+Only one backend can be selected at a time.
+
+| Backend                           | What it does                                                                                                                                     | How to select it                                                                                                                                                 |
+|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| RTT (`defmt-rtt` / `rtt-target`)  | Sends output over RTT. Use `defmt-rtt` with the `defmt` facade, and `rtt-target` with the `log` facade for human-readable debug console output.  | `defmt-rtt` is selected automatically when using `defmt` with `probe-rs`. `rtt-target` can be selected explicitly when you want RTT output for the `log` facade. |
+| `debug-uart`                      | Sends human-readable output over the board's configured debug UART. This is a good choice when you want logs on a serial console.                | Select the `debug-uart` laze module (only for the `log` facade).                                                                                                 |
+| `esp-println`                     | Uses `esp-println` on ESP targets. This integrates well with `espflash monitor`; with `defmt`, it also supports `defmt-espflash`.                | Selected automatically for ESP targets.                                                                                                                          |
+| `custom-log-handler`              | Calls an application-provided function for every `println!()` call and every `log` record. Until a handler is installed, it is a no-op.          | Select the `custom-log-handler` laze module.                                                                                                                     |
+| `std`                             | Sends output to the host standard output stream using `std::println!()`. This is the backend used by native builds.                              | Selected automatically for native builds.                                                                                                                        |
+
+### Using `custom-log-handler`
+
+`custom-log-handler` is intended for `println!()` output and for the `log`
+facade.
+Because the handler receives `core::fmt::Arguments<'_>`, it should format or
+forward the arguments immediately rather than storing them for later.
+
+Select the `debug-console` and `custom-log-handler` laze modules, and
+optionally `log` if you want `log` records to use the same backend.
+Then install the handler early during startup.
+The handler can only be installed once and cannot be removed.
+
+```rust
+use ariel_os::debug::{self, log::info};
+use core::fmt::Arguments;
+use std::fs::OpenOptions;
+use std::io::Write;
+
+fn my_log_handler(args: Arguments<'_>) {
+    // Do whatever you want with the line, such as writing it to a file or sending it to your server
+    if let Ok(mut file) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("debug.log")
+    {
+        let _ = file.write_fmt(format_args!("{args}"));
+    }
+}
+
+#[ariel_os::task(autostart)]
+async fn main() {
+    let _ = debug::install_log_handler(my_log_handler);
+
+    debug::println!("Hello from println!");
+    info!("Hello from log!");
+}
+```
+
+Before `install_log_handler()` is called, this backend drops all output.
+
 ## Debug Logging
 
 Ariel OS supports debug logging on all platforms and it is enabled by default with the `debug-logging-facade` [laze module][laze-modules-book].

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -376,7 +376,7 @@ contexts:
     parent: ariel-os
     selects:
       - ?debug-console
-      - ?esp-println
+      - ?esp-debug-backend-default
     provides:
       - has_hwrng
     env:
@@ -1848,6 +1848,24 @@ modules:
         CARGO_RUNNER: '"espflash flash --monitor ${ESPFLASH_LOG_FORMAT}"'
         FEATURES:
           - ariel-os/esp-println
+
+  - name: esp-debug-backend-default
+    help: default debug backend selection for esp targets
+    context:
+      - esp
+    selects:
+      - esp-println
+
+  - name: custom-log-handler
+    help: use a custom log handler in ariel-os-debug
+    disables:
+      - esp-debug-backend-default
+    provides_unique:
+      - ariel-os-debug-backend
+    env:
+      global:
+        FEATURES:
+          - ariel-os/custom-log-handler
 
   - name: semihosting
     help: enable semihosting in ariel-os-debug

--- a/src/ariel-os-debug/Cargo.toml
+++ b/src/ariel-os-debug/Cargo.toml
@@ -21,7 +21,7 @@ rtt-target = { workspace = true, optional = true }
 semihosting = { workspace = true, optional = true }
 
 [package.metadata.feature-groups]
-debug-backend.xor = { features = ["esp-println", "rtt-target", "uart"] }
+debug-backend.xor = { features = ["custom-log-handler", "esp-println", "rtt-target", "uart"] }
 
 [package.metadata.features]
 debug-console = { groups = ["debug-backend"] }
@@ -71,6 +71,7 @@ esp-println = ["dep:esp-println"]
 rtt-target = ["dep:rtt-target"]
 std = []
 uart = []
+custom-log-handler = []
 
 [lints]
 workspace = true

--- a/src/ariel-os-debug/src/lib.rs
+++ b/src/ariel-os-debug/src/lib.rs
@@ -198,7 +198,45 @@ pub mod backend {
     }
 }
 
-#[cfg(all(feature = "debug-console", feature = "std"))]
+#[cfg(all(feature = "debug-console", feature = "custom-log-handler"))]
+#[doc(hidden)]
+pub mod backend {
+    use embassy_sync::once_lock::OnceLock;
+
+    /// A function pointer that receives debug output as formatting arguments.
+    pub type LogHandler = fn(core::fmt::Arguments<'_>);
+
+    static LOG_HANDLER: OnceLock<LogHandler> = OnceLock::new();
+
+    /// Installs the debug log handler.
+    ///
+    /// Returns `Err(handler)` if a handler has already been installed.
+    pub fn install_log_handler(handler: LogHandler) -> Result<(), LogHandler> {
+        LOG_HANDLER.init(handler)
+    }
+
+    pub fn init() {
+        #[cfg(feature = "log")]
+        crate::logger::init();
+    }
+
+    #[doc(hidden)]
+    pub fn _print(args: core::fmt::Arguments<'_>) {
+        if let Some(log_handler) = LOG_HANDLER.try_get() {
+            log_handler(args);
+        }
+    }
+
+    #[macro_export]
+    macro_rules! println {
+        ($($arg:tt)*) => {{
+            #[expect(clippy::used_underscore_items, reason = "consistency with std::println")]
+            $crate::backend::_print(format_args!("{}\n", format_args!($($arg)*)));
+        }};
+    }
+}
+
+#[cfg(all(feature = "debug-console", feature = "std", not(feature = "custom-log-handler")))]
 mod backend {
     pub use std::println;
 

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -222,6 +222,7 @@ rtt-target = ["ariel-os-debug/rtt-target"]
 defmt-rtt = ["ariel-os-debug/defmt-rtt"]
 esp-println = ["ariel-os-debug/esp-println"]
 semihosting = ["ariel-os-debug/semihosting"]
+custom-log-handler = ["ariel-os-debug/custom-log-handler"]
 
 net = ["ariel-os-embassy/net"]
 


### PR DESCRIPTION
# Description
Add a laze module that allows the user to provide their own backend for log output. 

## Testing
I created example applications for native and esp32 that simply output to std::print and esp_println::print. No actual unit or integration tests have been added. Guidance on a better way of testing this is appreciated.

## Issues/PRs References


## Open Questions
I weighed defining a trait and injecting a dyn reference instead of a function pointer but decided the function pointer would be better because it's less overhead and easy to implement. Feel free to challenge me on this.

The most difficult part of the implementation (taking up most of my time) was figuring out how to enable and disable the correct laze modules for the corresponding builds. I'm not actually sure I'm done here:
- For native builds the std output gets selected automatically, I've gated that in ariel-os-debug lib.rs. 
- For ESP32 builds esp-println got selected automatically for the target. I moved that to a separate module that gets selected by default and is disabled when custom-log-handler is selected
- For probe-rs builds I'm not actually sure what will happen. Guidance on how to test this is appreciated, big chance that breaks now when the custom-log-handler is selected. If I understand correctly you select either RTT or UART as a backend for that normally? This should be a third acceptable backend for such a build.

I've added documentation in the book about the different backends including an example for the custom-log-handler. Please check the documentation about the other backends as I'm not 100% sure about what I wrote there.


## Changelog Entry
<!-- changelog:begin -->
A custom log backend can now be selected
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventional-commits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
