### PR TITLE
docs(boards): document ad hoc support for logging over UART

### DIFF
--- a/book/src/boards/nrf52-dk.md
+++ b/book/src/boards/nrf52-dk.md
@@ -38,6 +38,13 @@ laze build -b nrf52dk
 |Hardware Random Number Generator|<span title="supported">✅</span>|
 |Persistent Storage|<span title="supported">✅</span>|
 
+#### Additional Notes
+
+##### Logging over UART
+
+Using UART as the [logging transport](../logging.md#logging-transports) is supported on this board.
+Currently only the UART peripheral and the UART pins connected to the onboard, built-in debug probe can be used.
+
 <p>Legend:</p>
 
 <dl>

--- a/book/src/boards/nrf52840-dk.md
+++ b/book/src/boards/nrf52840-dk.md
@@ -38,6 +38,13 @@ laze build -b nrf52840dk
 |Hardware Random Number Generator|<span title="supported">✅</span>|
 |Persistent Storage|<span title="supported">✅</span>|
 
+#### Additional Notes
+
+##### Logging over UART
+
+Using UART as the [logging transport](../logging.md#logging-transports) is supported on this board.
+Currently only the UART peripheral and the UART pins connected to the onboard, built-in debug probe can be used.
+
 <p>Legend:</p>
 
 <dl>

--- a/book/src/boards/raspberry-pi-pico-w.md
+++ b/book/src/boards/raspberry-pi-pico-w.md
@@ -38,6 +38,13 @@ laze build -b rpi-pico-w
 |Hardware Random Number Generator|<span title="supported">✅</span>|
 |Persistent Storage|<span title="supported">✅</span>|
 
+#### Additional Notes
+
+##### Logging over UART
+
+Using UART as the [logging transport](../logging.md#logging-transports) is supported on this board.
+Currently the UART0 peripheral is used and the output is on the GP0 pin.
+
 <p>Legend:</p>
 
 <dl>

--- a/book/src/boards/raspberry-pi-pico.md
+++ b/book/src/boards/raspberry-pi-pico.md
@@ -38,6 +38,13 @@ laze build -b rpi-pico
 |Hardware Random Number Generator|<span title="supported">✅</span>|
 |Persistent Storage|<span title="supported">✅</span>|
 
+#### Additional Notes
+
+##### Logging over UART
+
+Using UART as the [logging transport](../logging.md#logging-transports) is supported on this board.
+Currently the UART0 peripheral is used and the output is on the GP0 pin.
+
 <p>Legend:</p>
 
 <dl>

--- a/book/src/boards/st-b-l475e-iot01a.md
+++ b/book/src/boards/st-b-l475e-iot01a.md
@@ -38,6 +38,13 @@ laze build -b st-b-l475e-iot01a
 |Hardware Random Number Generator|<span title="supported">✅</span>|
 |Persistent Storage|<span title="supported with some caveats">☑️</span>[^removing-items-not-supported]|
 
+#### Additional Notes
+
+##### Logging over UART
+
+Using UART as the [logging transport](../logging.md#logging-transports) is supported on this board.
+Currently only the UART peripheral and the UART pins connected to the onboard, built-in debug probe can be used.
+
 <p>Legend:</p>
 
 <dl>

--- a/book/src/boards/st-nucleo-wb55rg.md
+++ b/book/src/boards/st-nucleo-wb55rg.md
@@ -38,6 +38,13 @@ laze build -b st-nucleo-wb55
 |Hardware Random Number Generator|<span title="supported">✅</span>|
 |Persistent Storage|<span title="supported with some caveats">☑️</span>[^removing-items-not-supported]|
 
+#### Additional Notes
+
+##### Logging over UART
+
+Using UART as the [logging transport](../logging.md#logging-transports) is supported on this board.
+Currently only the UART peripheral and the UART pins connected to the onboard, built-in debug probe can be used.
+
 <p>Legend:</p>
 
 <dl>

--- a/book/src/boards/stm32u083c-dk.md
+++ b/book/src/boards/stm32u083c-dk.md
@@ -38,6 +38,13 @@ laze build -b stm32u083c-dk
 |Hardware Random Number Generator|<span title="supported">✅</span>|
 |Persistent Storage|<span title="supported with some caveats">☑️</span>[^removing-items-not-supported]|
 
+#### Additional Notes
+
+##### Logging over UART
+
+Using UART as the [logging transport](../logging.md#logging-transports) is supported on this board.
+Currently only the UART peripheral and the UART pins connected to the onboard, built-in debug probe can be used.
+
 <p>Legend:</p>
 
 <dl>

--- a/book/src/logging.md
+++ b/book/src/logging.md
@@ -78,11 +78,11 @@ Ariel OS's logger for `log` supports configuring the log level globally, but do
 Logging can use various transports, but currently only one can be used at a time.
 The table below presents those supported in Ariel OS and which hardware and host tool are required:
 
-| Logging transport                        | Supported               | laze module                  | Required hardware                                                                         | Required host tool              |
-| ---------------------------------------- | :---------------------: | ---------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------- |
-| Debug channel                            | Available on all chips  | `logging-over-debug-channel` | Debug probe attached to the debug interface                                               | Debug channel-enabled host tool |
-| [USB CDC-ACM][usb-cdc-acm-glossary-book] | On ESP32 MCUs only      | `logging-over-usb`           | USB cable attached to the user USB port                                                   | Serial monitor                  |
-| [UART][uart-glossary-book]               | On ESP32 MCUs only      | `logging-over-uart`          | USB ⟷ UART adapter attached to the supported UART pins (may already be part of the board) | Serial monitor                  |
+| Logging transport                        | Supported                         | laze module                  | Required hardware                                                                         | Required host tool              |
+| ---------------------------------------- | :-------------------------------: | ---------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------- |
+| Debug channel                            | Available on all chips            | `logging-over-debug-channel` | Debug probe attached to the debug interface                                               | Debug channel-enabled host tool |
+| [USB CDC-ACM][usb-cdc-acm-glossary-book] | On ESP32 MCUs only                | `logging-over-usb`           | USB cable attached to the user USB port                                                   | Serial monitor                  |
+| [UART][uart-glossary-book]               | On ESP32 MCUs and selected boards | `logging-over-uart`          | USB ⟷ UART adapter attached to the supported UART pins (may already be part of the board) | Serial monitor                  |
 
 On ESP32 devices, Ariel OS uses [`espflash`][espflah-cratesio] by default to obtain and print logs, whose usage is determined by the `espflash` [laze module][laze-modules-book].
 When `espflash` is selected at the time of compilation, `logging-over-debug-channel` is not enabled and one of the other available logging transports is used instead.

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -124,6 +124,18 @@ note_snippets:
       It can also be used to obtain logs when the [`logging-over-uart`](../logging.md#logging-transports) laze module is enabled.
 
       Note: On the ESP32-C3, enabling `logging-over-uart` will [not prevent the logs from also being printed using the USB CDC-ACM USB peripheral](https://github.com/esp-rs/esp-hal/issues/4510).
+  - name: logging-over-uart-board-debug-probe
+    content: |-
+      ##### Logging over UART
+
+      Using UART as the [logging transport](../logging.md#logging-transports) is supported on this board.
+      Currently only the UART peripheral and the UART pins connected to the onboard, built-in debug probe can be used.
+  - name: logging-over-uart-rpi-pico
+    content: |-
+      ##### Logging over UART
+
+      Using UART as the [logging transport](../logging.md#logging-transports) is supported on this board.
+      Currently the UART0 peripheral is used and the output is on the GP0 pin.
 
 # Encodes support status for each chip.
 chips:
@@ -1070,6 +1082,8 @@ builders:
     tier: "2"
     support:
       ble: supported
+    note_snippets:
+      - logging-over-uart-board-debug-probe
 
   nrf52840dk:
     chip: nrf52840
@@ -1077,6 +1091,8 @@ builders:
     support:
       user_usb: supported
       ethernet_over_usb: supported
+    note_snippets:
+      - logging-over-uart-board-debug-probe
 
   nrf5340dk-app:
     chip: nrf5340-app
@@ -1111,6 +1127,8 @@ builders:
     support:
       user_usb: supported
       ethernet_over_usb: supported
+    note_snippets:
+      - logging-over-uart-rpi-pico
 
   rpi-pico-w:
     chip: rp2040
@@ -1120,6 +1138,8 @@ builders:
       wifi: supported
       ble: supported
       ethernet_over_usb: supported
+    note_snippets:
+      - logging-over-uart-rpi-pico
 
   rpi-pico2:
     chip: rp235xa
@@ -1212,6 +1232,8 @@ builders:
         status: not_currently_supported
         comments:
           - "[USB does not enumerate](https://github.com/embassy-rs/embassy/issues/2376), [workaround](https://github.com/ariel-os/ariel-os/pull/1126)"
+    note_snippets:
+      - logging-over-uart-board-debug-probe
 
   st-nucleo-c031c6:
     chip: stm32c031c6
@@ -1278,6 +1300,8 @@ builders:
       user_usb: supported
       wifi: not_available
       ethernet_over_usb: supported
+    note_snippets:
+      - logging-over-uart-board-debug-probe
 
   st-nucleo-wba55:
     chip: stm32wba55cg
@@ -1321,6 +1345,8 @@ builders:
       user_usb: supported
       wifi: not_available
       ethernet_over_usb: supported
+    note_snippets:
+      - logging-over-uart-board-debug-probe
 
   ulanzi-tc001:
     chip: esp32-d0wd

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -124,6 +124,12 @@ note_snippets:
       It can also be used to obtain logs when the [`logging-over-uart`](../logging.md#logging-transports) laze module is enabled.
 
       Note: On the ESP32-C3, enabling `logging-over-uart` will [not prevent the logs from also being printed using the USB CDC-ACM USB peripheral](https://github.com/esp-rs/esp-hal/issues/4510).
+  - name: logging-over-uart-board-debug-probe
+    content: |-
+      ##### Logging over UART
+
+      Using UART as the [logging transport](../logging.md#logging-transports) is supported on this board.
+      Currently only the UART peripheral and the UART pins connected to the onboard, built-in debug probe can be used.
 
 # Encodes support status for each chip.
 chips:
@@ -1070,6 +1076,8 @@ builders:
     tier: "2"
     support:
       ble: supported
+    note_snippets:
+      - logging-over-uart-board-debug-probe
 
   nrf52840dk:
     chip: nrf52840
@@ -1077,6 +1085,8 @@ builders:
     support:
       user_usb: supported
       ethernet_over_usb: supported
+    note_snippets:
+      - logging-over-uart-board-debug-probe
 
   nrf5340dk-app:
     chip: nrf5340-app
@@ -1212,6 +1222,8 @@ builders:
         status: not_currently_supported
         comments:
           - "[USB does not enumerate](https://github.com/embassy-rs/embassy/issues/2376), [workaround](https://github.com/ariel-os/ariel-os/pull/1126)"
+    note_snippets:
+      - logging-over-uart-board-debug-probe
 
   st-nucleo-c031c6:
     chip: stm32c031c6
@@ -1278,6 +1290,8 @@ builders:
       user_usb: supported
       wifi: not_available
       ethernet_over_usb: supported
+    note_snippets:
+      - logging-over-uart-board-debug-probe
 
   st-nucleo-wba55:
     chip: stm32wba55cg
@@ -1321,6 +1335,8 @@ builders:
       user_usb: supported
       wifi: not_available
       ethernet_over_usb: supported
+    note_snippets:
+      - logging-over-uart-board-debug-probe
 
   ulanzi-tc001:
     chip: esp32-d0wd


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This documents the ad-hoc support for logging over UART that was added by #1029, now that the `logging-over-uart` laze module exists and that we have the infrastructure to document this functionality on the small set of boards supported. Even if the implementation *will* evolve later (by being generalized and by leveraging SBD files), I believe we can now document it because these future evolutions should result in few breaking changes (if any) and because this reduces the surface of undocumented features.

## TODO

- [ ] Consider documenting the UART settings, see https://github.com/ariel-os/ariel-os/pull/2097#discussion_r3258163846.
- [ ] Consider how this interacts with the `run` and `attach` laze tasks from #2091.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Successfully tested the `log` example on stm32u083c-dk and nrf52840dk.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Closes #1925
- Works towards #1008 (which aims to implement this in a more generic manner)

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
Logging over UART is now supported on a small set of boards (on top of the existing support for ESP32 MCUs).
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
