### PR TITLE
fix(threading): Improve error messages in the thread proc-macro and feature gate `CoreAffinity`

### DIFF
--- a/book/src/multithreading.md
+++ b/book/src/multithreading.md
@@ -58,7 +58,7 @@ When an idle thread is scheduled, it prompts the current core to enter sleep mod
 ### Core Affinity
 
 Core affinity, also known as core pinning, is optionally configurable for each thread using the [`#[ariel_os:thread]` attribute macro][thread-attr-macro-rustdoc].
-It allows to restrict the execution of a thread to a specific core and prevent it from being scheduled on another one.
+It allows restricting the execution of a thread to a specific core and prevents it from being scheduled on another one. This is only enabled when the `core-affinity` [laze module][laze-modules-book] is selected. Otherwise, the `affinity` parameter of the [`#[ariel_os:thread]` attribute macro][thread-attr-macro-rustdoc] is ignored.
 See the [`threading-multicore` example][threading-multicore-example-repo] for a usage example.
 
 [Embassy]: https://embassy.dev/

--- a/book/src/multithreading.md
+++ b/book/src/multithreading.md
@@ -58,7 +58,8 @@ When an idle thread is scheduled, it prompts the current core to enter sleep mod
 ### Core Affinity
 
 Core affinity, also known as core pinning, is optionally configurable for each thread using the [`#[ariel_os:thread]` attribute macro][thread-attr-macro-rustdoc].
-It allows restricting the execution of a thread to a specific core and prevents it from being scheduled on another one. This is only enabled when the `core-affinity` [laze module][laze-modules-book] is selected. Otherwise, the `affinity` parameter of the [`#[ariel_os:thread]` attribute macro][thread-attr-macro-rustdoc] is ignored.
+It allows restricting the execution of a thread to a specific core and prevents it from being scheduled on another one. This is only enabled when the `core-affinity` [laze module][laze-modules-book] is selected.
+When disabled the `affinity` parameter of the [`#[ariel_os:thread]` attribute macro][thread-attr-macro-rustdoc] is ignored.
 See the [`threading-multicore` example][threading-multicore-example-repo] for a usage example.
 
 [Embassy]: https://embassy.dev/

--- a/book/src/multithreading.md
+++ b/book/src/multithreading.md
@@ -59,7 +59,7 @@ When an idle thread is scheduled, it prompts the current core to enter sleep mod
 
 Core affinity, also known as core pinning, is optionally configurable for each thread using the [`#[ariel_os:thread]` attribute macro][thread-attr-macro-rustdoc].
 It allows restricting the execution of a thread to a specific core and prevents it from being scheduled on another one. This is only enabled when the `core-affinity` [laze module][laze-modules-book] is selected.
-When disabled the `affinity` parameter of the [`#[ariel_os:thread]` attribute macro][thread-attr-macro-rustdoc] is ignored.
+When disabled, the `affinity` parameter of the [`#[ariel_os:thread]` attribute macro][thread-attr-macro-rustdoc] is ignored.
 See the [`threading-multicore` example][threading-multicore-example-repo] for a usage example.
 
 [Embassy]: https://embassy.dev/

--- a/book/src/multithreading.md
+++ b/book/src/multithreading.md
@@ -58,8 +58,8 @@ When an idle thread is scheduled, it prompts the current core to enter sleep mod
 ### Core Affinity
 
 Core affinity, also known as core pinning, is optionally configurable for each thread using the [`#[ariel_os:thread]` attribute macro][thread-attr-macro-rustdoc].
-It allows restricting the execution of a thread to a specific core and prevents it from being scheduled on another one. This is only enabled when the `core-affinity` [laze module][laze-modules-book] is selected.
-When disabled, the `affinity` parameter of the [`#[ariel_os:thread]` attribute macro][thread-attr-macro-rustdoc] is ignored.
+It allows restricting the execution of a thread to a specific core and prevents it from being scheduled on another one.
+This can be enabled using the `core-affinity` Cargo feature.
 See the [`threading-multicore` example][threading-multicore-example-repo] for a usage example.
 
 [Embassy]: https://embassy.dev/

--- a/src/ariel-os-macros/Cargo.toml
+++ b/src/ariel-os-macros/Cargo.toml
@@ -30,6 +30,7 @@ trybuild = "=1.0.116"
 
 [features]
 _test = []
