### PR TITLE
chore(probe-rs): remove workaround obsolete since 0.28.0

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -308,9 +308,7 @@ contexts:
       - has_nrf91_modem
       - has_storage_support
     env:
-      # FIXME: probe-rs does not support the nRF9151_xxAA yet, because there is
-      # no CMSIS-Pack available
-      PROBE_RS_CHIP: nRF9160_xxAA
+      PROBE_RS_CHIP: nRF9151_xxAA
 
   - name: rp
     help: Raspberry Pi Pico (2) MCU support (based on embassy-rp)


### PR DESCRIPTION
# Description

Old probe-rs didn't know that chip; that has been resolved since 0.28.0 released >1y ago. Helps against spurious "something is wrong hey why is there a wrong chip in my debug output". cases.

## Testing

Tested flashing the device-info example onto a makerdiary-nrf9151-connect-kit, just worked as expected.

## Change Checklist

- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- n/a I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
