### PR TITLE
refactor: move nrf-specific linking to ariel-os-nrf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
 name = "ariel-os-nrf"
 version = "0.5.0"
 dependencies = [
+ "ariel-os-build",
  "ariel-os-embassy-common",
  "ariel-os-log",
  "ariel-os-random",
@@ -454,6 +455,7 @@ dependencies = [
  "embedded-io-async 0.6.1",
  "heapless 0.8.0",
  "heapless 0.9.1",
+ "ld-memory",
  "nrf-modem",
  "nrf-sdc",
  "paste",
@@ -526,7 +528,6 @@ dependencies = [
  "embassy-rp",
  "embedded-test",
  "esp-hal",
- "ld-memory",
  "linkme",
  "portable-atomic",
  "riscv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "ariel-os-build"
+version = "0.5.0"
+
+[[package]]
 name = "ariel-os-buildinfo"
 version = "0.5.0"
 dependencies = [
@@ -483,6 +487,7 @@ dependencies = [
 name = "ariel-os-rp"
 version = "0.5.0"
 dependencies = [
+ "ariel-os-build",
  "ariel-os-embassy-common",
  "ariel-os-log",
  "ariel-os-random",
@@ -510,6 +515,7 @@ name = "ariel-os-rt"
 version = "0.5.0"
 dependencies = [
  "ariel-os-alloc",
+ "ariel-os-build",
  "ariel-os-debug",
  "ariel-os-log",
  "ariel-os-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ ariel-os = { path = "src/ariel-os", default-features = false }
 ariel-os-alloc = { path = "src/ariel-os-alloc", default-features = false }
 ariel-os-bench = { path = "src/ariel-os-bench", default-features = false }
 ariel-os-boards = { path = "src/ariel-os-boards", default-features = false }
+ariel-os-build = { path = "src/ariel-os-build", default-features = false }
 ariel-os-buildinfo = { path = "src/ariel-os-buildinfo", default-features = false }
 ariel-os-coap = { path = "src/ariel-os-coap", default-features = false }
 ariel-os-debug = { path = "src/ariel-os-debug", default-features = false }

--- a/src/ariel-os-build/Cargo.toml
+++ b/src/ariel-os-build/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ariel-os-build"
+version = "0.5.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true

--- a/src/ariel-os-build/src/lib.rs
+++ b/src/ariel-os-build/src/lib.rs
@@ -1,0 +1,17 @@
+//! Ariel OS build-time tools.
+
+/// Returns the first of the given contexts that is in the current `cfg` contexts.
+pub fn context_any(contexts: &[&'static str]) -> Option<&'static str> {
+    // Contexts cannot include commas.
+    contexts.iter().find(|c| context(c)).copied()
+}
+
+/// Returns whether the given context is in the current 'cfg' contexts.
+pub fn context(context: &'static str) -> bool {
+    let Ok(context_var) = std::env::var("CARGO_CFG_CONTEXT") else {
+        return false;
+    };
+
+    // Contexts cannot include commas.
+    context_var.split(',').any(|c| c == context)
+}

--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 ariel-os-embassy-common = { workspace = true }
 ariel-os-log = { workspace = true }
 ariel-os-random = { workspace = true, optional = true }
-ariel-os-rt = { workspace = true, features = ["memory-x"] }
+ariel-os-rt = { workspace = true }
 cortex-m = { workspace = true, optional = true }
 defmt = { workspace = true, optional = true }
 embassy-embedded-hal = { workspace = true, optional = true }
@@ -37,6 +37,10 @@ embassy-net = { workspace = true, optional = true }
 embassy-net-driver-channel = { workspace = true, optional = true }
 heapless_for_embassy = { package = "heapless", version = "0.9.0", optional = true }
 heapless_for_nrfmodem = { package = "heapless", version = "0.8.0", optional = true }
+
+[build-dependencies]
+ariel-os-build = { workspace = true }
+ld-memory = { workspace = true, features = ["build-rs"] }
 
 [target.'cfg(context = "nrf51822-xxaa")'.dependencies]
 embassy-nrf = { workspace = true, features = ["nrf51"] }

--- a/src/ariel-os-nrf/build.rs
+++ b/src/ariel-os-nrf/build.rs
@@ -1,0 +1,63 @@
+use ariel_os_build::{context, context_any};
+use ld_memory::{Memory, MemorySection};
+
+// 32 KiB recommended by [nrf-modem](https://github.com/diondokter/nrf-modem?tab=readme-ov-file#memory)
+#[allow(dead_code, reason = "only used when the feature is enabled")]
+const NRF91_MODEM_IPC_KB: u64 = 32;
+
+fn main() {
+    if !context("ariel-os") {
+        // Platform-independent tooling.
+        return;
+    }
+
+    let (ram, flash) = if context("nrf51822-xxaa") {
+        (16, 256)
+    } else if context("nrf52832") {
+        (64, 256)
+    } else if context("nrf52833") {
+        (128, 512)
+    } else if context("nrf52840") {
+        (256, 1024)
+    } else if context("nrf5340-app") {
+        (512, 1024)
+    } else if context("nrf5340-net") {
+        (64, 256)
+    } else if context_any(&["nrf9151", "nrf9160"]).is_some() {
+        let ram = 256;
+        let flash = 1024;
+        if cfg!(feature = "nrf91-modem") {
+            (ram - NRF91_MODEM_IPC_KB, flash)
+        } else {
+            (ram, flash)
+        }
+    } else {
+        panic!("please set the MCU laze context");
+    };
+
+    let (pagesize, ram_base, flash_base) = if context("nrf5340-net") {
+        (2048, 0x2100_0000, 0x0100_0000)
+    } else if cfg!(feature = "nrf91-modem") {
+        (4096, 0x2000_0000 + NRF91_MODEM_IPC_KB * 1024, 0)
+    } else {
+        (4096, 0x2000_0000, 0)
+    };
+
+    // generate linker script
+    let memory = Memory::new()
+        .add_section(MemorySection::new("RAM", ram_base, ram * 1024))
+        .add_section(
+            MemorySection::new("FLASH", flash_base, flash * 1024)
+                .pagesize(pagesize)
+                .from_env(),
+        );
+
+    #[cfg(feature = "nrf91-modem")]
+    let memory = memory.add_section(MemorySection::new(
+        "MODEM",
+        0x2000_0000,
+        NRF91_MODEM_IPC_KB * 1024,
+    ));
+
+    memory.to_cargo_outdir("memory.x").expect("wrote memory.x");
+}

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -36,6 +36,9 @@ bt-hci = { workspace = true, optional = true }
 embassy-sync = { workspace = true, optional = true }
 trouble-host = { workspace = true, optional = true }
 
+[build-dependencies]
+ariel-os-build = { workspace = true }
+
 [target.'cfg(context = "cortex-m")'.dependencies]
 embassy-executor = { workspace = true, default-features = false, features = [
   "arch-cortex-m",

--- a/src/ariel-os-rp/build.rs
+++ b/src/ariel-os-rp/build.rs
@@ -2,8 +2,10 @@ use std::env;
 use std::fs::copy;
 use std::path::PathBuf;
 
+use ariel_os_build::context;
+
 fn main() {
-    if !is_in_current_contexts(&["ariel-os"]) {
+    if !context("ariel-os") {
         // Platform-independent tooling.
         return;
     }
@@ -11,9 +13,9 @@ fn main() {
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
-    let memory_script = if is_in_current_contexts(&["rp2040"]) {
+    let memory_script = if context("rp2040") {
         "memory.x"
-    } else if is_in_current_contexts(&["rp235xa"]) {
+    } else if context("rp235xa") {
         "memory-rp235xa.x"
     } else {
         panic!("unsupported RP MCU");
@@ -25,14 +27,4 @@ fn main() {
 
     println!("cargo:rerun-if-changed=memory.x");
     println!("cargo:rerun-if-changed=build.rs");
-}
-
-/// Returns whether any of the current `cfg` contexts is one of the given contexts.
-fn is_in_current_contexts(contexts: &[&str]) -> bool {
-    let Ok(context_var) = std::env::var("CARGO_CFG_CONTEXT") else {
-        return false;
-    };
-
-    // Contexts cannot include commas.
-    context_var.split(',').any(|c| contexts.contains(&c))
 }

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -17,7 +17,6 @@ linkme = { workspace = true }
 
 [build-dependencies]
 ariel-os-build = { workspace = true }
-ld-memory = { workspace = true, features = ["build-rs"], optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
 cortex-m = { workspace = true }
@@ -58,8 +57,6 @@ panic-printing = []
 _panic-handler = []
 single-core = ["cortex-m/critical-section-single-core"]
 multi-core = ["embassy-rp/critical-section-impl"]
-memory-x = ["dep:ld-memory"]
-nrf91-modem = []
 
 # features needed for `cargo test`
 _test = []

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -16,6 +16,7 @@ embedded-test = { workspace = true, optional = true }
 linkme = { workspace = true }
 
 [build-dependencies]
+ariel-os-build = { workspace = true }
 ld-memory = { workspace = true, features = ["build-rs"], optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -1,6 +1,8 @@
 use std::env;
 use std::path::PathBuf;
 
+use ariel_os_build::{context, context_any};
+
 // 32 KiB recommended by [nrf-modem](https://github.com/diondokter/nrf-modem?tab=readme-ov-file#memory)
 #[allow(dead_code, reason = "only used when the feature is enabled")]
 const NRF91_MODEM_IPC_KB: u64 = 32;
@@ -127,20 +129,4 @@ fn write_memoryx() {
     ));
 
     memory.to_cargo_outdir("memory.x").expect("wrote memory.x");
-}
-
-/// Returns the first of the given contexts that is in the current `cfg` contexts.
-fn context_any(contexts: &[&'static str]) -> Option<&'static str> {
-    // Contexts cannot include commas.
-    contexts.iter().find(|c| context(c)).copied()
-}
-
-/// Returns whether the given context is in the current 'cfg' contexts.
-fn context(context: &'static str) -> bool {
-    let Ok(context_var) = std::env::var("CARGO_CFG_CONTEXT") else {
-        return false;
-    };
-
-    // Contexts cannot include commas.
-    context_var.split(',').any(|c| c == context)
 }

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -3,10 +3,6 @@ use std::path::PathBuf;
 
 use ariel_os_build::{context, context_any};
 
-// 32 KiB recommended by [nrf-modem](https://github.com/diondokter/nrf-modem?tab=readme-ov-file#memory)
-#[allow(dead_code, reason = "only used when the feature is enabled")]
-const NRF91_MODEM_IPC_KB: u64 = 32;
-
 fn main() {
     if !context("ariel-os") {
         // Platform-independent tooling.
@@ -63,70 +59,9 @@ fn main() {
     std::fs::copy("eheap.x", out.join("eheap.x")).unwrap();
     std::fs::copy("keep-stack-sizes.x", out.join("keep-stack-sizes.x")).unwrap();
 
-    #[cfg(feature = "memory-x")]
-    write_memoryx();
-
     println!("cargo:rerun-if-changed=linkme.x");
     println!("cargo:rerun-if-changed=eheap.x");
     println!("cargo:rerun-if-changed=keep-stack-sizes.x");
 
     println!("cargo:rustc-link-search={}", out.display());
-}
-
-/// Writes `memory.x` based on `ld-memory` settings to `$OUTDIR`.
-///
-/// # Panics
-/// Panics if called outside of a known laze context.
-#[cfg(feature = "memory-x")]
-fn write_memoryx() {
-    use ld_memory::{Memory, MemorySection};
-    let (ram, flash) = if context("nrf51822-xxaa") {
-        (16, 256)
-    } else if context("nrf52832") {
-        (64, 256)
-    } else if context("nrf52833") {
-        (128, 512)
-    } else if context("nrf52840") {
-        (256, 1024)
-    } else if context("nrf5340-app") {
-        (512, 1024)
-    } else if context("nrf5340-net") {
-        (64, 256)
-    } else if context_any(&["nrf9151", "nrf9160"]).is_some() {
-        let ram = 256;
-        let flash = 1024;
-        if cfg!(feature = "nrf91-modem") {
-            (ram - NRF91_MODEM_IPC_KB, flash)
-        } else {
-            (ram, flash)
-        }
-    } else {
-        panic!("please set the MCU laze context");
-    };
-
-    let (pagesize, ram_base, flash_base) = if context("nrf5340-net") {
-        (2048, 0x2100_0000, 0x0100_0000)
-    } else if cfg!(feature = "nrf91-modem") {
-        (4096, 0x2000_0000 + NRF91_MODEM_IPC_KB * 1024, 0)
-    } else {
-        (4096, 0x2000_0000, 0)
-    };
-
-    // generate linker script
-    let memory = Memory::new()
-        .add_section(MemorySection::new("RAM", ram_base, ram * 1024))
-        .add_section(
-            MemorySection::new("FLASH", flash_base, flash * 1024)
-                .pagesize(pagesize)
-                .from_env(),
-        );
-
-    #[cfg(feature = "nrf91-modem")]
-    let memory = memory.add_section(MemorySection::new(
-        "MODEM",
-        0x2000_0000,
-        NRF91_MODEM_IPC_KB * 1024,
-    ));
-
-    memory.to_cargo_outdir("memory.x").expect("wrote memory.x");
 }

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -178,7 +178,7 @@ ble-peripheral = ["ariel-os-embassy/ble-peripheral", "ble"]
 ble-config-static-address = ["ariel-os-embassy/ble-config-static-address"]
 
 # ## Enables support for the nRF91xx SiP modem.
-nrf91-modem = ["ariel-os-embassy/nrf91-modem", "ariel-os-rt/nrf91-modem"]
+nrf91-modem = ["ariel-os-embassy/nrf91-modem"]
 # Adjusts nRF modem (or related components) to assume that there is the DECT firmware running on the radio core.
 nrf-radiocore-firmware-dect = ["ariel-os-nrf/radiocore-firmware-dect"]
 


### PR DESCRIPTION
# Description

Moves the nrf-specific linker generation into ariel-os-nrf

## Testing

Resulting binaries must not change in any way. Tested locally by comparing the output for examples/hello-world on the:
- nrf9151-dk
- nrf52840dk
- st-nucleo-f401re
- espressif-esp32-c3-devkit-rust-1
- rpi-pico

## Issues/PRs References

Depends on #2177

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
