### PR TITLE
feat(coap): add initial ping support POC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,8 @@ dependencies = [
  "cboritem",
  "coap-handler",
  "coap-handler-implementations",
+ "coap-message",
+ "coap-message-utils",
  "coap-numbers",
  "coapcore",
  "critical-section",
@@ -237,6 +239,7 @@ dependencies = [
  "lakers",
  "lakers-crypto-rustcrypto",
  "minicbor",
+ "minicbor-derive",
  "serde",
  "serde_yaml",
  "static_cell",
@@ -1055,7 +1058,7 @@ dependencies = [
  "embedded-io 0.6.1",
  "embedded-io-async 0.6.1",
  "futures-intrusive",
- "heapless 0.8.0",
+ "heapless 0.9.1",
 ]
 
 [[package]]
@@ -1430,9 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "coap-numbers"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62940de3d016deb4c2e8bf5062435d69eba7f2c64b35537de4c56586db52231c"
+checksum = "f84b6d4175638be4f037388dc1fae0d03862ba666a6942fa057b6031d3abb5a0"
 
 [[package]]
 name = "coap-request"
@@ -1852,7 +1855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4408,9 +4411,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "minicbor"
-version = "2.1.3"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a1119e42fbacc2bb65d860de6eb7c930562bc71d42dca026d06b0228231f77"
+checksum = "1b7a5041e12946f8b7d3f5a9d96383a19d694b9335457c522be7815b9abafb02"
 dependencies = [
  "minicbor-derive",
 ]
@@ -4429,9 +4432,9 @@ dependencies = [
 
 [[package]]
 name = "minicbor-derive"
-version = "0.18.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50fcf6ee04e942da7d65066bf427fe7bdd229256998809eeecee25db6dc9aac2"
+checksum = "7c9303a7d70578b101a21b3043ade4ab825c59063bbcd89af1066729399b79c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5195,18 +5198,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]

--- a/src/ariel-os-coap/Cargo.toml
+++ b/src/ariel-os-coap/Cargo.toml
@@ -7,13 +7,18 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-ariel-os-embassy = { workspace = true }
+ariel-os-embassy = { workspace = true , features =["time"]}
 ariel-os-log = { workspace = true }
 ariel-os-macros = { path = "../ariel-os-macros" }
 ariel-os-random = { workspace = true, features = ["csprng"], optional = true }
 ariel-os-storage = { workspace = true, optional = true }
 coap-handler = "0.2.0"
 coap-handler-implementations = "0.6.1"
+coap-message = "0.3.2" # not sure how to avoid this ?
+coap-numbers = "0.2.9"
+coap-message-utils = "0.3.9" # not sure how to avoid this ?
+minicbor = "2.2.2"
+minicbor-derive = "0.19.4"
 coapcore = { path = "../lib/coapcore", default-features = false }
 critical-section = { workspace = true }
 # These features should be more selective and not enabled here, but as things
@@ -24,6 +29,7 @@ critical-section = { workspace = true }
 embassy-net = { workspace = true, features = [
   "proto-ipv4",
   "proto-ipv6",
+  "icmp",
   "udp",
 ], optional = true }
 embassy-sync = { workspace = true }

--- a/src/ariel-os-coap/Cargo.toml
+++ b/src/ariel-os-coap/Cargo.toml
@@ -32,6 +32,7 @@ embassy-net = { workspace = true, features = [
   "icmp",
   "udp",
 ], optional = true }
+
 embassy-sync = { workspace = true }
 embedded-nal-async = { version = "0.8", optional = true }
 embedded-nal-coap = { workspace = true }
@@ -73,6 +74,10 @@ coap-server = []
 coap-server-config-storage = ["dep:ariel-os-random", "dep:ariel-os-storage"]
 coap-server-config-unprotected = []
 coap-server-config-demokeys = ["dep:ariel-os-random"]
+
+coap-ping-monitoring = [
+  "dep:embassy-net",
+]
 
 coap-transport-udp = [
   "dep:ariel-os-random",

--- a/src/ariel-os-coap/src/cbor_impls.rs
+++ b/src/ariel-os-coap/src/cbor_impls.rs
@@ -1,0 +1,118 @@
+use crate::ping::{
+    CborPingSchema, IpV4Wrapper, IpV6Wrapper, IpWrapper, JobEntry, JobType, MAX_REQ_SZ, PING_JOB,
+    PJob, Stats,
+};
+use heapless::Vec;
+use minicbor::{
+    Decode, Decoder, Encode, Encoder,
+    decode::ArrayIterWithCtx,
+    encode::{Error, Write},
+};
+
+impl<C> Encode<C> for JobEntry {
+    fn encode<W: minicbor::encode::Write>(
+        &self,
+        e: &mut Encoder<W>,
+        _ctx: &mut C,
+    ) -> Result<(), minicbor::encode::Error<W::Error>> {
+        e.u64(self.id)?.encode(self.job.clone())?.ok()
+    }
+}
+
+impl<C> Encode<C> for PJob {
+    fn encode<W: minicbor::encode::Write>(
+        &self,
+        e: &mut Encoder<W>,
+        _ctx: &mut C,
+    ) -> Result<(), minicbor::encode::Error<W::Error>> {
+        e.str_len(PING_JOB.len() as u64)?.str(PING_JOB)?.ok()?;
+
+        for (ip, stat) in &self.target {
+            e.map(self.target.len() as u64)?.ok()?;
+            e.encode(ip)?.ok()?;
+            e.encode(stat)?.ok()?;
+        }
+        Ok(())
+    }
+}
+
+impl<C> Encode<C> for IpV6Wrapper {
+    fn encode<W: Write>(
+        &self,
+        e: &mut Encoder<W>,
+        _: &mut C,
+    ) -> Result<(), minicbor::encode::Error<W::Error>> {
+        e.bytes(&self.0.octets())?.ok()
+    }
+}
+
+impl<C> Encode<C> for IpV4Wrapper {
+    fn encode<W: Write>(&self, e: &mut Encoder<W>, _: &mut C) -> Result<(), Error<W::Error>> {
+        e.bytes(&self.0.octets())?.ok()
+    }
+}
+
+impl<C> Encode<C> for IpWrapper {
+    fn encode<W: Write>(&self, e: &mut Encoder<W>, ctx: &mut C) -> Result<(), Error<W::Error>> {
+        e.array(2)?;
+        match self {
+            IpWrapper::V4(ip) => e.u32(0)?.encode_with(ip, ctx)?.ok(),
+            IpWrapper::V6(ip) => e.u32(1)?.encode_with(ip, ctx)?.ok(),
+        }
+    }
+}
+
+impl<'b, C> Decode<'b, C> for IpV4Wrapper {
+    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        let octets: minicbor::bytes::ByteArray<4> = Decode::decode(d, ctx)?;
+        Ok(IpV4Wrapper(<[u8; 4]>::from(octets).into()))
+    }
+}
+
+impl<'b, C> Decode<'b, C> for IpV6Wrapper {
+    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        let octets: minicbor::bytes::ByteArray<16> = Decode::decode(d, ctx)?;
+        Ok(IpV6Wrapper(<[u8; 16]>::from(octets).into()))
+    }
+}
+
+impl<'b, C> Decode<'b, C> for IpWrapper {
+    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        let p = d.position();
+        if Some(2) != d.array()? {
+            return Err(minicbor::decode::Error::message("expected enum (2-element array)").at(p));
+        }
+        let p = d.position();
+        match d.i64()? {
+            0 => Ok(IpWrapper::V4(IpV4Wrapper::decode(d, ctx)?)),
+            1 => Ok(IpWrapper::V6(IpV6Wrapper::decode(d, ctx)?)),
+            n => Err(minicbor::decode::Error::unknown_variant(n).at(p)),
+        }
+    }
+}
+
+impl<'b, C> Decode<'b, C> for CborPingSchema {
+    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        let _ = d.decode::<&str>()?;
+        let kype = match d.decode::<u8>()? {
+            0 => JobType::Ping,
+            1 => JobType::PortScan,
+            2 => JobType::Broadcast,
+            _ => return Err(minicbor::decode::Error::type_mismatch(d.datatype()?)),
+        };
+
+        let arr: ArrayIterWithCtx<'_, '_, C, (IpWrapper, Stats)> = d.array_iter_with(ctx)?;
+        let mut ip_list: Vec<(IpWrapper, Stats), MAX_REQ_SZ> = Vec::new();
+        for i in arr {
+            ip_list
+                .push(i?)
+                .map_err(|_| minicbor::decode::Error::message("Vector push failed"))?;
+        }
+        let count = d.decode::<Option<u32>>()?;
+        Ok(CborPingSchema {
+            kype,
+            ip_list,
+            count,
+        })
+    }
+}

