### PR TITLE
feat(uart): expose sbd defined UARTs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3113,6 +3113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-uart-echo"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+ "embedded-io-async 0.6.1",
+]
+
+[[package]]
 name = "example-usb-serial"
 version = "0.0.0"
 dependencies = [

--- a/boards/bbc-microbit-v2.yaml
+++ b/boards/bbc-microbit-v2.yaml
@@ -7,3 +7,12 @@ targets:
       - pin: P0_14
       # button1
       - pin: P0_23
+    uarts:
+      - aliases:
+          - UART_INT
+        # According to https://tech.microbit.org/hardware/schematic/, which
+        # explains that pins are labeled from the host point of view.
+        rx_pin: P1_08 # UART_INT_TX
+        tx_pin: P0_06 # UART_INT_RX
+        possible_peripherals: [UARTE0, UARTE1]
+        host_facing: true

--- a/boards/nrf52840dk.yaml
+++ b/boards/nrf52840dk.yaml
@@ -34,3 +34,12 @@ targets:
       # button3
       - pin: P0_25
         active: low
+    uarts:
+      - aliases:
+          - VCOM0
+        tx_pin: P0_06
+        rx_pin: P0_08
+        rts_pin: P0_05
+        cts_pin: P0_07
+        possible_peripherals: [UARTE0, UARTE1]
+        host_facing: true

--- a/boards/nrf9151-dk.yaml
+++ b/boards/nrf9151-dk.yaml
@@ -44,3 +44,23 @@ targets:
         active: low
         aliases:
           - Button 4
+    uarts:
+      - aliases:
+          - VCOM0
+        tx_pin: P0_27
+        rx_pin: P0_26
+        rts_pin: P0_14
+        cts_pin: P0_15
+        # FIXME: Is this exhaustive? (Seems those are all we have in Ariel right now)
+        possible_peripherals: [SERIAL3]
+        host_facing: true
+      # Pins are correct, but SERIAL3 is already taken
+      # - aliases:
+      #   - VCOM1
+      #   tx_pin: P0_29
+      #   rx_pin: P0_28
+      #   rts_pin: P0_16
+      #   cts_pin: P0_17
+      #   # FIXME: Is this exhaustive? (Seems those are all we have in Ariel right now)
+      #   possible_peripherals: [SERIAL3]
+      #   host_facing: true

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -35,6 +35,7 @@ subdirs:
   - threading-event
   - threading-multicore
   - threading-timers
+  - uart-echo
   - udp-echo
   - usb-keyboard
   - usb-serial

--- a/examples/uart-echo/Cargo.toml
+++ b/examples/uart-echo/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "example-uart-echo"
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+ariel-os = { path = "../../src/ariel-os", features = ["time", "uart"] }
+ariel-os-boards = { path = "../../src/ariel-os-boards" }
+embedded-io-async = { workspace = true }
+
+[lints]
+workspace = true

--- a/examples/uart-echo/README.md
+++ b/examples/uart-echo/README.md
@@ -1,0 +1,13 @@
+# UART echo example
+
+## About
+
+This application shows how to use the UARTs that are defined in a board's SBD descriptions.
+
+## How to run
+
+In this directory, run:
+
+    laze build -b nrf52840dk run
+
+The example initializes the host-facing UART (at 115200baud 8N1) and echoes all incoming bytes.

--- a/examples/uart-echo/laze.yml
+++ b/examples/uart-echo/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: example-uart-echo
+    depends:
+      - has_host_facing_uart

--- a/examples/uart-echo/src/main.rs
+++ b/examples/uart-echo/src/main.rs
@@ -1,0 +1,56 @@
+//! This example shows how to use SBD defined uarts.
+
+#![no_main]
+#![no_std]
+
+use ariel_os::{
+    debug::{ExitCode, exit},
+    hal,
+    log::info,
+    uart::{Assignment, Baudrate},
+};
+
+use embedded_io_async::{Read as _, Write as _};
+
+type UartAssignment = ariel_os_boards::pins::HOST_FACING_UART;
+
+#[ariel_os::task(autostart, peripherals)]
+async fn main(peripherals: UartAssignment) {
+    info!("Starting UART echo test");
+
+    let mut config = hal::uart::Config::default();
+    config.baudrate = Baudrate::_115200;
+
+    info!("Selected configuration: {:?}", config);
+
+    let mut rx_buf = [0u8; 32];
+    let mut tx_buf = [0u8; 32];
+
+    let (tx, rx) = peripherals.into_pins();
+
+    let mut uart =
+        <UartAssignment as Assignment>::Device::new(rx, tx, &mut rx_buf, &mut tx_buf, config)
+            .expect("Invalid UART configuration");
+
+    uart.write_all(b"Ariel OS uart echo started!\r\n")
+        .await
+        .unwrap();
+
+    let mut input = [0u8; 32];
+
+    'main: loop {
+        let n = uart.read(&mut input).await.unwrap();
+
+        for byte in input.iter_mut().take(n) {
+            if *byte == 0x03 {
+                info!("exiting");
+                uart.write_all(b"exiting\r\n").await.unwrap();
+                break 'main;
+            }
+        }
+
+        let _ = uart.write(&input[0..n]).await.unwrap();
+    }
+
+    exit(ExitCode::SUCCESS);
+}

