### PR TITLE
fix: check if peripheral is already used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,7 @@ dependencies = [
  "embedded-hal-async",
  "embedded-io-async 0.6.1",
  "paste",
+ "portable-atomic",
  "static_cell",
  "trouble-host",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
  "esp-sync",
  "fugit",
  "paste",
+ "portable-atomic",
  "static_cell",
  "trouble-host",
 ]

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -31,6 +31,7 @@ esp-hal = { workspace = true, default-features = false, features = [
   "optfield",
   "rt",
 ] }
+portable-atomic = { workspace = true }
 
 esp-radio = { workspace = true, default-features = false, features = [
   "esp-alloc",

--- a/src/ariel-os-esp/src/i2c/controller/mod.rs
+++ b/src/ariel-os-esp/src/i2c/controller/mod.rs
@@ -2,6 +2,8 @@
 
 #![expect(unsafe_code)]
 
+use portable_atomic::{AtomicBool, Ordering};
+
 use ariel_os_embassy_common::impl_async_i2c_for_driver_enum;
 use esp_hal::{
     Async,
@@ -93,6 +95,11 @@ macro_rules! define_i2c_drivers {
                 twim: EspI2c<'static, Async>,
             }
 
+            // Ensure this peripheral has only one active Instance.
+            paste::paste! {
+                static [< ACTIVE_ $peripheral >]: AtomicBool = AtomicBool::new(false);
+            }
+
             impl $peripheral {
                 /// Returns a driver implementing [`embedded_hal_async::i2c::I2c`] for this
                 /// I2C peripheral.
@@ -121,9 +128,16 @@ macro_rules! define_i2c_drivers {
                             BusTimeout::Maximum
                             );
 
+                    // Check if we can initialize this peripheral (check if the value was previously false, set it to true).
+                    paste::paste! {
+                        if [< ACTIVE_ $peripheral >].swap(true, Ordering::AcqRel) {
+                            panic!("I2C peripheral already initialized")
+                        }
+                    }
+
                     // FIXME(safety): enforce that the init code indeed has run
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // peripheral multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let i2c_peripheral = unsafe { peripherals::$peripheral::steal() };
 
                     let twim = EspI2c::new(
@@ -136,6 +150,14 @@ macro_rules! define_i2c_drivers {
                         .with_scl(scl_pin.into_hal_peripheral());
 
                     I2c::$peripheral(Self { twim })
+                }
+            }
+
+            impl Drop for $peripheral {
+                fn drop(&mut self) {
+                    paste::paste! {
+                        [< ACTIVE_ $peripheral >].store(false, Ordering::Release);
+                    }
                 }
             }
         )*

--- a/src/ariel-os-esp/src/spi/main/mod.rs
+++ b/src/ariel-os-esp/src/spi/main/mod.rs
@@ -2,6 +2,8 @@
 
 #![expect(unsafe_code)]
 
+use portable_atomic::{AtomicBool, Ordering};
+
 use ariel_os_embassy_common::{
     impl_async_spibus_for_driver_enum,
     spi::{BitOrder, Mode, main::Kilohertz},
@@ -78,6 +80,11 @@ macro_rules! define_spi_drivers {
                 spim: YieldingAsync<BlockingAsync<InnerSpi<'static, esp_hal::Blocking>>>,
             }
 
+            // Ensure this peripheral has only one active Instance.
+            paste::paste! {
+                static [< ACTIVE_ $peripheral >]: AtomicBool = AtomicBool::new(false);
+            }
+
             impl $peripheral {
                 /// Returns a driver implementing [`embedded_hal_async::spi::SpiBus`] for this SPI
                 /// peripheral.
@@ -106,9 +113,16 @@ macro_rules! define_spi_drivers {
                         .with_read_bit_order(crate::spi::from_bit_order(config.bit_order))
                         .with_write_bit_order(crate::spi::from_bit_order(config.bit_order));
 
+                    // Check if we can initialize this peripheral (check if the value was previously false, set it to true).
+                    paste::paste! {
+                        if [< ACTIVE_ $peripheral >].swap(true, Ordering::AcqRel) {
+                            panic!("SPI peripheral already initialized")
+                        }
+                    }
+
                     // FIXME(safety): enforce that the init code indeed has run
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // peripheral multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let spi_peripheral = unsafe { peripherals::$peripheral::steal() };
 
                     let spi = esp_hal::spi::master::Spi::new(
@@ -122,6 +136,14 @@ macro_rules! define_spi_drivers {
                         .with_cs(gpio::NoPin); // The CS pin is managed separately
 
                     Spi::$peripheral(Self { spim: YieldingAsync::new(BlockingAsync::new(spi)) })
+                }
+            }
+
+            impl Drop for $peripheral {
+                fn drop(&mut self) {
+                    paste::paste! {
+                        [< ACTIVE_ $peripheral >].store(false, Ordering::Release);
+                    }
                 }
             }
         )*

--- a/src/ariel-os-esp/src/uart.rs
+++ b/src/ariel-os-esp/src/uart.rs
@@ -2,6 +2,8 @@
 
 #![expect(unsafe_code)]
 
+use portable_atomic::{AtomicBool, Ordering};
+
 use ariel_os_embassy_common::{impl_async_uart_for_driver_enum, uart::ConfigError};
 
 use esp_hal::{
@@ -182,6 +184,11 @@ macro_rules! define_uart_drivers {
                 static [<PREVENT_MULTIPLE_ $peripheral>]: () = ();
             }
 
+            // Ensure this peripheral has only one active Instance.
+            paste::paste! {
+                static [< ACTIVE_ $peripheral >]: AtomicBool = AtomicBool::new(false);
+            }
+
             impl<'d> $peripheral<'d> {
                 /// Returns a driver implementing embedded-io traits for this Uart
                 /// peripheral.
@@ -208,21 +215,42 @@ macro_rules! define_uart_drivers {
                         .with_stop_bits(from_stop_bits(config.stop_bits))
                         .with_parity(from_parity(config.parity));
 
+                    // Check if we can initialize this peripheral (check if the value was previously false, set it to true).
+                    paste::paste! {
+                        if [< ACTIVE_ $peripheral >].swap(true, Ordering::AcqRel) {
+                            panic!("UART peripheral already initialized")
+                        }
+                    }
+
                     // FIXME(safety): enforce that the init code indeed has run
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // peripheral multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let uart_peripheral = unsafe { peripherals::$peripheral::steal() };
 
                     let uart = EspUart::new(
                         uart_peripheral,
                         uart_config
                     )
-                        .map_err(convert_error)?
+                        .map_err(|e| {
+                            // Turns out we didn't initialize it.
+                            paste::paste! {
+                                [< ACTIVE_ $peripheral >].store(false, Ordering::Release);
+                            }
+                            convert_error(e)
+                        })?
                         .with_tx(tx_pin.into_hal_peripheral())
                         .with_rx(rx_pin.into_hal_peripheral())
                         .into_async();
 
                     Ok(Uart::$peripheral(Self { uart }))
+                }
+            }
+
+            impl<'d> Drop for $peripheral<'d> {
+                fn drop(&mut self) {
+                    paste::paste! {
+                        [< ACTIVE_ $peripheral >].store(false, Ordering::Release);
+                    }
                 }
             }
         )*

--- a/src/ariel-os-nrf/src/i2c/controller/mod.rs
+++ b/src/ariel-os-nrf/src/i2c/controller/mod.rs
@@ -2,6 +2,8 @@
 
 #![expect(unsafe_code)]
 
+use portable_atomic::{AtomicBool, Ordering};
+
 use ariel_os_embassy_common::impl_async_i2c_for_driver_enum;
 
 use embassy_nrf::{
@@ -137,6 +139,11 @@ macro_rules! define_i2c_drivers {
                 twim: Twim<'static>,
             }
 
+            // Ensure this peripheral has only one active Instance.
+            paste::paste! {
+                static [< ACTIVE_ $peripheral >]: AtomicBool = AtomicBool::new(false);
+            }
+
             impl $peripheral {
                 /// Returns a driver implementing [`embedded_hal_async::i2c::I2c`] for this
                 /// I2C peripheral.
@@ -167,9 +174,16 @@ macro_rules! define_i2c_drivers {
                         static [<PREVENT_MULTIPLE_ $peripheral>]: () = ();
                     }
 
+                    // Check if we can initialize this peripheral (check if the value was previously false, set it to true).
+                    paste::paste! {
+                        if [< ACTIVE_ $peripheral >].swap(true, Ordering::AcqRel) {
+                            panic!("I2C peripheral already initialized")
+                        }
+                    }
+
                     // FIXME(safety): enforce that the init code indeed has run
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // peripheral multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let twim_peripheral = unsafe { peripherals::$peripheral::steal() };
 
                     // NOTE(hal): the I2C implementation for nrf needs a buffer, define it here.
@@ -192,6 +206,14 @@ macro_rules! define_i2c_drivers {
                     }
 
                     I2c::$peripheral(Self { twim })
+                }
+            }
+
+            impl Drop for $peripheral {
+                fn drop(&mut self) {
+                    paste::paste! {
+                        [< ACTIVE_ $peripheral >].store(false, Ordering::Release);
+                    }
                 }
             }
         )*

--- a/src/ariel-os-nrf/src/spi/main/mod.rs
+++ b/src/ariel-os-nrf/src/spi/main/mod.rs
@@ -2,6 +2,8 @@
 
 #![expect(unsafe_code)]
 
+use portable_atomic::{AtomicBool, Ordering};
+
 use ariel_os_embassy_common::{
     impl_async_spibus_for_driver_enum,
     spi::{BitOrder, Mode},
@@ -152,6 +154,11 @@ macro_rules! define_spi_drivers {
                 spim: Spim<'static>,
             }
 
+            // Ensure this peripheral has only one active Instance.
+            paste::paste! {
+                static [< ACTIVE_ $peripheral >]: AtomicBool = AtomicBool::new(false);
+            }
+
             impl $peripheral {
                 /// Returns a driver implementing [`embedded_hal_async::spi::SpiBus`] for this SPI
                 /// peripheral.
@@ -181,9 +188,16 @@ macro_rules! define_spi_drivers {
                         static [<PREVENT_MULTIPLE_ $peripheral>]: () = ();
                     }
 
+                    // Check if we can initialize this peripheral (check if the value was previously false, set it to true).
+                    paste::paste! {
+                        if [< ACTIVE_ $peripheral >].swap(true, Ordering::AcqRel) {
+                            panic!("SPI peripheral already initialized")
+                        }
+                    }
+
                     // FIXME(safety): enforce that the init code indeed has run
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // peripheral multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let spim_peripheral = unsafe { peripherals::$peripheral::steal() };
 
                     let spim = Spim::new(
@@ -196,6 +210,14 @@ macro_rules! define_spi_drivers {
                     );
 
                     Spi::$peripheral(Self { spim })
+                }
+            }
+
+            impl Drop for $peripheral {
+                fn drop(&mut self) {
+                    paste::paste! {
+                        [< ACTIVE_ $peripheral >].store(false, Ordering::Release);
+                    }
                 }
             }
         )*

--- a/src/ariel-os-nrf/src/uart.rs
+++ b/src/ariel-os-nrf/src/uart.rs
@@ -2,6 +2,8 @@
 
 #![expect(unsafe_code)]
 
+use portable_atomic::{AtomicBool, Ordering};
+
 use ariel_os_embassy_common::{impl_async_uart_for_driver_enum, uart::ConfigError};
 use embassy_nrf::{
     bind_interrupts,
@@ -228,6 +230,11 @@ macro_rules! define_uart_drivers {
                 static [<PREVENT_MULTIPLE_ $ppi_group>]: () = ();
             }
 
+            // Ensure this peripheral has only one active Instance.
+            paste::paste! {
+                static [< ACTIVE_ $peripheral >]: AtomicBool = AtomicBool::new(false);
+            }
+
             impl<'d> $peripheral<'d> {
                 /// Returns a driver implementing [`embedded_io_async`] for this Uart
                 /// peripheral.
@@ -250,21 +257,28 @@ macro_rules! define_uart_drivers {
                         $interrupt => InterruptHandler<peripherals::$peripheral>;
                     });
 
+                    // Check if we can initialize this peripheral (check if the value was previously false, set it to true).
+                    paste::paste! {
+                        if [< ACTIVE_ $peripheral >].swap(true, Ordering::AcqRel) {
+                            panic!("UART peripheral already initialized")
+                        }
+                    }
+
                     // FIXME(safety): enforce that the init code indeed has run
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // peripheral multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let uart_peripheral = unsafe { peripherals::$peripheral::steal() };
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // required timer multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let timer_peripheral = unsafe { peripherals::$timer::steal() };
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // required ppi channel multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let ppi_ch1_peripheral = unsafe { peripherals::$ppi_ch1::steal() };
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // required ppi channel multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let ppi_ch2_peripheral = unsafe { peripherals::$ppi_ch2::steal() };
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // required ppi group multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let ppi_group_peripheral = unsafe { peripherals::$ppi_group::steal() };
 
                     let uart = BufferedUarte::new(
@@ -282,6 +296,14 @@ macro_rules! define_uart_drivers {
                     );
 
                     Ok(Uart::$peripheral(Self { uart }))
+                }
+            }
+
+            impl<'d> Drop for $peripheral<'d> {
+                fn drop(&mut self) {
+                    paste::paste! {
+                        [< ACTIVE_ $peripheral >].store(false, Ordering::Release);
+                    }
                 }
             }
         )*

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -23,6 +23,7 @@ embassy-rp = { workspace = true, default-features = false, features = [
 embedded-hal-async = { workspace = true }
 embedded-io-async = { workspace = true, optional = true }
 paste = { workspace = true }
+portable-atomic = { workspace = true }
 static_cell = { workspace = true, optional = true }
 
 # rpi-pico-w cyw43

--- a/src/ariel-os-rp/src/i2c/controller/mod.rs
+++ b/src/ariel-os-rp/src/i2c/controller/mod.rs
@@ -2,6 +2,8 @@
 
 #![expect(unsafe_code)]
 
+use portable_atomic::{AtomicBool, Ordering};
+
 use ariel_os_embassy_common::{i2c::controller::Kilohertz, impl_async_i2c_for_driver_enum};
 use embassy_rp::{
     bind_interrupts,
@@ -116,6 +118,11 @@ macro_rules! define_i2c_drivers {
                 twim: embassy_rp::i2c::I2c<'static, peripherals::$peripheral, embassy_rp::i2c::Async>,
             }
 
+            // Ensure this peripheral has only one active Instance.
+            paste::paste! {
+                static [< ACTIVE_ $peripheral >]: AtomicBool = AtomicBool::new(false);
+            }
+
             impl $peripheral {
                 /// Returns a driver implementing [`embedded_hal_async::i2c::I2c`] for this
                 /// I2C peripheral.
@@ -142,9 +149,16 @@ macro_rules! define_i2c_drivers {
                         }
                     );
 
+                    // Check if we can initialize this peripheral (check if the value was previously false, set it to true).
+                    paste::paste! {
+                        if [< ACTIVE_ $peripheral >].swap(true, Ordering::AcqRel) {
+                            panic!("I2C peripheral already initialized")
+                        }
+                    }
+
                     // FIXME(safety): enforce that the init code indeed has run
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // peripheral multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let i2c_peripheral = unsafe { peripherals::$peripheral::steal() };
 
                     // NOTE(hal): even though we handle bus timeout at a higher level as well, it
@@ -158,6 +172,14 @@ macro_rules! define_i2c_drivers {
                     );
 
                     I2c::$peripheral(Self { twim: i2c })
+                }
+            }
+
+            impl Drop for $peripheral {
+                fn drop(&mut self) {
+                    paste::paste! {
+                        [< ACTIVE_ $peripheral >].store(false, Ordering::Release);
+                    }
                 }
             }
         )*

--- a/src/ariel-os-rp/src/spi/main/mod.rs
+++ b/src/ariel-os-rp/src/spi/main/mod.rs
@@ -2,6 +2,8 @@
 
 #![expect(unsafe_code)]
 
+use portable_atomic::{AtomicBool, Ordering};
+
 use ariel_os_embassy_common::{
     impl_async_spibus_for_driver_enum,
     spi::{Mode, main::Kilohertz},
@@ -66,6 +68,11 @@ macro_rules! define_spi_drivers {
                 spim: YieldingAsync<BlockingAsync<InnerSpi<'static, peripherals::$peripheral, Blocking>>>,
             }
 
+            // Ensure this peripheral has only one active Instance.
+            paste::paste! {
+                static [< ACTIVE_ $peripheral >]: AtomicBool = AtomicBool::new(false);
+            }
+
             impl $peripheral {
                 /// Returns a driver implementing [`embedded_hal_async::spi::SpiBus`] for this SPI
                 /// peripheral.
@@ -95,9 +102,16 @@ macro_rules! define_spi_drivers {
                     spi_config.polarity = pol;
                     spi_config.phase = phase;
 
+                    // Check if we can initialize this peripheral (check if the value was previously false, set it to true).
+                    paste::paste! {
+                        if [< ACTIVE_ $peripheral >].swap(true, Ordering::AcqRel) {
+                            panic!("SPI peripheral already initialized")
+                        }
+                    }
+
                     // FIXME(safety): enforce that the init code indeed has run
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // peripheral multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let spi_peripheral = unsafe { peripherals::$peripheral::steal() };
 
                     // The order of MOSI/MISO pins is inverted.
@@ -110,6 +124,14 @@ macro_rules! define_spi_drivers {
                     );
 
                     Spi::$peripheral(Self { spim: YieldingAsync::new(BlockingAsync::new(spi)) })
+                }
+            }
+
+            impl Drop for $peripheral {
+                fn drop(&mut self) {
+                    paste::paste! {
+                        [< ACTIVE_ $peripheral >].store(false, Ordering::Release);
+                    }
                 }
             }
         )*

--- a/src/ariel-os-rp/src/uart.rs
+++ b/src/ariel-os-rp/src/uart.rs
@@ -2,6 +2,8 @@
 
 #![expect(unsafe_code)]
 
+use portable_atomic::{AtomicBool, Ordering};
+
 use ariel_os_embassy_common::{impl_async_uart_for_driver_enum, uart::ConfigError};
 
 use embassy_rp::{
@@ -177,6 +179,11 @@ macro_rules! define_uart_drivers {
                 static [<PREVENT_MULTIPLE_ $peripheral>]: () = ();
             }
 
+            // Ensure this peripheral has only one active Instance.
+            paste::paste! {
+                static [< ACTIVE_ $peripheral >]: AtomicBool = AtomicBool::new(false);
+            }
+
             impl<'d> $peripheral<'d> {
                 /// Returns a driver implementing embedded-io traits for this Uart
                 /// peripheral.
@@ -201,9 +208,16 @@ macro_rules! define_uart_drivers {
                         $interrupt => BufferedInterruptHandler<peripherals::$peripheral>;
                     });
 
+                    // Check if we can initialize this peripheral (check if the value was previously false, set it to true).
+                    paste::paste! {
+                        if [< ACTIVE_ $peripheral >].swap(true, Ordering::AcqRel) {
+                            panic!("UART peripheral already initialized")
+                        }
+                    }
+
                     // FIXME(safety): enforce that the init code indeed has run
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // peripheral multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let uart_peripheral = unsafe { peripherals::$peripheral::steal() };
 
                     let uart = BufferedUart::new(
@@ -218,6 +232,14 @@ macro_rules! define_uart_drivers {
                     );
 
                     Ok(Uart::$peripheral(Self { uart, _phantom: core::marker::PhantomData }))
+                }
+            }
+
+            impl<'d> Drop for $peripheral<'d> {
+                fn drop(&mut self) {
+                    paste::paste! {
+                        [< ACTIVE_ $peripheral >].store(false, Ordering::Release);
+                    }
                 }
             }
         )*

--- a/src/ariel-os-stm32/src/i2c/controller/mod.rs
+++ b/src/ariel-os-stm32/src/i2c/controller/mod.rs
@@ -2,6 +2,8 @@
 
 #![expect(unsafe_code)]
 
+use portable_atomic::{AtomicBool, Ordering};
+
 use ariel_os_embassy_common::{i2c::controller::Kilohertz, impl_async_i2c_for_driver_enum};
 use embassy_embedded_hal::adapter::{BlockingAsync, YieldingAsync};
 use embassy_stm32::{
@@ -132,6 +134,11 @@ macro_rules! define_i2c_drivers {
                 twim: YieldingAsync<BlockingAsync<InnerI2c<'static, Blocking, Master>>>,
             }
 
+            // Ensure this peripheral has only one active Instance.
+            paste::paste! {
+                static [< ACTIVE_ $peripheral >]: AtomicBool = AtomicBool::new(false);
+            }
+
             impl $peripheral {
                 /// Returns a driver implementing [`embedded_hal_async::i2c::I2c`] for this
                 /// I2C peripheral.
@@ -162,9 +169,16 @@ macro_rules! define_i2c_drivers {
                         static [<PREVENT_MULTIPLE_ $peripheral>]: () = ();
                     }
 
+                    // Check if we can initialize this peripheral (check if the value was previously false, set it to true).
+                    paste::paste! {
+                        if [< ACTIVE_ $peripheral >].swap(true, Ordering::AcqRel) {
+                            panic!("I2C peripheral already initialized")
+                        }
+                    }
+
                     // FIXME(safety): enforce that the init code indeed has run
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // peripheral multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let twim_peripheral = unsafe { peripherals::$peripheral::steal() };
 
                     let i2c = InnerI2c::new_blocking(
@@ -175,6 +189,14 @@ macro_rules! define_i2c_drivers {
                     );
 
                     I2c::$peripheral(Self { twim: YieldingAsync::new(BlockingAsync::new(i2c)) })
+                }
+            }
+
+            impl Drop for $peripheral {
+                fn drop(&mut self) {
+                    paste::paste! {
+                        [< ACTIVE_ $peripheral >].store(false, Ordering::Release);
+                    }
                 }
             }
         )*

--- a/src/ariel-os-stm32/src/spi/main/mod.rs
+++ b/src/ariel-os-stm32/src/spi/main/mod.rs
@@ -2,6 +2,8 @@
 
 #![expect(unsafe_code)]
 
+use portable_atomic::{AtomicBool, Ordering};
+
 use ariel_os_embassy_common::{
     impl_async_spibus_for_driver_enum,
     spi::{BitOrder, Mode, main::Kilohertz},
@@ -89,6 +91,11 @@ macro_rules! define_spi_drivers {
                 spim: YieldingAsync<BlockingAsync<InnerSpi<'static, Blocking>>>,
             }
 
+            // Ensure this peripheral has only one active Instance.
+            paste::paste! {
+                static [< ACTIVE_ $peripheral >]: AtomicBool = AtomicBool::new(false);
+            }
+
             impl $peripheral {
                 /// Returns a driver implementing [`embedded_hal_async::spi::SpiBus`] for this SPI
                 /// peripheral.
@@ -117,9 +124,16 @@ macro_rules! define_spi_drivers {
                     spi_config.bit_order = crate::spi::from_bit_order(config.bit_order);
                     spi_config.miso_pull = gpio::Pull::None;
 
+                    // Check if we can initialize this peripheral (check if the value was previously false, set it to true).
+                    paste::paste! {
+                        if [< ACTIVE_ $peripheral >].swap(true, Ordering::AcqRel) {
+                            panic!("SPI peripheral already initialized")
+                        }
+                    }
+
                     // FIXME(safety): enforce that the init code indeed has run
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // peripheral multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let spim_peripheral = unsafe { peripherals::$peripheral::steal() };
 
                     // The order of MOSI/MISO pins is inverted.
@@ -132,6 +146,14 @@ macro_rules! define_spi_drivers {
                     );
 
                     Spi::$peripheral(Self { spim: YieldingAsync::new(BlockingAsync::new(spim)) })
+                }
+            }
+
+            impl Drop for $peripheral {
+                fn drop(&mut self) {
+                    paste::paste! {
+                        [< ACTIVE_ $peripheral >].store(false, Ordering::Release);
+                    }
                 }
             }
         )*

--- a/src/ariel-os-stm32/src/uart.rs
+++ b/src/ariel-os-stm32/src/uart.rs
@@ -2,6 +2,8 @@
 
 #![expect(unsafe_code)]
 
+use portable_atomic::{AtomicBool, Ordering};
+
 use ariel_os_embassy_common::{impl_async_uart_for_driver_enum, uart::ConfigError};
 use embassy_stm32::{
     bind_interrupts, peripherals,
@@ -186,6 +188,11 @@ macro_rules! define_uart_drivers {
                 static [<PREVENT_MULTIPLE_ $peripheral>]: () = ();
             }
 
+            // Ensure this peripheral has only one active Instance.
+            paste::paste! {
+                static [< ACTIVE_ $peripheral >]: AtomicBool = AtomicBool::new(false);
+            }
+
             impl<'d> $peripheral<'d> {
                 /// Returns a driver implementing embedded-io traits for this Uart
                 /// peripheral.
@@ -217,9 +224,16 @@ macro_rules! define_uart_drivers {
                     });
 
                     // FIXME(safety): enforce that the init code indeed has run
-                    // SAFETY: this struct being a singleton prevents us from stealing the
-                    // peripheral multiple times.
+                    // SAFETY: We check with an AtomicBool that only one instance of this peripheral
+                    // is active at once.
                     let uart_peripheral = unsafe { peripherals::$peripheral::steal() };
+
+                    // Check if we can initialize this peripheral (check if the value was previously false, set it to true).
+                    paste::paste! {
+                        if [< ACTIVE_ $peripheral >].swap(true, Ordering::AcqRel) {
+                            panic!("UART peripheral already initialized")
+                        }
+                    }
 
                     let uart = BufferedUart::new(
                         uart_peripheral,
@@ -229,9 +243,23 @@ macro_rules! define_uart_drivers {
                         rx_buf,
                         Irqs,
                         uart_config,
-                    ).map_err(convert_error)?;
+                    ).map_err(|e| {
+                        // Turns out we didn't initialize it.
+                        paste::paste! {
+                            [< ACTIVE_ $peripheral >].store(false, Ordering::Release);
+                        }
+                        convert_error(e)
+                    })?;
 
                     Ok(Uart::$peripheral(Self { uart }))
+                }
+            }
+
+            impl<'d> Drop for $peripheral<'d> {
+                fn drop(&mut self) {
+                    paste::paste! {
+                        [< ACTIVE_ $peripheral >].store(false, Ordering::Release);
+                    }
                 }
             }
         )*


