### PR TITLE
feat(power): provide an API to enter stop mode in a portable manner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,8 @@ dependencies = [
 name = "ariel-os-power"
 version = "0.5.0"
 dependencies = [
+ "ariel-os-embassy-common",
+ "ariel-os-hal",
  "cortex-m",
  "esp-hal",
 ]

--- a/src/ariel-os-embassy-common/src/lib.rs
+++ b/src/ariel-os-embassy-common/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod cell;
 pub mod gpio;
+pub mod power;
 
 #[cfg(context = "cortex-m")]
 pub mod executor_swi;

--- a/src/ariel-os-embassy-common/src/power.rs
+++ b/src/ariel-os-embassy-common/src/power.rs
@@ -1,0 +1,11 @@
+//! Provides power management functionality.
+
+/// GPIO event that should trigger a wake-up.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum GpioWakeupTriggerEvent {
+    /// The GPIO is low.
+    Low,
+    /// The GPIO is high.
+    High,
+}

--- a/src/ariel-os-hal/src/hal/dummy/mod.rs
+++ b/src/ariel-os-hal/src/hal/dummy/mod.rs
@@ -23,6 +23,9 @@ pub mod gpio;
 pub mod peripheral;
 
 #[doc(hidden)]
+pub mod power;
+
+#[doc(hidden)]
 #[cfg(feature = "ble")]
 pub mod ble;
 

--- a/src/ariel-os-hal/src/hal/dummy/power.rs
+++ b/src/ariel-os-hal/src/hal/dummy/power.rs
@@ -1,0 +1,25 @@
+//! Provides power management functionality.
+
+use ariel_os_embassy_common::power::GpioWakeupTriggerEvent;
+
+pub trait StopWakeupPin {}
+
+/// Interrupts to configure to trigger a wake-up from standby mode.
+#[derive(Debug, Default)]
+pub struct WakeupInterrupts {
+    _private: (),
+}
+
+pub fn enter_stop_mode<'a, T: crate::hal::IntoPeripheral<'a, P>, P: StopWakeupPin>(
+    gpio_wakeup: Option<(
+        T,
+        ariel_os_embassy_common::gpio::Pull,
+        GpioWakeupTriggerEvent,
+    )>,
+) {
+    unimplemented!();
+}
+
+pub fn enter_standby_mode(interrupts: WakeupInterrupts) {
+    unimplemented!();
+}