--- a/examples/uart-echo/src/main.rs
+++ b/examples/uart-echo/src/main.rs
@@ -7,15 +7,15 @@ use ariel_os::{
     debug::{ExitCode, exit},
     hal,
     log::info,
-    uart::{Assignment, Baudrate},
+    uart::Baudrate,
 };
 
 use embedded_io_async::{Read as _, Write as _};
 
-type UartAssignment = ariel_os_boards::pins::HOST_FACING_UART;
+type UartPeripherals = ariel_os_boards::pins::HOST_FACING_UART;
 
 #[ariel_os::task(autostart, peripherals)]
-async fn main(peripherals: UartAssignment) {
+async fn main(peripherals: UartPeripherals) {
     info!("Starting UART echo test");
 
     let mut config = hal::uart::Config::default();
@@ -26,11 +26,9 @@ async fn main(peripherals: UartAssignment) {
     let mut rx_buf = [0u8; 32];
     let mut tx_buf = [0u8; 32];
 
-    let (tx, rx) = peripherals.into_pins();
-
-    let mut uart =
-        <UartAssignment as Assignment>::Device::new(rx, tx, &mut rx_buf, &mut tx_buf, config)
-            .expect("Invalid UART configuration");
+    let mut uart = peripherals
+        .with_config(&mut rx_buf, &mut tx_buf, config)
+        .expect("Invalid UART configuration");
 
     uart.write_all(b"Ariel OS uart echo started!\r\n")
         .await

--- a/src/ariel-os-boards/laze.yml
+++ b/src/ariel-os-boards/laze.yml
@@ -30,6 +30,7 @@ builders:
   parent: nrf52833
   provides:
   - has_buttons
+  - has_host_facing_uart
 - name: dfrobot-firebeetle2-esp32-c6
   parent: esp32c6fx4
   provides:
@@ -110,6 +111,7 @@ builders:
   parent: nrf52840
   provides:
   - has_buttons
+  - has_host_facing_uart
   - has_leds
   - has_usb_device_port
 - name: nrf52dk
@@ -129,6 +131,7 @@ builders:
   parent: nrf9151
   provides:
   - has_buttons
+  - has_host_facing_uart
   - has_leds
 - name: nrf9160dk-nrf9160
   parent: nrf9160

--- a/src/ariel-os-boards/src/bbc-microbit-v2.rs
+++ b/src/ariel-os-boards/src/bbc-microbit-v2.rs
@@ -4,6 +4,9 @@ pub mod pins {
     ariel_os_hal::define_peripherals!(
         ButtonPeripherals { button0 : P0_14, button1 : P0_23, }
     );
+    ariel_os_hal::define_uarts![
+        { name : uart0, device : UARTE0, tx : P0_06, rx : P1_08, host_facing : true },
+    ];
 }
 #[allow(unused_variables)]
 pub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}

--- a/src/ariel-os-boards/src/nrf52840dk.rs
+++ b/src/ariel-os-boards/src/nrf52840dk.rs
@@ -8,6 +8,9 @@ pub mod pins {
         ButtonPeripherals { button0 : P0_11, button1 : P0_12, button2 : P0_24, button3 :
         P0_25, }
     );
+    ariel_os_hal::define_uarts![
+        { name : uart0, device : UARTE0, tx : P0_06, rx : P0_08, host_facing : true },
+    ];
 }
 #[allow(unused_variables)]
 pub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}

--- a/src/ariel-os-boards/src/nrf9151-dk.rs
+++ b/src/ariel-os-boards/src/nrf9151-dk.rs
@@ -8,6 +8,9 @@ pub mod pins {
         ButtonPeripherals { button0 : P0_08, button1 : P0_09, button2 : P0_18, button3 :
         P0_19, }
     );
+    ariel_os_hal::define_uarts![
+        { name : uart0, device : SERIAL3, tx : P0_27, rx : P0_26, host_facing : true },
+    ];
 }
 #[allow(unused_variables)]
 pub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}

