### PR TITLE
refactor(hal): make `define_peripherals!()`  use `$crate::hal::peripherals` internally

### DIFF
--- a/examples/i2c-scanner/src/pins.rs
+++ b/examples/i2c-scanner/src/pins.rs
@@ -1,4 +1,4 @@
-use ariel_os::hal::{i2c, peripherals};
+use ariel_os::hal::i2c;
 
 #[cfg(any(context = "nrf52833", context = "nrf52840"))]
 pub type SensorI2c = i2c::controller::TWISPI0;

--- a/examples/sensors-debug/src/pins.rs
+++ b/examples/sensors-debug/src/pins.rs
@@ -1,4 +1,4 @@
-use ariel_os::hal::{i2c, peripherals};
+use ariel_os::hal::i2c;
 
 #[cfg(context = "heltec-wifi-lora-32-v3")]
 pub type SensorI2c = i2c::controller::I2C0;

--- a/examples/thermometer/src/pins.rs
+++ b/examples/thermometer/src/pins.rs
@@ -1,4 +1,4 @@
-use ariel_os::hal::{i2c, peripherals};
+use ariel_os::hal::i2c;
 
 ariel_os::hal::group_peripherals!(Peripherals {
     lcd: LcdPeripherals,

--- a/examples/usb-keyboard/src/pins.rs
+++ b/examples/usb-keyboard/src/pins.rs
@@ -1,5 +1,3 @@
-use ariel_os::hal::peripherals;
-
 #[cfg(context = "nrf52840dk")]
 ariel_os::hal::define_peripherals!(Buttons {
     btn1: P0_11,

--- a/src/ariel-os-hal/src/hal/define_peripherals.rs
+++ b/src/ariel-os-hal/src/hal/define_peripherals.rs
@@ -5,12 +5,6 @@
 /// the [`cfg`
 /// attribute](https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg-attribute)),
 /// to define different setups for different boards.
-///
-/// # Note
-///
-/// The [`define_peripherals!`](crate::define_peripherals!) macro expects the
-/// `ariel_os::hal::peripherals` module to be in scope.
-///
 // Inspired by https://github.com/adamgreig/assign-resources/tree/94ad10e2729afdf0fd5a77cd12e68409a982f58a
 // under MIT license
 #[macro_export]
@@ -65,7 +59,7 @@ macro_rules! define_peripherals {
 #[doc(hidden)]
 macro_rules! __peripheral_ty {
     ($field:ident) => {
-        $crate::hal::peripheral::Peri<'static, peripherals::$field>
+        $crate::hal::peripheral::Peri<'static, $crate::hal::peripherals::$field>
     };
 }
 
@@ -74,7 +68,7 @@ macro_rules! __peripheral_ty {
 #[doc(hidden)]
 macro_rules! __peripheral_ty {
     ($field:ident) => {
-        peripherals::$field<'static>
+        $crate::hal::peripherals::$field<'static>
     };
 }
 

--- a/tests/gpio-interrupt-nrf/src/main.rs
+++ b/tests/gpio-interrupt-nrf/src/main.rs
@@ -4,7 +4,6 @@
 use ariel_os::{
     debug::{ExitCode, exit},
     gpio::{self, Input, Pull},
-    hal::peripherals,
     log::info,
 };
 

--- a/tests/gpio-interrupt-stm32/src/main.rs
+++ b/tests/gpio-interrupt-stm32/src/main.rs
@@ -4,7 +4,6 @@
 use ariel_os::{
     debug::{ExitCode, exit},
     gpio::{self, Input, Pull},
-    hal::peripherals,
     log::info,
 };
 

--- a/tests/gpio/src/pins.rs
+++ b/tests/gpio/src/pins.rs
@@ -1,5 +1,3 @@
-use ariel_os::hal::peripherals;
-
 #[cfg(context = "nrf51")]
 ariel_os::hal::define_peripherals!(Peripherals {
     pin_0: P0_00,

--- a/tests/i2c-controller/src/pins.rs
+++ b/tests/i2c-controller/src/pins.rs
@@ -1,4 +1,4 @@
-use ariel_os::hal::{i2c, peripherals};
+use ariel_os::hal::i2c;
 
 #[cfg(context = "esp")]
 pub type SensorI2c = i2c::controller::I2C0;

--- a/tests/spi-loopback/src/pins.rs
+++ b/tests/spi-loopback/src/pins.rs
@@ -1,4 +1,4 @@
-use ariel_os::hal::{peripherals, spi};
+use ariel_os::hal::spi;
 
 #[cfg(context = "esp")]
 pub type SensorSpi = spi::main::SPI2;

--- a/tests/spi-main/src/pins.rs
+++ b/tests/spi-main/src/pins.rs
@@ -1,4 +1,4 @@
-use ariel_os::hal::{peripherals, spi};
+use ariel_os::hal::spi;
 
 #[cfg(context = "esp")]
 pub type SensorSpi = spi::main::SPI2;

--- a/tests/uart-loopback/src/pins.rs
+++ b/tests/uart-loopback/src/pins.rs
@@ -1,4 +1,4 @@
-use ariel_os::hal::{peripherals, uart};
+use ariel_os::hal::uart;
 
 #[cfg(context = "esp")]
 pub type TestUart<'a> = uart::UART0<'a>;


### PR DESCRIPTION
# Description

All users of `define_peripherals!()` had to include `ariel_os_hal::hal::peripherals`, as `define_peripherals!()` internally uses `peripherals::` as prefix for peripherals.

This changes the macro to just use `$crate::hal::peripherals` directly.

WIP, depends on ~~#2118~~.
https://github.com/ariel-os/sbd/pull/153 is needed to remove "unused imports" warning.

Change looks scary, but it is essential two lines here, one line in sbd-gen, and the rest is fall-out.

The two lines here are in [`9d550c7` (this PR)](https://github.com/ariel-os/ariel-os/pull/2120/changes/9d550c79f6230286b2a19a16c537099e5195650f#r3313783233)


## Testing

Compilation should actually suffice here to check if anything broke.
Also, leftover includes might now warn. I've done some grep/cleanup on `tests/` and `examples/` to remove now obsolete imports, but may have missed some.

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
When using `define_peripherals!()`, it is in most cases no longer necessary to import `ariel_os::hal::peripherals`.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash

Signed-off-by: Kaspar Schleiser <kaspar@schleiser.de>