--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -8,6 +8,7 @@
 #![no_std]
 #![deny(missing_docs)]
 
+mod ping;
 // Moving work from https://github.com/embassy-rs/embassy/pull/2519 in here for the time being
 #[cfg(feature = "coap-transport-udp")]
 mod udp_nal;

--- a/src/ariel-os-coap/src/lib.rs
+++ b/src/ariel-os-coap/src/lib.rs
@@ -8,7 +8,11 @@
 #![no_std]
 #![deny(missing_docs)]
 
-mod ping;
+#[cfg(feature = "coap-ping-monitoring")]
+mod cbor_impls;
+#[cfg(feature = "coap-ping-monitoring")]
+pub mod ping;
+
 // Moving work from https://github.com/embassy-rs/embassy/pull/2519 in here for the time being
 #[cfg(feature = "coap-transport-udp")]
 mod udp_nal;

--- a/src/ariel-os-coap/src/ping.rs
+++ b/src/ariel-os-coap/src/ping.rs
@@ -175,13 +175,8 @@ impl MeasurmentManager {
         })
     }
 
-    /// Initializez the [`MeasurmentManaget`]
-    ///
-    /// This function connects to the configured endpoint and waits for a response.
-    ///
     /// # Panics
-    ///
-    /// Panics if the internal state is invalid or if a required invariant is violated.
+    /// Panics if the index is wrong which is imposible.
     fn init(&'static self, config: CborPingSchema) -> Result<u64, ()> {
         if config.ip_list.is_empty() || config.ip_list.len() > 16 {
             return Err(());

--- a/src/ariel-os-coap/src/ping.rs
+++ b/src/ariel-os-coap/src/ping.rs
@@ -1,0 +1,291 @@
+use ariel_os_embassy::api::time::Instant;
+use ariel_os_embassy::asynch::Spawner;
+use coap_handler::Handler;
+use coap_message::Code;
+use coap_message::{MinimalWritableMessage, MutableWritableMessage, ReadableMessage};
+use coap_message_utils::Error;
+use core::cell::RefCell;
+use core::default;
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use core::sync::atomic::AtomicI32;
+use core::sync::atomic::Ordering::Relaxed;
+use embassy_net::icmp::PacketMetadata;
+use embassy_net::icmp::ping::{PingManager, PingParams};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::channel::Channel;
+use heapless::vec::Vec;
+use minicbor::decode::ArrayIterWithCtx;
+use minicbor::{Decode, Decoder, Encode, Encoder};
+
+//TODO: Investigate adding observe functionality to the coap server
+//so that we dont need to keep state
+
+/// Queue of pending ping requests shared by the worker pool.
+static PING_QUEUE: Channel<CriticalSectionRawMutex, InternalTarget, 32> = Channel::new();
+
+const PING_WORKERS: usize = 4;
+const MAX_REQ_SZ: usize = 16;
+static ID_COUNTER: AtomicI32 = AtomicI32::new(0);
+
+//NOTE: We would really just want to have some sort of PingJob that the caller
+//can define in the POST
+
+/// Shared statistics storage.
+/// Currently global for the proof-of-concept.
+static STAT_STORAGE: critical_section::Mutex<RefCell<heapless::Vec<PingStats, 16>>> =
+    critical_section::Mutex::new(RefCell::new(heapless::Vec::new()));
+
+#[ariel_os_macros::spawner(autostart)]
+fn spawn_task_pool(spawner: Spawner) {
+    for _ in 0..PING_WORKERS {
+        spawner.spawn(ping_worker()).unwrap();
+    }
+}
+
+#[ariel_os_macros::task(pool_size = PING_WORKERS)]
+async fn ping_worker() -> ! {
+    //Coap run also does this. Im not sure we can recover
+    let stack = ariel_os_embassy::net::network_stack().await.unwrap();
+
+    let mut rx_buffer = [0; 256];
+    let mut tx_buffer = [0; 256];
+    let mut rx_meta = [PacketMetadata::EMPTY];
+    let mut tx_meta = [PacketMetadata::EMPTY];
+
+    let mut ping_manager = PingManager::new(
+        stack,
+        &mut rx_meta,
+        &mut rx_buffer,
+        &mut tx_meta,
+        &mut tx_buffer,
+    );
+
+    loop {
+        let internal_target = PING_QUEUE.receive().await;
+
+        let mut ping_params = match internal_target.t.ip_addr {
+            IpWrapper::V4(ip_v4_wrapper) => PingParams::new(ip_v4_wrapper.0),
+            IpWrapper::V6(ip_v6_wrapper) => PingParams::new(ip_v6_wrapper.0),
+        };
+
+        ping_params
+            .set_count(internal_target.t.count.unwrap_or(1))
+            .set_hop_limit(internal_target.t.hop_limit);
+
+        let timestamp = Instant::now();
+        match ping_manager.ping(&ping_params).await {
+            Ok(_) => {
+                let ip: [u8; 16] = ping_params.target().map_or_else(
+                    || [0; 16],
+                    |x| match x {
+                        IpAddr::V4(ipv4) => ipv4.to_ipv6_mapped().octets(),
+                        IpAddr::V6(ipv6) => ipv6.octets(),
+                    },
+                );
+
+                let elapsed = Instant::now()
+                    .checked_duration_since(timestamp)
+                    .expect("The clock wrapped around");
+
+                let stats = PingStats::new(ip, elapsed.as_micros());
+                critical_section::with(|cs| {
+                    let mut storage = STAT_STORAGE.borrow_ref_mut(cs);
+
+                    if let Some(existing) = storage.iter_mut().find(|s| s.ip == stats.ip) {
+                        // Mutate the existing entry.
+                        existing.update_from(&stats);
+                    } else {
+                        // Try to insert a new one. If full, ignore it.
+                        let _ = storage.push(stats);
+                    }
+                });
+            }
+
+            Err(e) => todo!("We will have to add a error code section in the stats"),
+        }
+    }
+}
+
+enum IpWrapper {
+    V4(IpV4Wrapper),
+    V6(IpV6Wrapper),
+}
+
+//TODO: Despite net:: Ip stuff being in core for a while now minicbor still has
+//it behind a std cfg flag
+//UPDATE: PR is apparently in the works and will be pushed the week of july 13th
+pub struct IpV4Wrapper(Ipv4Addr);
+pub struct IpV6Wrapper(Ipv6Addr);
+
+impl<'b, C> Decode<'b, C> for IpV4Wrapper {
+    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        let octets: minicbor::bytes::ByteArray<4> = Decode::decode(d, ctx)?;
+        Ok(IpV4Wrapper(<[u8; 4]>::from(octets).into()))
+    }
+}
+
+impl<'b, C> Decode<'b, C> for IpV6Wrapper {
+    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        let octets: minicbor::bytes::ByteArray<16> = Decode::decode(d, ctx)?;
+        Ok(IpV6Wrapper(<[u8; 16]>::from(octets).into()))
+    }
+}
+
+impl<'b, C> Decode<'b, C> for IpWrapper {
+    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        let p = d.position();
+        if Some(2) != d.array()? {
+            return Err(minicbor::decode::Error::message("expected enum (2-element array)").at(p));
+        }
+        let p = d.position();
+        match d.i64()? {
+            0 => Ok(IpWrapper::V4(IpV4Wrapper::decode(d, ctx)?)),
+            1 => Ok(IpWrapper::V6(IpV6Wrapper::decode(d, ctx)?)),
+            n => Err(minicbor::decode::Error::unknown_variant(n).at(p)),
+        }
+    }
+}
+
+///This is the mininum CBOR element for us to do work with
+#[derive(Decode)]
+struct Target {
+    #[n(0)]
+    ip_addr: IpWrapper,
+    #[n(1)]
+    count: Option<u16>,
+    #[n(2)]
+    hop_limit: Option<u8>,
+    // #[n(3)]
+    // latency: Option<u32>,
+}
+
+struct InternalTarget {
+    t: Target,
+    id: i32,
+}
+
+struct CborPingSchema {
+    targets: Vec<Target, MAX_REQ_SZ>,
+}
+
+impl<'b, 'c, C> Decode<'b, C> for CborPingSchema {
+    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        let arr_travle: ArrayIterWithCtx<'_, '_, C, Target> = d.array_iter_with(ctx)?;
+        let mut out: Vec<Target, MAX_REQ_SZ> = Vec::new();
+        for i in arr_travle {
+            out.push(i?)
+                .map_err(|_| minicbor::decode::Error::message("Vector push failed"))?;
+        }
+        Ok(CborPingSchema { targets: out })
+    }
+}
+
+struct PingHandler {
+    vals: CborPingSchema,
+}
+
+#[derive(Encode, Default, Debug, PartialEq)]
+struct PingStats {
+    #[n(0)]
+    ip: [u8; 16],
+    #[n(1)]
+    ave_latency: u64,
+    #[n(2)]
+    ping_count: u64,
+}
+
+impl PingStats {
+    fn new(ip: [u8; 16], ave_latency: u64) -> Self {
+        Self {
+            ip,
+            ave_latency,
+            ping_count: default::Default::default(),
+        }
+    }
+
+    fn update_from(&mut self, stats: &Self) {
+        self.ave_latency = stats.ave_latency;
+        self.ping_count += 1;
+    }
+}
+
+enum ReqData {
+    P(CborPingSchema),
+    G,
+}
+
+impl Handler for PingHandler {
+    type RequestData = ReqData;
+
+    type ExtractRequestError = Error;
+
+    type BuildResponseError<M: MinimalWritableMessage> = M::UnionError;
+
+    fn extract_request_data<M: ReadableMessage>(
+        &mut self,
+        request: &M,
+    ) -> Result<Self::RequestData, Self::ExtractRequestError> {
+        match request.code().into() {
+            coap_numbers::code::GET => Ok(ReqData::G),
+            coap_numbers::code::POST => {
+                let payload: &[u8] = request.payload();
+                if payload.is_empty() || payload.len() > MAX_REQ_SZ {
+                    return Err(Error::bad_request());
+                }
+                let mut de = Decoder::new(payload);
+                Ok(ReqData::P(
+                    de.decode::<CborPingSchema>()
+                        .map_err(|_| Error::unsupported_content_format())?,
+                ))
+            }
+            _ => Err(Error::method_not_allowed()),
+        }
+    }
+
+    fn estimate_length(&mut self, request: &Self::RequestData) -> usize {
+        //Taken from coap_messages
+        1280 - 40 - 4 // does this correclty calculate the IPv6 minimum MTU?
+    }
+
+    fn build_response<M: MutableWritableMessage>(
+        &mut self,
+        response: &mut M,
+        request: Self::RequestData,
+    ) -> Result<(), Self::BuildResponseError<M>> {
+        match request {
+            ReqData::P(cbor_ping_schema) => {
+                for t in cbor_ping_schema.targets {
+                    //Relaxed since its all on one thread ?
+                    match PING_QUEUE.try_send(InternalTarget {
+                        t,
+                        id: ID_COUNTER.fetch_add(1, Relaxed),
+                    }) {
+                        Ok(()) => response.set_code(Code::new(coap_numbers::code::CREATED)?),
+                        Err(_) => response.set_code(Code::new(coap_numbers::code::CONFLICT)?),
+                    }
+                }
+            }
+            ReqData::G => {
+                // Temporary PoC.
+                // The semantics of exposing statistics are intentionally left open.
+                let stats = critical_section::with(|cs| STAT_STORAGE.borrow_ref_mut(cs).pop())
+                    .unwrap_or_default();
+                let mut buffer = [0u8; 512];
+                let mut encoder = Encoder::new(&mut buffer[..]);
+                match encoder.encode(stats) {
+                    Ok(_) => response.set_payload(&buffer[..])?,
+                    Err(_) => {
+                        response.set_code(
+                            Code::new(coap_numbers::code::INTERNAL_SERVER_ERROR).unwrap(),
+                        );
+                    }
+                }
+            }
+            ReqData::BadRequest => {
+                response.set_code(Code::new(coap_numbers::code::BAD_REQUEST).unwrap());
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/ariel-os-coap/src/ping.rs
+++ b/src/ariel-os-coap/src/ping.rs
@@ -1,51 +1,300 @@
-use ariel_os_embassy::api::time::Instant;
+//! # Ping
+//!
+//! ## Ping Semantics
+//! ### POST
+//! Will create the job and queue it.
+//!
+//! ### GET
+//! Will COPY out the job INCLUDING ALL THE IPs so don't spam this one. For
+//! example a Ping Job (in its current format) is at max (16 ip's to ping) 512 bytes.
+//!
+//! ### DELETE
+//! Will *wait* for the job to finish a *round*. *round* being a single decrement
+//! of the count field in the POST request data used to instantiate the job in the first place.
+//! *wait* meaning that the actualy Job will be removed from the Managers vector of Jobs. If there
+//! is a in progress execution of the `run` method (of Manager) this run method makes a internal
+//! copy of the Job and if the delete occurs after this copy has been made, the copy will execute
+//! its job (Ping, Broadcast, scan, etc.) and the run function will return. The next call of the
+//! run function will (asuming this job is not a oneshot) try and run the job again. This
+//! will return None at which point the job can be considered completly delete.
+//! ## Schema
+//! TODO
+//!
+//! ## Examples
+//! ```
+//! TODO
+//! ```
+//!
+
 use ariel_os_embassy::asynch::Spawner;
 use coap_handler::Handler;
-use coap_message::Code;
+use coap_message::Code as _;
+use coap_message::MessageOption as _;
 use coap_message::{MinimalWritableMessage, MutableWritableMessage, ReadableMessage};
 use coap_message_utils::Error;
+use coap_numbers::code::DELETED;
+use coap_numbers::code::INTERNAL_SERVER_ERROR;
+use coap_numbers::code::{CONTENT, CREATED, NOT_FOUND};
+use coap_numbers::option::URI_PATH;
 use core::cell::RefCell;
-use core::default;
-use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use core::sync::atomic::AtomicI32;
+use core::net::{Ipv4Addr, Ipv6Addr};
+use core::sync::atomic::AtomicU64;
 use core::sync::atomic::Ordering::Relaxed;
+use critical_section::Mutex;
 use embassy_net::icmp::PacketMetadata;
 use embassy_net::icmp::ping::{PingManager, PingParams};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
-use embassy_sync::channel::Channel;
+use embassy_sync::channel::{self, Channel};
 use heapless::vec::Vec;
-use minicbor::decode::ArrayIterWithCtx;
-use minicbor::{Decode, Decoder, Encode, Encoder};
+use minicbor::Decode;
+use minicbor::{Decoder, Encode, Encoder};
 
-//TODO: Investigate adding observe functionality to the coap server
-//so that we dont need to keep state
+///Max length of the user request IP list, so for a single ping job you can only have 16 targets at
+///one time.
+pub(crate) const MAX_REQ_SZ: usize = 16;
 
-/// Queue of pending ping requests shared by the worker pool.
-static PING_QUEUE: Channel<CriticalSectionRawMutex, InternalTarget, 32> = Channel::new();
-
+///Num of tasks that can concurently operate on the ping job queue.
 const PING_WORKERS: usize = 4;
-const MAX_REQ_SZ: usize = 16;
-static ID_COUNTER: AtomicI32 = AtomicI32::new(0);
 
-//NOTE: We would really just want to have some sort of PingJob that the caller
-//can define in the POST
+static MEASURMENT_MANAGER: static_cell::StaticCell<MeasurmentManager> =
+    static_cell::StaticCell::new();
 
-/// Shared statistics storage.
-/// Currently global for the proof-of-concept.
-static STAT_STORAGE: critical_section::Mutex<RefCell<heapless::Vec<PingStats, 16>>> =
-    critical_section::Mutex::new(RefCell::new(heapless::Vec::new()));
+///ID generator.
+static ID_GEN: AtomicU64 = AtomicU64::new(0);
 
-#[ariel_os_macros::spawner(autostart)]
-fn spawn_task_pool(spawner: Spawner) {
-    for _ in 0..PING_WORKERS {
-        spawner.spawn(ping_worker()).unwrap();
+///Queue for the worker tasks to pull job IDs from.
+static JOB_ID_QUEUE: Channel<CriticalSectionRawMutex, u64, 32> = channel::Channel::new();
+
+pub(crate) static PING_JOB: &str = "ping";
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum IpWrapper {
+    V4(IpV4Wrapper),
+    V6(IpV6Wrapper),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct IpV4Wrapper(pub(crate) Ipv4Addr);
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct IpV6Wrapper(pub(crate) Ipv6Addr);
+
+#[derive(Clone, Debug, PartialEq, Decode)]
+pub(crate) enum JobType {
+    #[n(0)]
+    Ping,
+    #[n(1)]
+    PortScan,
+    #[n(2)]
+    Broadcast,
+}
+
+pub(crate) struct CborPingSchema {
+    pub(crate) kype: JobType,
+    pub(crate) ip_list: Vec<(IpWrapper, Stats), MAX_REQ_SZ>,
+    pub(crate) count: Option<u32>,
+}
+
+///Handeler, first thing that touches the incoming data.
+///
+///This is only way to enable the Ping funcitonality via CoAP. The schema/semantics are defined at
+///the module level `ping` docs.
+pub struct MeasurmentHandler {
+    manager: &'static MeasurmentManager,
+}
+
+impl Default for MeasurmentHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MeasurmentHandler {
+    ///Constructor.
+    #[must_use]
+    pub fn new() -> Self {
+        MeasurmentHandler {
+            manager: MeasurmentManager::new(),
+        }
+    }
+}
+
+///Exposed due to trait
+pub struct ReqData {
+    x: Internal,
+}
+
+pub(crate) enum Internal {
+    P,
+    D(u64),
+    G(u64),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct PJob {
+    pub(crate) count: u32,
+    pub(crate) completed: i32,
+    pub(crate) has_errors: bool,
+    pub(crate) target: Vec<(IpWrapper, Stats), 16>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Encode, Decode, Default)]
+pub(crate) struct Stats {
+    #[n(0)]
+    ave_rtt: u64,
+    #[n(1)]
+    sent: u32,
+    #[n(2)]
+    received: u32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct JobEntry {
+    pub(crate) id: u64,
+    pub(crate) job: Job,
+}
+
+#[derive(Clone, Debug, PartialEq, Encode)]
+pub(crate) enum Job {
+    #[n(0)]
+    Ping(#[n(1)] PJob),
+    #[n(2)]
+    TraceRoung(#[n(3)] PJob),
+    #[n(4)]
+    MuiltyCast(#[n(5)] PJob),
+}
+
+struct MeasurmentManager {
+    id_table: critical_section::Mutex<RefCell<Vec<Option<JobEntry>, 16>>>,
+}
+
+impl MeasurmentManager {
+    ///Panics if cell is full
+    fn new() -> &'static Self {
+        MEASURMENT_MANAGER.init_with(|| MeasurmentManager {
+            id_table: Mutex::new(RefCell::new(Vec::new())),
+        })
+    }
+
+    /// Initializez the [`MeasurmentManaget`]
+    ///
+    /// This function connects to the configured endpoint and waits for a response.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal state is invalid or if a required invariant is violated.
+    fn init(&'static self, config: CborPingSchema) -> Result<u64, ()> {
+        if config.ip_list.is_empty() || config.ip_list.len() > 16 {
+            return Err(());
+        }
+
+        //Single threaded
+        let id = ID_GEN.fetch_add(1, Relaxed);
+        let job = match config.kype {
+            JobType::Ping => {
+                let count = config.count.unwrap_or(1);
+                Job::Ping(PJob {
+                    target: config.ip_list,
+
+                    count,
+                    completed: 0,
+                    has_errors: false,
+                })
+            }
+            _ => todo!(),
+        };
+
+        critical_section::with(|cs| {
+            let mut table = self.id_table.borrow_ref_mut(cs);
+            let index = table
+                .iter()
+                .position(core::option::Option::is_none)
+                .ok_or(())?;
+            let job = JobEntry { id, job };
+            *table.get_mut(index).unwrap() = Some(job);
+            Ok(id)
+        })
+    }
+
+    /// # Panics if somehow the index is wrong. This should be imposible.
+    fn delete(&'static self, id: u64) -> Option<JobEntry> {
+        critical_section::with(|cs| {
+            let mut table = self.id_table.borrow_ref_mut(cs);
+            let i = table.iter().position(|x| match x {
+                Some(x) => x.id == id,
+                None => false,
+            })?;
+            let val = table.get(i).unwrap().clone();
+            table.remove(i);
+            val
+        })
+    }
+
+    /// # Panics if somehow the index is wrong. This should be imposible.
+    fn get(&'static self, id: u64) -> Option<JobEntry> {
+        critical_section::with(|cs| {
+            let table = self.id_table.borrow_ref_mut(cs);
+            let i = table.iter().position(|x| match x {
+                Some(x) => x.id == id,
+                None => false,
+            })?;
+            table.get(i).unwrap().clone()
+        })
+    }
+
+    //TODO: There should be some Runnable trait probably you can have the output of the ip
+    //param creation for loop be a asos type
+
+    /// # Panics if somehow the index is wrong. This should be imposible.
+    async fn run<'a>(&self, id: u64, ping_manager: &mut PingManager<'a>) -> Option<u32> {
+        let mut val = critical_section::with(|cs| {
+            let table = self.id_table.borrow_ref_mut(cs);
+            let i = table.iter().position(|x| match x {
+                Some(x) => x.id == id,
+                None => false,
+            })?;
+            table.get(i).unwrap().clone()
+        })?;
+
+        match &mut val.job {
+            Job::Ping(PJob {
+                target,
+                count,
+                completed,
+                has_errors,
+            }) => {
+                for (ip, stat) in target.iter_mut() {
+                    let params = match ip {
+                        IpWrapper::V4(ip_v4_wrapper) => PingParams::new(ip_v4_wrapper.0),
+                        IpWrapper::V6(ip_v6_wrapper) => PingParams::new(ip_v6_wrapper.0),
+                    };
+                    match ping_manager.ping(&params).await {
+                        Ok(x) => {
+                            stat.ave_rtt = x.as_micros();
+                            *completed += 1;
+                            *count -= 1;
+                        }
+                        Err(_e) => {
+                            *has_errors = true;
+                            *completed -= 1;
+                            *count -= 1;
+                        }
+                    }
+                }
+                Some(*count)
+            }
+            Job::TraceRoung(_pjob) => todo!(),
+            Job::MuiltyCast(_pjob) => todo!(),
+        }
     }
 }
 
 #[ariel_os_macros::task(pool_size = PING_WORKERS)]
-async fn ping_worker() -> ! {
-    //Coap run also does this. Im not sure we can recover
-    let stack = ariel_os_embassy::net::network_stack().await.unwrap();
+async fn ping_worker(job_manager: &'static MeasurmentManager) -> ! {
+    let stack = loop {
+        if let Some(x) = ariel_os_embassy::net::network_stack().await {
+            break x;
+        }
+    };
 
     let mut rx_buffer = [0; 256];
     let mut tx_buffer = [0; 256];
@@ -61,164 +310,25 @@ async fn ping_worker() -> ! {
     );
 
     loop {
-        let internal_target = PING_QUEUE.receive().await;
-
-        let mut ping_params = match internal_target.t.ip_addr {
-            IpWrapper::V4(ip_v4_wrapper) => PingParams::new(ip_v4_wrapper.0),
-            IpWrapper::V6(ip_v6_wrapper) => PingParams::new(ip_v6_wrapper.0),
-        };
-
-        ping_params
-            .set_count(internal_target.t.count.unwrap_or(1))
-            .set_hop_limit(internal_target.t.hop_limit);
-
-        let timestamp = Instant::now();
-        match ping_manager.ping(&ping_params).await {
-            Ok(_) => {
-                let ip: [u8; 16] = ping_params.target().map_or_else(
-                    || [0; 16],
-                    |x| match x {
-                        IpAddr::V4(ipv4) => ipv4.to_ipv6_mapped().octets(),
-                        IpAddr::V6(ipv6) => ipv6.octets(),
-                    },
-                );
-
-                let elapsed = Instant::now()
-                    .checked_duration_since(timestamp)
-                    .expect("The clock wrapped around");
-
-                let stats = PingStats::new(ip, elapsed.as_micros());
-                critical_section::with(|cs| {
-                    let mut storage = STAT_STORAGE.borrow_ref_mut(cs);
-
-                    if let Some(existing) = storage.iter_mut().find(|s| s.ip == stats.ip) {
-                        // Mutate the existing entry.
-                        existing.update_from(&stats);
-                    } else {
-                        // Try to insert a new one. If full, ignore it.
-                        let _ = storage.push(stats);
-                    }
-                });
-            }
-
-            Err(e) => todo!("We will have to add a error code section in the stats"),
-        }
+        let id = JOB_ID_QUEUE.receive().await;
+        while job_manager.run(id, &mut ping_manager).await.is_some() {}
     }
 }
 
-enum IpWrapper {
-    V4(IpV4Wrapper),
-    V6(IpV6Wrapper),
-}
-
-//TODO: Despite net:: Ip stuff being in core for a while now minicbor still has
-//it behind a std cfg flag
-//UPDATE: PR is apparently in the works and will be pushed the week of july 13th
-pub struct IpV4Wrapper(Ipv4Addr);
-pub struct IpV6Wrapper(Ipv6Addr);
-
-impl<'b, C> Decode<'b, C> for IpV4Wrapper {
-    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
-        let octets: minicbor::bytes::ByteArray<4> = Decode::decode(d, ctx)?;
-        Ok(IpV4Wrapper(<[u8; 4]>::from(octets).into()))
+#[ariel_os_macros::spawner(autostart)]
+/// # Panics
+/// If this panics then embassy cant spawn any more tasks and there are bigger problems to worry
+/// about.
+fn spawn_task_pool(spawner: Spawner) {
+    let manager = MeasurmentManager::new();
+    for _ in 0..PING_WORKERS {
+        spawner.spawn(ping_worker(manager)).unwrap();
     }
 }
 
-impl<'b, C> Decode<'b, C> for IpV6Wrapper {
-    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
-        let octets: minicbor::bytes::ByteArray<16> = Decode::decode(d, ctx)?;
-        Ok(IpV6Wrapper(<[u8; 16]>::from(octets).into()))
-    }
-}
-
-impl<'b, C> Decode<'b, C> for IpWrapper {
-    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
-        let p = d.position();
-        if Some(2) != d.array()? {
-            return Err(minicbor::decode::Error::message("expected enum (2-element array)").at(p));
-        }
-        let p = d.position();
-        match d.i64()? {
-            0 => Ok(IpWrapper::V4(IpV4Wrapper::decode(d, ctx)?)),
-            1 => Ok(IpWrapper::V6(IpV6Wrapper::decode(d, ctx)?)),
-            n => Err(minicbor::decode::Error::unknown_variant(n).at(p)),
-        }
-    }
-}
-
-///This is the mininum CBOR element for us to do work with
-#[derive(Decode)]
-struct Target {
-    #[n(0)]
-    ip_addr: IpWrapper,
-    #[n(1)]
-    count: Option<u16>,
-    #[n(2)]
-    hop_limit: Option<u8>,
-    // #[n(3)]
-    // latency: Option<u32>,
-}
-
-struct InternalTarget {
-    t: Target,
-    id: i32,
-}
-
-struct CborPingSchema {
-    targets: Vec<Target, MAX_REQ_SZ>,
-}
-
-impl<'b, 'c, C> Decode<'b, C> for CborPingSchema {
-    fn decode(d: &mut Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
-        let arr_travle: ArrayIterWithCtx<'_, '_, C, Target> = d.array_iter_with(ctx)?;
-        let mut out: Vec<Target, MAX_REQ_SZ> = Vec::new();
-        for i in arr_travle {
-            out.push(i?)
-                .map_err(|_| minicbor::decode::Error::message("Vector push failed"))?;
-        }
-        Ok(CborPingSchema { targets: out })
-    }
-}
-
-struct PingHandler {
-    vals: CborPingSchema,
-}
-
-#[derive(Encode, Default, Debug, PartialEq)]
-struct PingStats {
-    #[n(0)]
-    ip: [u8; 16],
-    #[n(1)]
-    ave_latency: u64,
-    #[n(2)]
-    ping_count: u64,
-}
-
-impl PingStats {
-    fn new(ip: [u8; 16], ave_latency: u64) -> Self {
-        Self {
-            ip,
-            ave_latency,
-            ping_count: default::Default::default(),
-        }
-    }
-
-    fn update_from(&mut self, stats: &Self) {
-        self.ave_latency = stats.ave_latency;
-        self.ping_count += 1;
-    }
-}
-
-enum ReqData {
-    P(CborPingSchema),
-    G,
-}
-
-impl Handler for PingHandler {
+impl Handler for MeasurmentHandler {
     type RequestData = ReqData;
-
     type ExtractRequestError = Error;
-
     type BuildResponseError<M: MinimalWritableMessage> = M::UnionError;
 
     fn extract_request_data<M: ReadableMessage>(
@@ -226,23 +336,44 @@ impl Handler for PingHandler {
         request: &M,
     ) -> Result<Self::RequestData, Self::ExtractRequestError> {
         match request.code().into() {
-            coap_numbers::code::GET => Ok(ReqData::G),
+            coap_numbers::code::GET => {
+                let id = request
+                    .options()
+                    .find(|opt| opt.number() == URI_PATH)
+                    .and_then(|x| x.value_str().and_then(|y| y.parse::<u64>().ok()))
+                    .ok_or(Error::bad_request())?;
+
+                Ok(ReqData { x: Internal::G(id) })
+            }
+
+            coap_numbers::code::DELETE => {
+                let id = request
+                    .options()
+                    .find(|opt| opt.number() == URI_PATH)
+                    .and_then(|x| x.value_str().and_then(|y| y.parse::<u64>().ok()))
+                    .ok_or(Error::bad_request())?;
+
+                Ok(ReqData { x: Internal::D(id) })
+            }
+
             coap_numbers::code::POST => {
                 let payload: &[u8] = request.payload();
-                if payload.is_empty() || payload.len() > MAX_REQ_SZ {
-                    return Err(Error::bad_request());
-                }
                 let mut de = Decoder::new(payload);
-                Ok(ReqData::P(
-                    de.decode::<CborPingSchema>()
-                        .map_err(|_| Error::unsupported_content_format())?,
-                ))
+                let config = de
+                    .decode::<CborPingSchema>()
+                    .map_err(|_| Error::unsupported_content_format())?;
+
+                self.manager
+                    .init(config)
+                    .map_err(|()| Error::service_unavailable())?;
+
+                Ok(ReqData { x: Internal::P })
             }
             _ => Err(Error::method_not_allowed()),
         }
     }
 
-    fn estimate_length(&mut self, request: &Self::RequestData) -> usize {
+    fn estimate_length(&mut self, _request: &Self::RequestData) -> usize {
         //Taken from coap_messages
         1280 - 40 - 4 // does this correclty calculate the IPv6 minimum MTU?
     }
@@ -252,40 +383,37 @@ impl Handler for PingHandler {
         response: &mut M,
         request: Self::RequestData,
     ) -> Result<(), Self::BuildResponseError<M>> {
-        match request {
-            ReqData::P(cbor_ping_schema) => {
-                for t in cbor_ping_schema.targets {
-                    //Relaxed since its all on one thread ?
-                    match PING_QUEUE.try_send(InternalTarget {
-                        t,
-                        id: ID_COUNTER.fetch_add(1, Relaxed),
-                    }) {
-                        Ok(()) => response.set_code(Code::new(coap_numbers::code::CREATED)?),
-                        Err(_) => response.set_code(Code::new(coap_numbers::code::CONFLICT)?),
+        match request.x {
+            Internal::P => {
+                response.set_code(M::Code::new(CREATED)?);
+                Ok(())
+            }
+            Internal::G(id) => {
+                if let Some(x) = self.manager.get(id) {
+                    let out = &mut [0; 1024];
+                    let mut e = Encoder::new(&mut out[..]);
+
+                    match e.encode(x) {
+                        Ok(_) => {}
+                        Err(_) => response.set_code(M::Code::new(INTERNAL_SERVER_ERROR)?),
                     }
+                    response.set_code(M::Code::new(CONTENT)?);
+                    response.set_payload(out)?;
+                    Ok(())
+                } else {
+                    response.set_code(M::Code::new(NOT_FOUND)?);
+                    Ok(())
                 }
             }
-            ReqData::G => {
-                // Temporary PoC.
-                // The semantics of exposing statistics are intentionally left open.
-                let stats = critical_section::with(|cs| STAT_STORAGE.borrow_ref_mut(cs).pop())
-                    .unwrap_or_default();
-                let mut buffer = [0u8; 512];
-                let mut encoder = Encoder::new(&mut buffer[..]);
-                match encoder.encode(stats) {
-                    Ok(_) => response.set_payload(&buffer[..])?,
-                    Err(_) => {
-                        response.set_code(
-                            Code::new(coap_numbers::code::INTERNAL_SERVER_ERROR).unwrap(),
-                        );
-                    }
+            Internal::D(id) => {
+                if self.manager.delete(id).is_some() {
+                    response.set_code(M::Code::new(DELETED)?);
+                    Ok(())
+                } else {
+                    response.set_code(M::Code::new(INTERNAL_SERVER_ERROR)?);
+                    Ok(())
                 }
-            }
-            ReqData::BadRequest => {
-                response.set_code(Code::new(coap_numbers::code::BAD_REQUEST).unwrap());
             }
         }
-
-        Ok(())
     }
 }


### PR DESCRIPTION
# Description

This PR adds an initial proof-of-concept ping component to `ariel-os-coap`.

The current implementation provides:
- ICMP ping execution using `embassy-net`
- a worker pool for asynchronous ping tasks
- CoAP request handling for submitting ping targets
- CBOR decoding of ping requests
- basic collection of ping timing statistics

This is intended as a first implementation to validate the approach and gather feedback on the final API/resource model.

## Testing

Tested by:
- building the affected crate with `cargo check`

## Issues/PRs References

[Related to #2029](https://github.com/ariel-os/ariel-os/issues/2090)

## Open Questions

The following design points are intentionally left open for discussion:

- Should ping requests become explicit job resources (`POST` → job URI → poll/observe)?
- What should the final `GET` semantics for statistics be?
- Should statistics represent current state, a history/ring buffer, or streamed events?
- How should ping failures and error codes be represented?
- Should CoAP Observe be used for live updates once supported?

## Changelog Entry

<!-- changelog:begin -->
Adds an initial proof-of-concept CoAP ping component.
<!-- changelog:end -->

## Change Checklist

- [x] The commit history will be clean at the latest after applying autosquash.
- [x] I have followed the Coding Conventions.
- [x] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.