--- a/src/ariel-os-embassy-common/src/uart.rs
+++ b/src/ariel-os-embassy-common/src/uart.rs
@@ -1,41 +1,5 @@
 //! Provides HAL-agnostic UART-related types.
 
-/// A grouping of peripherals that can be combined to start a UART.
-///
-/// There is some asymmetry in the types involved because the [`Tx`][Self::Tx] and [`Rx`][Self::Rx]
-/// pins are carried as singleton instances, whereas the [`Device`][Self::Device] type is the one
-/// that has the `::new()` method (currently not associated with any trait) as a type method (which
-/// then takes ownership of the pin singletons).
-///
-/// # Usage
-///
-/// An application that works on some configured UART can be written as taking an type `U:
-/// Assignment` (not yet a generic, until the Ariel OS UART API is backed by traits), and is
-/// initialized with an owned instance thereof. A typical input would be
-/// `ariel_os::boards::pins::HOST_FACING_UART` on boards that have it, or an explicitly configured
-/// other assignment.
-///
-/// That application can then turn that assignment [`let (tx, rx) =
-/// u.into_pins()`][Self::into_pins], possibly set them up (eg. by sending a BREAK condition), and
-/// then create the UART as `<U as Assignment>::Device::new(rx, tx, rx_buf, tx_buf, config)`.
-///
-/// # Future development
-///
-/// Once "being a UART device" is formalized in a trait, this can become a requirement on the
-/// Device type, and this type can provide methods to initialize that concrete UART assignment into
-/// an operational instance.
-pub trait Assignment {
-    /// Type that has a `Device::new()` method that conforms to the informal Ariel OS HAL.
-    type Device<'a>;
-    /// Transmit pin type that is passed into the device's `new()` method as the `tx` argument.
-    type Tx;
-    /// Receive pin type that is passed into the device's `new()` method as the `rx` argument.
-    type Rx;
-
-    /// Destructor that provides the contained pin singletons to the user.
-    fn into_pins(self) -> (Self::Tx, Self::Rx);
-}
-
 /// UART configuration error.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/ariel-os-hal/src/hal.rs
+++ b/src/ariel-os-hal/src/hal.rs
@@ -28,6 +28,8 @@ pub mod define_peripherals;
 
 // these macros need explicit export from crate root in order to re-export them.
 pub use crate::define_peripherals;
+pub use crate::define_uart;
+pub use crate::define_uarts;
 pub use crate::group_peripherals;
 
 pub use define_peripherals::*;

