### PR TITLE
chore: update nrfxlib and its audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4589,9 +4589,9 @@ dependencies = [
 
 [[package]]
 name = "nrfxlib-sys"
-version = "3.0.3+3.0.2"
+version = "3.1.0+3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573d7e42c0dc325e4631bc22346d5c046ed68c4253c3da8fc990b3380fa8633d"
+checksum = "d024684e50e75bf8fb8d9e735b8cf5f213d615f1818825db79d6ffe6d3a12af3"
 dependencies = [
  "bindgen 0.70.1",
  "llvm-tools",

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -158,6 +158,12 @@ criteria = "safe-to-deploy"
 delta = "2.9.2 -> 3.0.3+3.0.2"
 notes = "Review extends to the source of nrfxlib-sys only. The library ships also proprietary C components, which were not (and, due to being closed source, can not) be reviewed."
 
+[[audits.nrfxlib-sys]]
+who = "chrysn <chrysn@fsfe.org>"
+criteria = "safe-to-deploy"
+delta = "3.0.3+3.0.2 -> 3.1.0+3.3.0"
+notes = "Review extends to the source of nrfxlib-sys only. The library ships also proprietary C components, which were not (and, due to being closed source, can not) be reviewed."
+
 [[audits.num-conv]]
 who = "Nils Ponsard <nils.ponsard@inria.fr>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -462,10 +462,6 @@ version = "1.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.defmt-macros]]
-version = "1.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.defmt-macros]]
 version = "1.1.0"
 criteria = "safe-to-deploy"
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2450,7 +2450,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-05-15"
-end = "2026-02-01"
+end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
@@ -2468,7 +2468,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-07-25"
-end = "2026-02-01"
+end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 


### PR DESCRIPTION
# Description

The updated nrfxlib-sys covers more use cases in hophop. No Cargo.toml changes here because the features are not needed here, but updating here makes sure tests see a consistent version.

The update also encodes my updated cargo vet check of the crate.

Note that this was done with cargo nightly; had I used stable Rust for cargo update, it'd have picked a different windows-target dependency of libloading -- but this way, nothing unrelated changes.

## Testing

I ran:

```console
$ laze -C examples/device-metadata build -b nrf9151-dk -s nrf-radiocore-firmware-dect run -- --probe 1366:1059:001051290288
[INFO ] Available information: (device_metadata device-metadata/src/main.rs:11)
[INFO ] Board type: nrf9151-dk (device_metadata device-metadata/src/main.rs:12)
[INFO ] Device ID: [c3, ca, c0, 54, 18, 6e, 83, 7e] (device_metadata device-metadata/src/main.rs:14)
[INFO ] Device's first EUI-48 address: 22:82:17:47:ef:cd (device_metadata device-metadata/src/main.rs:19)
[INFO ] We have an nRF modem: (device_metadata device-metadata/src/main.rs:30)
[INFO ] Model: ERROR (device_metadata device-metadata/src/main.rs:47)
[INFO ] Revision: mfw-nr+_nrf91x1_2.0.0 (device_metadata device-metadata/src/main.rs:51)
[INFO ] Serial: ERROR (device_metadata device-metadata/src/main.rs:55)
Firmware exited successfully
```

(The ERROR lines are expected, that radio just reports it that way literally).

## Change Checklist

- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