--- a/src/ariel-os-power/Cargo.toml
+++ b/src/ariel-os-power/Cargo.toml
@@ -7,6 +7,8 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+ariel-os-embassy-common = { workspace = true }
+ariel-os-hal = { workspace = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
 cortex-m = { workspace = true }

--- a/src/ariel-os-power/src/lib.rs
+++ b/src/ariel-os-power/src/lib.rs
@@ -5,4 +5,6 @@
 
 mod reset;
 
+pub mod stop_mode;
+
 pub use reset::*;

--- a/src/ariel-os-power/src/stop_mode.rs
+++ b/src/ariel-os-power/src/stop_mode.rs
@@ -1,0 +1,107 @@
+//! Support for Ariel OS low-power stop mode, see [`enter()`].
+
+use ariel_os_hal::gpio::Pull;
+
+pub use ariel_os_embassy_common::power::GpioWakeupTriggerEvent;
+
+/// Defines a GPIO event to trigger a wake-up from [stop mode](enter).
+pub struct GpioWakeupTrigger<
+    'a,
+    T: ariel_os_hal::hal::IntoPeripheral<'a, P>,
+    P: ariel_os_hal::hal::power::StopWakeupPin,
+> {
+    /// GPIO pin on which to expect the event.
+    /// On certain MCUs, it is possible that not all GPIOs be usable as a wake-up trigger, even
+    /// though this is not typically the case for waking up from stop mode.
+    pub gpio: T,
+    /// Pull setting to use for the GPIO.
+    pub pull: ariel_os_hal::gpio::Pull,
+    /// GPIO event upon which to trigger a wake-up.
+    pub event: GpioWakeupTriggerEvent,
+    _phantom: core::marker::PhantomData<&'a P>,
+}
+
+impl<'a, T: ariel_os_hal::hal::IntoPeripheral<'a, P>, P: ariel_os_hal::hal::power::StopWakeupPin>
+    GpioWakeupTrigger<'a, T, P>
+{
+    /// Creates a  to define on which event to wake up from
+    /// [stop mode](enter).
+    #[must_use]
+    pub fn new(gpio: T, pull: Pull, event: GpioWakeupTriggerEvent) -> Self {
+        Self {
+            gpio,
+            pull,
+            event,
+            _phantom: core::marker::PhantomData,
+        }
+    }
+}
+
+/// Interrupts and events allowed to trigger a wake-up from stop mode.
+///
+/// If no triggers are set, the application's execution will not resume after calling
+/// [`enter()`].
+#[non_exhaustive]
+pub struct WakeupTriggers<
+    'a,
+    T: ariel_os_hal::hal::IntoPeripheral<'a, P>,
+    P: ariel_os_hal::hal::power::StopWakeupPin,
+> {
+    /// External interrupts that may trigger a wake-up.
+    pub gpio: Option<GpioWakeupTrigger<'a, T, P>>,
+    // TODO: an extra field should later be added to allow waking up from an RTC event.
+    pub(crate) _phantom: core::marker::PhantomData<&'a P>,
+}
+
+impl<'a, T: ariel_os_hal::hal::IntoPeripheral<'a, P>, P: ariel_os_hal::hal::power::StopWakeupPin>
+    Default for WakeupTriggers<'a, T, P>
+{
+    fn default() -> Self {
+        Self {
+            gpio: None,
+            _phantom: core::marker::PhantomData,
+        }
+    }
+}
+
+/// Enters stop mode.
+///
+/// In this mode, almost every clock of the microcontroller is off, but the RAM contents are
+/// retained.
+// TODO: enable this doc comment fragment when landing `standby_mode::enter()`.
+// Unlike [`standby_mode::enter()`], waking up does not involve rebooting, and execution resumes
+// normally after calling this function.
+/// In addition, the state of GPIOs, including their pull setting, is maintained.
+///
+/// The entry into the low-power mode may be delayed by a few cycles, in particular because of
+/// outstanding memory writes.
+///
+/// # Important note
+///
+/// This is currently implemented on a best-effort basis.
+/// Some microcontrollers may not support these low-power settings, they may not be implemented
+/// yet, or they may be lacking testing.
+/// Do measure the power consumption of your hardware when relevant for your application.
+///
+/// # Wake-up conditions
+///
+/// Depending on the microcontroller, waking up from this mode usually requires an RTC interrupt or
+/// an external interrupt (sometimes on a limited set of pins).
+pub fn enter<
+    'a,
+    T: ariel_os_hal::hal::IntoPeripheral<'a, P>,
+    P: ariel_os_hal::hal::power::StopWakeupPin,
+>(
+    wakeup: WakeupTriggers<'a, T, P>,
+) {
+    match wakeup {
+        WakeupTriggers {
+            gpio: Some(gpio), ..
+        } => {
+            ariel_os_hal::hal::power::enter_stop_mode(Some((gpio.gpio, gpio.pull, gpio.event)));
+        }
+        WakeupTriggers { gpio: None, .. } => {
+            ariel_os_hal::hal::power::enter_stop_mode::<T, _>(None);
+        }
+    }
+}

--- a/src/ariel-os-power/src/stop_mode.rs
+++ b/src/ariel-os-power/src/stop_mode.rs
@@ -72,6 +72,9 @@ impl<'a, T: ariel_os_hal::hal::IntoPeripheral<'a, P>, P: ariel_os_hal::hal::powe
 // Unlike [`standby_mode::enter()`], waking up does not involve rebooting, and execution resumes
 // normally after calling this function.
 /// In addition, the state of GPIOs, including their pull setting, is maintained.
+/// On some microcontrollers, whose power management is done automatically by hardware through a
+/// power management unit (PMU), calling this function may be similar to simply entering the sleep
+/// mode, and peripherals should instead be released by dropping their drivers when unneeded.
 ///
 /// The entry into the low-power mode may be delayed by a few cycles, in particular because of
 /// outstanding memory writes.


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
*This is still WIP.*

This PR currently only contains the common API: the implementations for ESP32, RP, and many STM32s exist but are not yet part of this PR (there is nothing to do for nRF, the PMU does it automatically).

A usage example will also be added later.

## Future Work

This first iteration of the API only supports waking up on *one external interrupt* (or not waking up at all).

- Waking up from an RTC event can be added later, and is expected to be purely additive (and not a breaking change).
- Waking up from any of multiple external interrupts can also be added later but will require breaking changes (but it is believed it is still worth moving forward with this iteration first, as the API surface, and therefore the breakage surface, is very small).

## TODO

- [ ] Complete the list GPIO trigger events by adding rising and falling edges, but only allow those that are supported by the hardware

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
TODO

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- (Partially) implements https://github.com/ariel-os/ariel-os/issues/510

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
