### PR TITLE
build: introduce ariel-os-buildutils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ariel-os-buildutils"
+version = "0.5.0"
+
+[[package]]
 name = "ariel-os-coap"
 version = "0.5.0"
 dependencies = [
@@ -483,6 +487,7 @@ dependencies = [
 name = "ariel-os-rp"
 version = "0.5.0"
 dependencies = [
+ "ariel-os-buildutils",
  "ariel-os-embassy-common",
  "ariel-os-log",
  "ariel-os-random",
@@ -510,6 +515,7 @@ name = "ariel-os-rt"
 version = "0.5.0"
 dependencies = [
  "ariel-os-alloc",
+ "ariel-os-buildutils",
  "ariel-os-debug",
  "ariel-os-log",
  "ariel-os-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "src/ariel-os-bench",
   "src/ariel-os-boards",
   "src/ariel-os-buildinfo",
+  "src/ariel-os-buildutils",
   "src/ariel-os-coap",
   "src/ariel-os-debug",
   "src/ariel-os-embassy-common",
@@ -127,6 +128,7 @@ ariel-os-alloc = { path = "src/ariel-os-alloc", default-features = false }
 ariel-os-bench = { path = "src/ariel-os-bench", default-features = false }
 ariel-os-boards = { path = "src/ariel-os-boards", default-features = false }
 ariel-os-buildinfo = { path = "src/ariel-os-buildinfo", default-features = false }
+ariel-os-buildutils = { path = "src/ariel-os-buildutils", default-features = false }
 ariel-os-coap = { path = "src/ariel-os-coap", default-features = false }
 ariel-os-debug = { path = "src/ariel-os-debug", default-features = false }
 ariel-os-embassy = { path = "src/ariel-os-embassy", default-features = false }

--- a/src/ariel-os-buildutils/Cargo.toml
+++ b/src/ariel-os-buildutils/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ariel-os-buildutils"
+version = "0.5.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true

--- a/src/ariel-os-buildutils/src/lib.rs
+++ b/src/ariel-os-buildutils/src/lib.rs
@@ -1,0 +1,17 @@
+//! Ariel OS build-time tools.
+
+/// Returns the first of the given contexts that is in the current `cfg` contexts.
+pub fn context_any(contexts: &[&'static str]) -> Option<&'static str> {
+    // Contexts cannot include commas.
+    contexts.iter().find(|c| context(c)).copied()
+}
+
+/// Returns whether the given context is in the current 'cfg' contexts.
+pub fn context(context: &'static str) -> bool {
+    let Ok(context_var) = std::env::var("CARGO_CFG_CONTEXT") else {
+        return false;
+    };
+
+    // Contexts cannot include commas.
+    context_var.split(',').any(|c| c == context)
+}

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -36,6 +36,9 @@ bt-hci = { workspace = true, optional = true }
 embassy-sync = { workspace = true, optional = true }
 trouble-host = { workspace = true, optional = true }
 
+[build-dependencies]
+ariel-os-buildutils = { workspace = true }
+
 [target.'cfg(context = "cortex-m")'.dependencies]
 embassy-executor = { workspace = true, default-features = false, features = [
   "arch-cortex-m",

--- a/src/ariel-os-rp/build.rs
+++ b/src/ariel-os-rp/build.rs
@@ -2,8 +2,10 @@ use std::env;
 use std::fs::copy;
 use std::path::PathBuf;
 
+use ariel_os_buildutils::context;
+
 fn main() {
-    if !is_in_current_contexts(&["ariel-os"]) {
+    if !context("ariel-os") {
         // Platform-independent tooling.
         return;
     }
@@ -11,9 +13,9 @@ fn main() {
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
-    let memory_script = if is_in_current_contexts(&["rp2040"]) {
+    let memory_script = if context("rp2040") {
         "memory.x"
-    } else if is_in_current_contexts(&["rp235xa"]) {
+    } else if context("rp235xa") {
         "memory-rp235xa.x"
     } else {
         panic!("unsupported RP MCU");
@@ -25,14 +27,4 @@ fn main() {
 
     println!("cargo:rerun-if-changed=memory.x");
     println!("cargo:rerun-if-changed=build.rs");
-}
-
-/// Returns whether any of the current `cfg` contexts is one of the given contexts.
-fn is_in_current_contexts(contexts: &[&str]) -> bool {
-    let Ok(context_var) = std::env::var("CARGO_CFG_CONTEXT") else {
-        return false;
-    };
-
-    // Contexts cannot include commas.
-    context_var.split(',').any(|c| contexts.contains(&c))
 }

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -16,6 +16,7 @@ embedded-test = { workspace = true, optional = true }
 linkme = { workspace = true }
 
 [build-dependencies]
+ariel-os-buildutils = { workspace = true }
 ld-memory = { workspace = true, features = ["build-rs"], optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -1,6 +1,8 @@
 use std::env;
 use std::path::PathBuf;
 
+use ariel_os_buildutils::{context, context_any};
+
 // 32 KiB recommended by [nrf-modem](https://github.com/diondokter/nrf-modem?tab=readme-ov-file#memory)
 #[allow(dead_code, reason = "only used when the feature is enabled")]
 const NRF91_MODEM_IPC_KB: u64 = 32;
@@ -127,20 +129,4 @@ fn write_memoryx() {
     ));
 
     memory.to_cargo_outdir("memory.x").expect("wrote memory.x");
-}
-
-/// Returns the first of the given contexts that is in the current `cfg` contexts.
-fn context_any(contexts: &[&'static str]) -> Option<&'static str> {
-    // Contexts cannot include commas.
-    contexts.iter().find(|c| context(c)).copied()
-}
-
-/// Returns whether the given context is in the current 'cfg' contexts.
-fn context(context: &'static str) -> bool {
-    let Ok(context_var) = std::env::var("CARGO_CFG_CONTEXT") else {
-        return false;
-    };
-
-    // Contexts cannot include commas.
-    context_var.split(',').any(|c| c == context)
 }


### PR DESCRIPTION
# Description

This commit adds the ariel-os-build crate for build-time helpers. Currently it splits out the `context` and `context_any` functions. 

## Testing

Resulting binaries must not change in any way. Tested locally by comparing the output for examples/hello-world on the:
- nrf9151-dk
- nrf52840dk
- st-nucleo-f401re
- espressif-esp32-c3-devkit-rust-1
- rpi-pico

## Issues/PRs References

Required for #2178

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The `ariel-os-build` crate has been introduced as collection of build-time helper functionality. 
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
