### PR TITLE
feat(ble): configure static address from env

### DIFF
--- a/book/src/bluetooth.md
+++ b/book/src/bluetooth.md
@@ -14,16 +14,28 @@ If you want to learn more about BLE concepts, you can read the [TrouBLE document
 
 ## Configuring the BLE Stack
 
-The ability to configure which Bluetooth address is used and other capacity parameters like the MTU is planned in future updates.
+The ability to use a private address and other capacity parameters like the MTU is planned in future updates.
 
 > [!IMPORTANT]
 > For compatibility reasons the MTU is fixed at 27 bytes.
 >
-> The device address is randomly generated at boot and may be periodically rotated.
+> By default the device address is randomly generated at boot and may be periodically rotated.
 >
 > Current implementation: the address is a static device address and is not rotated during execution.
 > This allows to use the BLE feature of Ariel OS on multiple devices in the same location.
 > We later plan to switch to private device addresses by default, which *are* rotated during execution.
+
+### Using a Static Address
+
+> [!IMPORTANT]
+> It is not recommended to have personal devices advertise a static (and constant) address as this can easily be tracked and compromise the privacy of the user.
+>
+> The use case of advertising a static address is for static devices like BLE beacons.
+
+To set an address that will persist across reboots, use the `ble-config-static-address` [laze module][laze-modules-book] and set the address using the `CONFIG_BLE_STATIC_ADDRESS` environment variable, the expected format is `XX:XX:XX:XX:XX:XX` where X is a hex digit.
+
+> [!NOTE]
+> The address will be advertised as a [random static address](https://www.bluetooth.com/wp-content/uploads/Files/Specification/HTML/Core-54/out/en/low-energy-controller/link-layer-specification.html#UUID-7edea27a-a47f-8436-4bd7-aedc1945c366_figure-idm4497995733171233616486354268) and the two most significant bits of the address will therefore be set to 1.
 
 ## Using the BLE Stack
 

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1456,6 +1456,15 @@ modules:
     selects:
       - doc-only
 
+  - name: ble-config-static-address
+    help: Use a static address for BLE, the two most significant bits will be set to 1 to indicate a static random address.
+    selects:
+      - ble
+    env:
+      global:
+        FEATURES:
+          - ariel-os/ble-config-static-address
+
   - name: has_nrf91_modem
     selects:
       - doc-only

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -169,6 +169,7 @@ ble-cyw43 = ["ariel-os-hal/ble-cyw43", "ble"]
 ble-esp = ["ariel-os-hal/ble-esp", "ble"]
 ble-central = ["ariel-os-hal/ble-central", "ble"]
 ble-peripheral = ["ariel-os-hal/ble-peripheral", "ble"]
+ble-config-static-address = []
 
 nrf91-modem = ["ariel-os-hal/nrf91-modem"]
 

--- a/src/ariel-os-embassy/src/ble.rs
+++ b/src/ariel-os-embassy/src/ble.rs
@@ -53,8 +53,19 @@ pub fn current_address() -> impl Future<Output = Address> {
 }
 
 /// Generates a random address.
+#[cfg(not(feature = "ble-config-static-address"))]
 fn get_random_addr() -> [u8; 6] {
     let mut addr = [0u8; 6];
     rand_core::RngCore::fill_bytes(&mut ariel_os_random::crypto_rng(), &mut addr);
     addr
+}
+
+/// Get random address from env.
+#[cfg(feature = "ble-config-static-address")]
+fn get_random_addr() -> [u8; 6] {
+    use ariel_os_utils::eui48_from_env;
+    eui48_from_env!(
+        "CONFIG_BLE_STATIC_ADDRESS",
+        "static address for BLE in format XX:XX:XX:XX:XX:XX",
+    )
 }

--- a/src/ariel-os-utils/src/env.rs
+++ b/src/ariel-os-utils/src/env.rs
@@ -232,3 +232,37 @@ macro_rules! ipv6_addr_from_env_or {
         }
     }};
 }
+
+/// Reads an eui48 at compile time from the given environment variable, produces an
+/// `[u8; 6]`, matched to the endianness of the target.
+///
+/// - The `$doc` parameter allows to provide a documentation string for this tunable (see
+///   [`str_from_env!`](str_from_env)).
+///
+/// # Errors
+///
+/// - Produces a compile-time error when [`option_env!`](option_env) does.
+/// - Produces a compile-time error when the environment variable cannot be parsed into a eui48
+#[macro_export]
+macro_rules! eui48_from_env {
+    // $doc is currently unused
+    ($env_var:literal, $doc:literal $(,)?) => {{
+        const {
+            const str_addr: &str = if let Some(str_value) = option_env!($env_var) {
+                str_value
+            } else {
+                $crate::env::const_panic::concat_panic!(
+                    "`",
+                    $env_var,
+                    "` environment variable was expected to provide the ",
+                    $doc,
+                );
+            };
+            let mut eui48: [u8; 6] =
+                $crate::const_str::hex!($crate::const_str::replace!(str_addr, ":", ""));
+            // Human readable eui48 is big endian.
+            eui48.reverse();
+            eui48
+        }
+    }};
+}

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -174,6 +174,8 @@ ble-esp = ["ariel-os-embassy/ble-esp"]
 ble-central = ["ariel-os-embassy/ble-central", "ble"]
 # Enables BLE to act as a peripheral. Can be used in conjunction with `ble-central`.
 ble-peripheral = ["ariel-os-embassy/ble-peripheral", "ble"]
+# Selects static BLE address configuration for setting a static address at build.
+ble-config-static-address = ["ariel-os-embassy/ble-config-static-address"]
 
 # ## Enables support for the nRF91xx SiP modem.
 nrf91-modem = ["ariel-os-embassy/nrf91-modem", "ariel-os-rt/nrf91-modem"]

--- a/src/ariel-os/src/lib.rs
+++ b/src/ariel-os/src/lib.rs
@@ -66,8 +66,8 @@ pub mod config {
     //! Provides configuration to the system and the application.
 
     pub use ariel_os_utils::{
-        ipv4_addr_from_env, ipv4_addr_from_env_or, ipv6_addr_from_env, ipv6_addr_from_env_or,
-        str_from_env, str_from_env_or,
+        eui48_from_env, ipv4_addr_from_env, ipv4_addr_from_env_or, ipv6_addr_from_env,
+        ipv6_addr_from_env_or, str_from_env, str_from_env_or,
     };
 }
 


### PR DESCRIPTION
# Description

This adds a way to set a static BLE address that persists across reboots for use cases like BLE Beacons.

## Testing

```sh
CONFIG_BLE_STATIC_ADDRESS=aa:aa:aa:aa:aa:aa  laze -C examples/ble-advertiser/ build -b nrf52840dk -s ble-config-static-address run   
```

And notice that the address advertised is `ea:aa:aa:aa:aa:aa` (two most significant bits set to 1).

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
It is now possible to set a static BLE address that persists across reboots, for use cases like BLE beacons.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