+core-affinity = []
 
 [lints]
 workspace = true

--- a/src/ariel-os-macros/src/thread.rs
+++ b/src/ariel-os-macros/src/thread.rs
@@ -78,7 +78,10 @@ pub fn thread(args: TokenStream, item: TokenStream) -> TokenStream {
         stack_size,
         priority,
         affinity,
-    } = Parameters::from(attrs);
+    } = match Parameters::try_from(attrs) {
+        Ok(p) => p,
+        Err(e) => return e.into_compile_error().into(),
+    };
 
     let expanded = quote! {
         #[inline(always)]
@@ -114,22 +117,32 @@ mod thread {
         }
     }
 
-    impl From<Attributes> for Parameters {
-        fn from(attrs: Attributes) -> Self {
+    impl TryFrom<Attributes> for Parameters {
+        type Error = syn::Error;
+
+        fn try_from(attrs: Attributes) -> syn::Result<Self> {
             let default = Self::default();
 
             let stack_size = attrs.stack_size.unwrap_or(default.stack_size);
             let priority = attrs.priority.unwrap_or(default.priority);
-            let affinity = attrs
-                .affinity
-                .map(|expr| syn::parse_quote! { Some(#expr) })
-                .unwrap_or(default.affinity);
+            let affinity = match attrs.affinity {
+                #[cfg(not(feature = "core-affinity"))]
+                Some(affinity) => {
+                    use syn::spanned::Spanned as _;
+                    return Err(syn::Error::new(affinity.span(), "Providing a core affinity does nothing unless the 'core-affinity' feature is enabled."))
+                },
+                #[cfg(feature = "core-affinity")]
+                Some(affinity) => {
+                    syn::parse_quote! { Some(#affinity) }
+                },
+                None => default.affinity
+            };
 
-            Self {
+            Ok(Self {
                 stack_size,
                 priority,
                 affinity,
-            }
+            })
         }
     }
 

--- a/src/ariel-os-macros/src/thread.rs
+++ b/src/ariel-os-macros/src/thread.rs
@@ -48,12 +48,8 @@ pub fn thread(args: TokenStream, item: TokenStream) -> TokenStream {
 
     let mut attrs = Attributes::default();
     let thread_parser = syn::meta::parser(|meta| attrs.parse(&meta));
-    syn::parse_macro_input!(args with thread_parser);
-
-    assert!(
-        attrs.autostart,
-        "the `autostart` parameter must be provided",
-    );
+    let args2 = args.clone();
+    syn::parse_macro_input!(args2 with thread_parser);
 
     let thread_function = syn::parse_macro_input!(item as syn::ItemFn);
 
@@ -80,7 +76,8 @@ pub fn thread(args: TokenStream, item: TokenStream) -> TokenStream {
         affinity,
     } = match Parameters::try_from(attrs) {
         Ok(p) => p,
-        Err(e) => return e.into_compile_error().into(),
+        Err(ParametersError::CoreAffinityNotEnabled) => return syn::Error::new_spanned(<TokenStream as Into<proc_macro2::TokenStream>>::into(args.clone()), "Providing a core affinity does nothing unless the 'core-affinity' feature is enabled.").into_compile_error().into(),
+        Err(ParametersError::NoAutostart) => return syn::Error::new_spanned(<TokenStream as Into<proc_macro2::TokenStream>>::into(args.clone()), "the `autostart` parameter must be provided").into_compile_error().into(),
     };
 
     let expanded = quote! {
@@ -117,19 +114,28 @@ mod thread {
         }
     }
 
-    impl TryFrom<Attributes> for Parameters {
-        type Error = syn::Error;
+    pub enum ParametersError {
+        NoAutostart,
+        #[allow(unused, reason = "conditionnal compilation")]
+        CoreAffinityNotEnabled,
+    }
 
-        fn try_from(attrs: Attributes) -> syn::Result<Self> {
+    impl TryFrom<Attributes> for Parameters {
+        type Error = ParametersError;
+
+        fn try_from(attrs: Attributes) -> Result<Self, ParametersError> {
             let default = Self::default();
+
+            if !attrs.autostart {
+                return Err(ParametersError::NoAutostart)
+            }
 
             let stack_size = attrs.stack_size.unwrap_or(default.stack_size);
             let priority = attrs.priority.unwrap_or(default.priority);
             let affinity = match attrs.affinity {
                 #[cfg(not(feature = "core-affinity"))]
-                Some(affinity) => {
-                    use syn::spanned::Spanned as _;
-                    return Err(syn::Error::new(affinity.span(), "Providing a core affinity does nothing unless the 'core-affinity' feature is enabled."))
+                Some(_affinity) => {
+                    return Err(ParametersError::CoreAffinityNotEnabled)
                 },
                 #[cfg(feature = "core-affinity")]
                 Some(affinity) => {

--- a/src/ariel-os-macros/src/thread.rs
+++ b/src/ariel-os-macros/src/thread.rs
@@ -76,8 +76,14 @@ pub fn thread(args: TokenStream, item: TokenStream) -> TokenStream {
         affinity,
     } = match Parameters::try_from(attrs) {
         Ok(p) => p,
-        Err(ParametersError::CoreAffinityNotEnabled) => return syn::Error::new_spanned(<TokenStream as Into<proc_macro2::TokenStream>>::into(args.clone()), "Providing a core affinity does nothing unless the 'core-affinity' feature is enabled.").into_compile_error().into(),
-        Err(ParametersError::NoAutostart) => return syn::Error::new_spanned(<TokenStream as Into<proc_macro2::TokenStream>>::into(args.clone()), "the `autostart` parameter must be provided").into_compile_error().into(),
+        Err(ParametersError::CoreAffinityNotEnabled) => return syn::Error::new_spanned(
+            <TokenStream as Into<proc_macro2::TokenStream>>::into(args.clone()),
+            "providing a core affinity does nothing unless the `core-affinity` feature is enabled"
+            ).into_compile_error().into(),
+        Err(ParametersError::NoAutostart) => return syn::Error::new_spanned(
+                <TokenStream as Into<proc_macro2::TokenStream>>::into(args.clone()),
+                "the `autostart` parameter must be provided"
+                ).into_compile_error().into(),
     };
 
     let expanded = quote! {

--- a/src/ariel-os-macros/src/thread.rs
+++ b/src/ariel-os-macros/src/thread.rs
@@ -116,7 +116,7 @@ mod thread {
 
     pub enum ParametersError {
         NoAutostart,
-        #[allow(unused, reason = "conditionnal compilation")]
+        #[allow(unused, reason = "conditional compilation")]
         CoreAffinityNotEnabled,
     }
 

--- a/src/ariel-os-macros/tests/ui/thread/core-affinity-without-the-feature.rs
+++ b/src/ariel-os-macros/tests/ui/thread/core-affinity-without-the-feature.rs
@@ -1,0 +1,8 @@
+// #![no_std]
+#![no_main]
+
+use ariel_os::thread::{CoreAffinity, CoreId};
+
+// FAIL: the `autostart` parameter is mandatory
+#[ariel_os::thread(autostart, affinity = CoreAffinity::one(CoreId::new(1)))]
+fn main() {}

--- a/src/ariel-os-macros/tests/ui/thread/core-affinity-without-the-feature.rs
+++ b/src/ariel-os-macros/tests/ui/thread/core-affinity-without-the-feature.rs
@@ -3,6 +3,6 @@
 
 use ariel_os::thread::{CoreAffinity, CoreId};
 
-// FAIL: the `autostart` parameter is mandatory
+// FAIL: using the affinity argument requires enabling the `core-affinity` feature.
 #[ariel_os::thread(autostart, affinity = CoreAffinity::one(CoreId::new(1)))]
 fn main() {}

--- a/src/ariel-os-macros/tests/ui/thread/core-affinity-without-the-feature.stderr
+++ b/src/ariel-os-macros/tests/ui/thread/core-affinity-without-the-feature.stderr
@@ -1,0 +1,13 @@
+error: Providing a core affinity does nothing unless the 'core-affinity' feature is enabled.
+ --> tests/ui/thread/core-affinity-without-the-feature.rs:7:42
+  |
+7 | #[ariel_os::thread(autostart, affinity = CoreAffinity::one(CoreId::new(1)))]
+  |                                          ^^^^^^^^^^^^
+
+warning: unused imports: `CoreAffinity` and `CoreId`
+ --> tests/ui/thread/core-affinity-without-the-feature.rs:4:24
+  |
+4 | use ariel_os::thread::{CoreAffinity, CoreId};
+  |                        ^^^^^^^^^^^^  ^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/src/ariel-os-macros/tests/ui/thread/core-affinity-without-the-feature.stderr
+++ b/src/ariel-os-macros/tests/ui/thread/core-affinity-without-the-feature.stderr
@@ -1,4 +1,4 @@
-error: Providing a core affinity does nothing unless the 'core-affinity' feature is enabled.
+error: providing a core affinity does nothing unless the `core-affinity` feature is enabled
  --> tests/ui/thread/core-affinity-without-the-feature.rs:7:20
   |
 7 | #[ariel_os::thread(autostart, affinity = CoreAffinity::one(CoreId::new(1)))]

--- a/src/ariel-os-macros/tests/ui/thread/core-affinity-without-the-feature.stderr
+++ b/src/ariel-os-macros/tests/ui/thread/core-affinity-without-the-feature.stderr
@@ -1,8 +1,8 @@
 error: Providing a core affinity does nothing unless the 'core-affinity' feature is enabled.
- --> tests/ui/thread/core-affinity-without-the-feature.rs:7:42
+ --> tests/ui/thread/core-affinity-without-the-feature.rs:7:20
   |
 7 | #[ariel_os::thread(autostart, affinity = CoreAffinity::one(CoreId::new(1)))]
-  |                                          ^^^^^^^^^^^^
+  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused imports: `CoreAffinity` and `CoreId`
  --> tests/ui/thread/core-affinity-without-the-feature.rs:4:24

--- a/src/ariel-os-macros/tests/ui/thread/missing_autostart_param.stderr
+++ b/src/ariel-os-macros/tests/ui/thread/missing_autostart_param.stderr
@@ -1,7 +1,7 @@
-error: custom attribute panicked
+error: the `autostart` parameter must be provided
  --> tests/ui/thread/missing_autostart_param.rs:5:1
   |
 5 | #[ariel_os::thread]
   | ^^^^^^^^^^^^^^^^^^^
   |
-  = help: message: the `autostart` parameter must be provided
+  = note: this error originates in the attribute macro `ariel_os::thread` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -136,7 +136,11 @@ override-usb-config = ["ariel-os-embassy/override-usb-config"]
 
 #! ## Multicore functionality
 ## Enables support for core affinities (restricting threads to specific cores).
-core-affinity = ["ariel-os-macros/core-affinity", "ariel-os-threads?/core-affinity", "multi-core"]
+core-affinity = [
+  "ariel-os-macros/core-affinity",
+  "ariel-os-threads?/core-affinity",
+  "multi-core",
+]
 # Exactly one of the features below must be enabled at once.
 # Selection of these should be done through laze configuration.
 # Enables one single core, even if the hardware provides multiple cores.

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -136,7 +136,7 @@ override-usb-config = ["ariel-os-embassy/override-usb-config"]
 
 #! ## Multicore functionality
 ## Enables support for core affinities (restricting threads to specific cores).
-core-affinity = ["ariel-os-threads?/core-affinity", "multi-core"]
+core-affinity = ["ariel-os-macros/core-affinity", "ariel-os-threads?/core-affinity", "multi-core"]
 # Exactly one of the features below must be enabled at once.
 # Selection of these should be done through laze configuration.
 # Enables one single core, even if the hardware provides multiple cores.


### PR DESCRIPTION
# Description

This PR expands the `core-affinity` section of the book to clarify the situation raised in #2088. it also makes code like 
```rust
#[ariel_os::thread(autostart, affinity = CoreAffinity::one(CoreId::new(1)), priority = 2)]
fn main() { ... }
```
A compile time error when the `core-affinity` is not enabled.
<!-- A summary of your changes and why you made them. -->

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Removing the `core-affinity` feature from the `threading-multicore` examples results in a compile time error with the following error message
```sh
error: Providing a core affinity does nothing unless the 'core-affinity' feature is enabled.
 --> examples/threading-multicore/src/main.rs:9:42
  |
9 | #[ariel_os::thread(autostart, affinity = CoreAffinity::one(CoreId::new(1)), priority = 2)]
  |                                          ^^^^^^^^^^^^
```

## Issues/PRs References
Advances #2088 
<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The `#[ariel_os::thread]` attribute macro now makes sure that the `core-affinity` Cargo feature is enabled when attempting to pin a thread.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
