### PR TITLE
feat(logging-over-uart): add ad-hoc support for RPi Pico (W)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "embassy-hal-internal",
  "embassy-net",
  "embassy-nrf",
+ "embassy-rp",
  "embassy-stm32",
  "embassy-sync 0.7.2",
  "embassy-time",

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1946,6 +1946,7 @@ modules:
       - esp
       - nrf52840dk
       - nrf52dk
+      - rp2040
       - stm32u083c-dk
     selects:
       - context::esp:
@@ -1964,6 +1965,7 @@ modules:
     context:
       - nrf52840dk
       - nrf52dk
+      - rp2040
       - stm32u083c-dk
     selects:
       - log # We could later support defmt as well

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -63,6 +63,11 @@ embassy-nrf = { workspace = true }
 embedded-io-async = { workspace = true }
 
 # Required for debug-over-uart.
+[target.'cfg(context = "rp")'.dependencies]
+embassy-rp = { workspace = true }
+embedded-io = { workspace = true }
+
+# Required for debug-over-uart.
 [target.'cfg(context = "stm32")'.dependencies]
 embassy-stm32 = { workspace = true }
 embedded-io = { workspace = true }
@@ -126,7 +131,8 @@ multicast = ["embassy-net?/multicast"]
 ## Enable storage support [`ariel-os::storage`].
 storage = ["dep:ariel-os-storage", "ariel-os-hal/storage", "time"]
 
-debug-uart = []
+# NOTE: `time` is only needed on RP.
+debug-uart = ["time"]
 
 # Enables cellular networking configuration.
 cellular-networking = [

--- a/src/ariel-os-embassy/src/debug_uart.rs
+++ b/src/ariel-os-embassy/src/debug_uart.rs
@@ -2,6 +2,8 @@
 
 #[cfg(context = "nrf")]
 type UartDriver = embassy_nrf::uarte::Uarte<'static>;
+#[cfg(context = "rp2040")]
+type UartDriver = embassy_rp::uart::Uart<'static, embassy_rp::uart::Blocking>;
 #[cfg(context = "stm32")]
 type UartDriver = embassy_stm32::usart::Uart<'static, embassy_stm32::mode::Blocking>;
 
@@ -25,7 +27,7 @@ pub fn init(peripherals: &mut crate::hal::OptionalPeripherals) {
 fn write_debug_uart(buffer: &[u8]) -> Result<(), ariel_os_log::backend::Error> {
     use ariel_os_log::backend::Error;
 
-    #[cfg(context = "stm32")]
+    #[cfg(any(context = "rp", context = "stm32"))]
     use embedded_io::Write as _;
     #[cfg(context = "nrf")]
     use embedded_io_async::Write as _;
@@ -42,6 +44,13 @@ fn write_debug_uart(buffer: &[u8]) -> Result<(), ariel_os_log::backend::Error> {
                 uart.write(buffer).await.map_err(|_| Error::Writing)?;
                 // TODO: is flushing needed here?
                 uart.flush().await.map_err(|_| Error::Writing)?;
+            }
+
+            #[cfg(context = "rp")]
+            {
+                uart.write_all(buffer).map_err(|_| Error::Writing)?;
+                // TODO: is flushing needed here?
+                uart.flush().map_err(|_| Error::Writing)?;
             }
 
             #[cfg(context = "stm32")]
@@ -79,6 +88,23 @@ mod iot_lab {
         };
 
         embassy_nrf::uarte::Uarte::new(p, uart_rx, uart_tx, Irqs, config)
+    }
+
+    #[cfg(context = "rp2040")]
+    pub fn get_uart_driver(peripherals: &mut crate::hal::OptionalPeripherals) -> super::UartDriver {
+        let mut config = embassy_rp::uart::Config::default();
+
+        #[cfg(any(context = "rpi-pico", context = "rpi-pico-w"))]
+        let (p, uart_rx, uart_tx) = {
+            config.baudrate = 115_200;
+            (
+                peripherals.UART0.take().unwrap(),
+                peripherals.PIN_1.take().unwrap(),
+                peripherals.PIN_0.take().unwrap(),
+            )
+        };
+
+        embassy_rp::uart::Uart::new_blocking(p, uart_tx, uart_rx, config)
     }
 
     #[cfg(context = "stm32")]


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Similarly to #1029, this adds ad-hoc support for logging-over-UART for the RPi Pico and RPi Pico W. The peripheral and pins used are currently hard-coded as done for the other boards. This is required for the integration of these boards in IoT-LAB/SLICES-FR, and the way we add support for this will be revisited later.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Successfully tested using the following:

```sh
laze -C examples/log build -s logging-over-uart -b rpi-pico-w run
```

The RPi Debug Probe is connected to act as a USB ⟷ UART adapter using the "U" connector (as well as a debug probe as usual). Using the stock cable, the yellow wire is connected to GP0 (UART0 TX), along with ground. The orange wire doesn't need to be connected as UART is only used as an output.

The following can then be used to obtain the logging output on the host (the serial port may need to be adapted):

```sh
picocom --imap lfcrlf /dev/ttyACM0 --baud 115200
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->
This functionality is not added to the changelog yet (nor is it documented). Documenting this ad-hoc support for logging-over-UART on a limited set of baords will be part of a later PR.

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
