### PR TITLE
fix(native): simulate scheduler run by acquire/release cs

### DIFF
--- a/src/ariel-os-threads/src/arch/native/critical_section.rs
+++ b/src/ariel-os-threads/src/arch/native/critical_section.rs
@@ -59,6 +59,25 @@ unsafe impl critical_section::Impl for ArielCriticalSection {
             // indicated by the threads entry in `THREAD_RUNNABLE`.
             if let Some(thread_id) = thread_id {
                 atomic_wait::wait(&super::THREAD_RUNNABLE[usize::from(thread_id)], 0);
+
+                // For regular multicore, setting a thread to `Runnable` (e.g., by doing a
+                // `threadlist::pop()`) triggers a scheduler run by pending an ISR that implicitly
+                // re-acquires a critical section in `sched()`. This is guaranteed to happen only
+                // after the critical section calling `pop()` has finished.
+                //
+                // As infinicore doesn't have a scheduler, that `pop()` immediately lets the popped
+                // thread continue (by releasing the `THREAD_RUNNABLE` atomic that is being waited
+                // for here), breaking a lot of assumptions in this crate's IPC code.
+                // E.g., see https://github.com/ariel-os/ariel-os/issues/2139 for how that
+                // manifests.
+                // To work around this, we explicitly get/release the (global) critical section
+                // here again, making sure the thread that woke this thread up finishes it's
+                // critical section first.
+                //
+                // SAFETY: delegating safety to upstream implementation
+                unsafe { StdCriticalSection::acquire() };
+                // SAFETY: delegating safety to upstream implementation
+                unsafe { StdCriticalSection::release(false) };
             }
         }
     }


### PR DESCRIPTION
# Description

@zhaolanhuang found an issue where `Channel` would receive wrong values. I traced this to infincore (native) not using a scheduler.

For regular multicore, setting a thread to `Runnable` (e.g., by doing a
`threadlist::pop()`) triggers a scheduler run that implicitly re-acquires a
critical section in `sched()`.

As infinicore doesn't have a scheduler, that `pop()` immediately let's the
thread continue, breaking a lot of assumptions in this crate's IPC code (which assumes the thread won't actually continue until the critical section ends).

#2139 is how this manifests in practice.

To mitigate, the critical section based infinicore thread parking mechanism now does a critical section `acquire()`/`release()` before letting the thread continue, ensuring that a currently active critical section ends first.

## Testing

I used the #2139 reproducer for confirming the bug, and for testing that this PR fixes it.
I then ran all `example/thread*` (that compile for native), seems like there are no regressions.

Maybe read the comment and check whether it provides enough explanation?

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

Fixes #2139.
<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(native) A scheduling bug that could lead to IPC errors on native has been fixed.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