--- a/src/ariel-os-hal/src/hal/define_peripherals.rs
+++ b/src/ariel-os-hal/src/hal/define_peripherals.rs
@@ -163,8 +163,8 @@ macro_rules! define_uart {
 
         #[allow(nonstandard_style)]
         pub struct $name {
-            tx: $crate::hal::peripheral::Peri<'static, peripherals::$tx>,
-            rx: $crate::hal::peripheral::Peri<'static, peripherals::$rx>,
+            tx: $crate::__peripheral_ty!($tx),
+            rx: $crate::__peripheral_ty!($rx),
         }
 
         impl $crate::hal::TakePeripherals<$name> for &mut $crate::hal::OptionalPeripherals {
@@ -178,8 +178,8 @@ macro_rules! define_uart {
 
         impl $crate::uart::Assignment for $name {
             type Device<'a> = $crate::hal::uart::$device<'a>;
-            type Tx = $crate::hal::peripheral::Peri<'static, peripherals::$tx>;
-            type Rx = $crate::hal::peripheral::Peri<'static, peripherals::$rx>;
+            type Tx = $crate::__peripheral_ty!($tx);
+            type Rx = $crate::__peripheral_ty!($rx);
 
             fn into_pins(self) -> (Self::Tx, Self::Rx) {
                 (self.tx, self.rx)

--- a/src/ariel-os-hal/src/hal/define_peripherals.rs
+++ b/src/ariel-os-hal/src/hal/define_peripherals.rs
@@ -145,15 +145,14 @@ macro_rules! define_uarts {
     ( $($_:tt)+ ) => {};
 }
 
-/// Creates a struct of the given `name`, containing everything needed to set up a UART.
+/// Creates a struct of the given `name`, containing all peripherals needed to set up a UART.
 ///
 /// It holds the TX and RX pins, and can be taken through the same mechanism as those defined using
 /// [`ariel_os::hal::define_peripherals!`] (that is, by using [`ariel_os::task(autostart,
 /// peripherals)`] or the underlying `TakePeripherals` trait).
 ///
-/// The struct also implement [`ariel_os::uart::Assignment`], and by that carries a type with the
-/// (not trait-backed) promise that it is something that can be initialized through the
-/// [`ariel_os::uart`] APIs.
+/// The struct also has a method [`with_config()`] that can be used to initialize an Ariel OS uart
+/// instance.
 #[cfg(feature = "uart")]
 #[macro_export]
 macro_rules! define_uart {
@@ -176,13 +175,15 @@ macro_rules! define_uart {
             }
         }
 
-        impl $crate::uart::Assignment for $name {
-            type Device<'a> = $crate::hal::uart::$device<'a>;
-            type Tx = $crate::__peripheral_ty!($tx);
-            type Rx = $crate::__peripheral_ty!($rx);
-
-            fn into_pins(self) -> (Self::Tx, Self::Rx) {
-                (self.tx, self.rx)
+        impl<'d> $name {
+            pub fn with_config(
+                self,
+                rx_buf: &'d mut [u8],
+                tx_buf: &'d mut [u8],
+                config: $crate::hal::uart::Config,
+            ) -> Result<$crate::hal::uart::Uart<'d>, ariel_os_embassy_common::uart::ConfigError>
+            {
+                $crate::hal::uart::$device::<'d>::new(self.rx, self.tx, rx_buf, tx_buf, config)
             }
         }
     };

--- a/src/ariel-os-hal/src/hal/define_peripherals.rs
+++ b/src/ariel-os-hal/src/hal/define_peripherals.rs
@@ -111,7 +111,7 @@ macro_rules! group_peripherals {
 /// This macro defines types which can be used as peripherals in autostart tasks for accessing
 /// UARTs as defined in board descriptions.
 ///
-/// Its argument is a comma-separated list of items that mostly go into repeated [`define_uart!`] calls
+/// Its argument is a comma-separated list of items that mostly go into repeated [`define_uart!`](crate::define_uart!) calls
 /// (which define a struct type); see there.
 ///
 /// In addition to that, type aliases are created for easier access; currently, that is only
@@ -148,10 +148,10 @@ macro_rules! define_uarts {
 /// Creates a struct of the given `name`, containing all peripherals needed to set up a UART.
 ///
 /// It holds the TX and RX pins, and can be taken through the same mechanism as those defined using
-/// [`ariel_os::hal::define_peripherals!`] (that is, by using [`ariel_os::task(autostart,
-/// peripherals)`] or the underlying `TakePeripherals` trait).
+/// [`define_peripherals!`](crate::define_peripherals!) (that is, by using [`ariel_os::task(autostart,
+/// peripherals)`](ariel_os::task()) or the underlying `TakePeripherals` trait).
 ///
-/// The struct also has a method [`with_config()`] that can be used to initialize an Ariel OS uart
+/// The struct also has a method `.with_config()` that can be used to initialize an Ariel OS uart
 /// instance.
 #[cfg(feature = "uart")]
 #[macro_export]

--- a/src/ariel-os-hal/src/hal/define_peripherals.rs
+++ b/src/ariel-os-hal/src/hal/define_peripherals.rs
@@ -108,6 +108,121 @@ macro_rules! group_peripherals {
     }
 }
 
+/// This macro defines types which can be used as peripherals in autostart tasks for accessing
+/// UARTs as defined in board descriptions.
+///
+/// Its argument is a comma-separated list of items that mostly go into repeated [`define_uart!`] calls
+/// (which define a struct type); see there.
+///
+/// In addition to that, type aliases are created for easier access; currently, that is only
+/// `HOST_FACING_UART` (an alias to the type of the host facing port, on boards with
+/// `has_host_facing_uart`).
+///
+/// While usable for applications just as well (to set up custom UARTs), it is most useful in board
+/// descriptions, because in addition to the individual exposed UARTs, it can also provide extra
+/// functionalities that take all UARTs into account.
+#[cfg(feature = "uart")]
+#[macro_export]
+macro_rules! define_uarts {
+    ( $( { $($args:tt)+ } ),* $(,)? ) => {
+        $(
+            $crate::define_uart!{ $($args)+ }
+        )*
+
+        $crate::_define_host_facing_uarts!{
+            // Note that this does *not* create an outer separator; instead, the inner macro
+            // creates a trailing comma for each item.
+            $(
+                $crate::_uart_get_host_facing_names!{ $($args)+ }
+            ),*
+        }
+    }
+}
+
+#[cfg(not(feature = "uart"))]
+#[macro_export]
+macro_rules! define_uarts {
+    ( $($_:tt)+ ) => {};
+}
+
+/// Creates a struct of the given `name`, containing everything needed to set up a UART.
+///
+/// It holds the TX and RX pins, and can be taken through the same mechanism as those defined using
+/// [`ariel_os::hal::define_peripherals!`] (that is, by using [`ariel_os::task(autostart,
+/// peripherals)`] or the underlying `TakePeripherals` trait).
+///
+/// The struct also implement [`ariel_os::uart::Assignment`], and by that carries a type with the
+/// (not trait-backed) promise that it is something that can be initialized through the
+/// [`ariel_os::uart`] APIs.
+#[cfg(feature = "uart")]
+#[macro_export]
+macro_rules! define_uart {
+    ( name: $name:ident, device: $device:ident, tx: $tx:ident, rx: $rx:ident, host_facing: $_host_facing:literal ) => {
+        // Rather than define_peripherals!'ing here, we define our type manually, because we also
+        // have to carry the device type, and that's not coming through TakePeripherals.
+
+        #[allow(nonstandard_style)]
+        pub struct $name {
+            tx: $crate::hal::peripheral::Peri<'static, peripherals::$tx>,
+            rx: $crate::hal::peripheral::Peri<'static, peripherals::$rx>,
+        }
+
+        impl $crate::hal::TakePeripherals<$name> for &mut $crate::hal::OptionalPeripherals {
+            fn take_peripherals(&mut self) -> $name {
+                $name {
+                    tx: self.$tx.take().unwrap(),
+                    rx: self.$rx.take().unwrap(),
+                }
+            }
+        }
+
+        impl $crate::uart::Assignment for $name {
+            type Device<'a> = $crate::hal::uart::$device<'a>;
+            type Tx = $crate::hal::peripheral::Peri<'static, peripherals::$tx>;
+            type Rx = $crate::hal::peripheral::Peri<'static, peripherals::$rx>;
+
+            fn into_pins(self) -> (Self::Tx, Self::Rx) {
+                (self.tx, self.rx)
+            }
+        }
+    };
+}
+
+#[cfg(not(feature = "uart"))]
+#[macro_export]
+macro_rules! define_uart {
+    ( $($_:tt)+ ) => {};
+}
+
+#[macro_export]
+macro_rules! _uart_get_host_facing_names {
+    ( name: $name:ident, device: $_device:ident, tx: $_tx:ident, rx: $_rx:ident, host_facing: true ) => {
+        $name
+    };
+    ( name: $_name:ident, device: $_device:ident, tx: $_tx:ident, rx: $_rx:ident, host_facing: false ) => {};
+}
+
+#[macro_export]
+macro_rules! _define_host_facing_uarts {
+    () => {};
+    ( $name:ty ) => {
+        pub type HOST_FACING_UART = $name;
+    };
+    ( $name:ty, $name2:ty $(, $($_:ty),+)? ) => {
+        pub type HOST_FACING_UART = $name;
+        // FIXME: This can only be accessed by application that have some prior knowledge of
+        // multiple UARTs being available, and, more importantly, has negotiated between its
+        // components which one takes which. Once any future mechanism enables that negotiation,
+        // these types will need to be advertised to this mechanism.
+        pub type HOST_FACING_UART_2 = $name2;
+    };
+    ( $name:ty, $name2:ty $(, $($_:ty),+)? ) => {
+        compile_error!(
+            "Larger numbers of host facing UARTs can be supported by expanding the `_define_host_facing_uarts` macro of ariel-os-hal to more cases."
+        );
+    };
+}
+
 #[doc(hidden)]
 pub trait TakePeripherals<T> {
     fn take_peripherals(&mut self) -> T;


### PR DESCRIPTION
# Description

This splits out the UART sbd handling code from the [slipmux PR](#1613).

Basically, it adds machinery to generate structs and types from the sbd generated `define_uarts!()` *call*.

Some board's host-facing UART pinouts are added so there's something to test with.

An example is added (`examples/uart-echo`).

~~This is a draft so we can discuss API et al.~~ -> API works, lets use it for now and iterate later.

**update 10.09.*

- dropped the `Assignment` trait, re-used @ROMemories idea of just implementing a `with_config()` on the generated type.

## Testing

`examples/uart-echo` hard-codes the "host facing uart".
I verified that replacing that with direct `uart0` still works:

```
-type UartPeripherals = ariel_os_boards::pins::HOST_FACING_UART;
+type UartPeripherals = ariel_os_boards::pins::uart0;
```

## Issues/PRs References

Split out of #1613.
~~Would be affected by https://github.com/ariel-os/sbd/pull/141 / https://github.com/ariel-os/ariel-os/pull/2123, and needs to either go in first or get adapted.~~ (rebased on this)

- Depends on #2123

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
UARTs defined in sbd files are now exposed via macros.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