### PR DESCRIPTION
# Description

Currently an application can create multiple instances of the same UART/I2C/SPI peripheral. This is because internally `::steal()` is used on the underlying HAL peripheral.

There is a safety comment claiming that the Ariel OS struct representing an UART/I2C/SPI peripheral works as a singleton, but this isn't actually enforced. This PR fixes that by panicking if another instance of the peripheral is already active.  

## Testing

[I created a branch](https://github.com/nponsard/ariel-os/tree/test/uart-reproducer) with reproducers for UART/SPI/I2C.

- `tests/uart-loopback`: panics in the assert because it didn't receive the correct message. Should now panic at initialization. 
- `tests/spi-loopback`:  panics in the assert because it didn't receive the correct message. Should now panic at initialization.
- `tests/i2c-controller`: (stm32u083c) manages to read the same WHOAMI from different pins (does it use both pairs of pins at once ?). Should now panic at initialization. 

Tested spi on `nrf52840dk`, `stm32u083c-dk`, `rpi-pico-w`, `seeedstudio-xiao-esp32c6`.
UART on `nrf52840dk`, `stm32u083c-dk`, `rpi-pico-w`, `seeedstudio-xiao-esp32c6`.
I2C on `stm32u083c-dk`.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

- Fixes #2145 

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
It is no longer possible to mistakenly create multiple driver instances for the same I2C/SPI/UART peripheral by providing different pins to them.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
