### PR TITLE
feat(ble): obtain the current address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,7 @@ dependencies = [
  "embedded-hal-async",
  "embedded-io 0.6.1",
  "embedded-io-async 0.6.1",
+ "futures-util",
  "linkme",
  "portable-atomic",
  "rand_core 0.9.3",

--- a/book/src/bluetooth.md
+++ b/book/src/bluetooth.md
@@ -23,7 +23,9 @@ The ability to configure which Bluetooth address is used and other capacity para
 >
 > Current implementation: the address is a static device address and is not rotated during execution.
 > This allows to use the BLE feature of Ariel OS on multiple devices in the same location.
-> We later plan to switch to private device addresses by default, which *are* rotated during execution.
+> We later plan to switch to private device addresses by default, which _are_ rotated during execution.
+>
+> To obtain the address at runtime, use `ariel_os::ble::current_address()`.
 
 ## Using the BLE Stack
 

--- a/book/src/bluetooth.md
+++ b/book/src/bluetooth.md
@@ -53,6 +53,8 @@ embassy_futures::join::join(host.runner.run(), async {
 }).await;
 ```
 
+To obtain the address at runtime, use [`ariel_os::ble::current_address()`](https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/ble/fn.current_address.html).
+
 See [the Ariel OS examples](https://github.com/ariel-os/ariel-os/tree/main/examples) for more details.
 
 [laze-modules-book]: ./build-system.md#laze-modules

--- a/examples/ble-advertiser/src/main.rs
+++ b/examples/ble-advertiser/src/main.rs
@@ -16,6 +16,8 @@ async fn run_advertisement() {
     let stack = ariel_os::ble::ble_stack().await;
     let mut host = stack.build();
 
+    info!("Using address: {}", ariel_os::ble::current_address().await);
+
     let mut adv_data = [0; 31];
 
     let len = AdStructure::encode_slice(

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -43,6 +43,7 @@ ariel-os-threads = { path = "../ariel-os-threads", optional = true }
 ariel-os-utils = { workspace = true }
 
 const-str = { workspace = true, optional = true }
+futures-util = { workspace = true, optional = true }
 trouble-host = { workspace = true, optional = true }
 usbd-hid = { version = "0.10.0", optional = true }
 
@@ -145,6 +146,7 @@ ltem-nrf-modem = [
 ]
 
 ble = [
+  "dep:futures-util",
   "dep:trouble-host",
   "ariel-os-embassy-common/ble",
   "ariel-os-hal/ble",

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -47,6 +47,7 @@ ariel-os-threads = { path = "../ariel-os-threads", optional = true }
 ariel-os-utils = { workspace = true }
 
 const-str = { workspace = true, optional = true }
+futures-util = { workspace = true, optional = true }
 trouble-host = { workspace = true, optional = true }
 usbd-hid = { version = "0.10.0", optional = true }
 
@@ -149,6 +150,7 @@ ltem-nrf-modem = [
 ]
 
 ble = [
+  "dep:futures-util",
   "dep:trouble-host",
   "ariel-os-embassy-common/ble",
   "ariel-os-hal/ble",

--- a/src/ariel-os-embassy/src/ble.rs
+++ b/src/ariel-os-embassy/src/ble.rs
@@ -9,6 +9,8 @@
 //!
 //! The address is not currently rotated during execution; however this behavior may not be relied upon.
 
+use embassy_sync::once_lock::OnceLock;
+use futures_util::FutureExt;
 use trouble_host::{
     Address,
     prelude::{AddrKind, BdAddr},
@@ -19,6 +21,8 @@ use ariel_os_log::debug;
 
 // Must be async and return &trouble_host::Stack<'static, impl Controller>
 pub use crate::hal::ble::ble_stack;
+
+static CURRENT_ADDRESS: OnceLock<Address> = OnceLock::new();
 
 #[allow(dead_code, reason = "false positive during builds outside of laze")]
 pub(crate) fn config() -> Config {
@@ -33,9 +37,17 @@ pub(crate) fn config() -> Config {
         kind: AddrKind::RANDOM,
     };
 
+    let _ = CURRENT_ADDRESS.init(address);
+
     debug!("Setting random address: {:?}", address);
 
     Config { address }
+}
+
+/// Returns the BLE address of the BLE adapter.
+pub fn current_address() -> impl Future<Output = Address> {
+    // Using map() to avoid creating a new state machine.
+    CURRENT_ADDRESS.get().map(|addr| *addr)
 }
 
 /// Generates a random address.

--- a/src/ariel-os-embassy/src/ble.rs
+++ b/src/ariel-os-embassy/src/ble.rs
@@ -10,7 +10,7 @@
 //! The address is not currently rotated during execution; however this behavior may not be relied upon.
 
 use embassy_sync::once_lock::OnceLock;
-use futures_util::FutureExt;
+use futures_util::FutureExt as _;
 use trouble_host::{
     Address,
     prelude::{AddrKind, BdAddr},

--- a/src/ariel-os-embassy/src/ble.rs
+++ b/src/ariel-os-embassy/src/ble.rs
@@ -9,6 +9,8 @@
 //!
 //! The address is not currently rotated during execution; however this behavior may not be relied upon.
 
+use embassy_sync::once_lock::OnceLock;
+use futures_util::FutureExt as _;
 use trouble_host::{
     Address,
     prelude::{AddrKind, BdAddr},
@@ -19,6 +21,8 @@ use ariel_os_log::debug;
 
 // Must be async and return &trouble_host::Stack<'static, impl Controller>
 pub use crate::hal::ble::ble_stack;
+
+static CURRENT_ADDRESS: OnceLock<Address> = OnceLock::new();
 
 #[allow(dead_code, reason = "false positive during builds outside of laze")]
 pub(crate) fn config() -> Config {
@@ -33,9 +37,19 @@ pub(crate) fn config() -> Config {
         kind: AddrKind::RANDOM,
     };
 
+    let _ = CURRENT_ADDRESS.init(address);
+
     debug!("Setting random address: {:?}", address);
 
     Config { address }
+}
+
+/// Returns the BLE address currently in use.
+///
+/// Note that the BLE address may be rotated over time.
+pub fn current_address() -> impl Future<Output = Address> {
+    // Using map() to avoid creating a new state machine.
+    CURRENT_ADDRESS.get().map(|addr| *addr)
 }
 
 /// Generates a random address.


### PR DESCRIPTION
# Description

This adds a way to retrieve the currently configured BLE address.

## Testing

```
laze -C examples/ble-advertiser build -b nrf52840dk
``` 

Should print the current random address at the start.

## Issues/PRs References

- Fixes #1666

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The current BLE address can now be accessed using `ariel_os::ble::current_address()`.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
