### PR TITLE
fix(rt): rerun build scripts on used env changed

### DIFF
--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -54,6 +54,7 @@ fn main() {
             .replace("${ISR_STACKSIZE}", &isr_stacksize);
         std::fs::write(out.join("isr_stack_xtensa.x"), &template).unwrap();
         println!("cargo:rerun-if-changed=isr_stack_xtensa.ld.in");
+        println!("cargo:rerun-if-env-changed=CONFIG_ISR_STACKSIZE");
     }
 
     std::fs::copy("linkme.x", out.join("linkme.x")).unwrap();


### PR DESCRIPTION
# Description

Debugging some lost memory on #1939, I realized that changing `CONFIG_ISR_STACKSIZE` does not rebuild the rt crate, which it needs to update the xtensa linker script.

Fixed by emitting the correct `cargo-rerun-if-env-changed` line.

~~I piggibacked the same fix for `CARGO_CFG_CTX`, not sure if that is redundant.~~ dropped

## Testing

1. build some xtensa binary
2. hard-code `CONFIG_ISR_STACKSIZE` to something large (`"100000000"`) in line 73 in `laze-project.yml`.
3. rebuild

this succeeds on main, properly fails with this PR.

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(Xtensa) The build system now correctly acts on changing `isr_stacksize_required`.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
