### PR TITLE
refactor: BLE stack handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,6 @@ dependencies = [
  "portable-atomic",
  "static_cell",
  "tinyrlibc",
- "trouble-host",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,13 +450,11 @@ dependencies = [
  "embassy-executor",
  "embassy-net-driver-channel 0.3.2",
  "embassy-rp",
- "embassy-sync 0.7.2",
  "embedded-hal-async",
  "embedded-io-async 0.6.1",
  "paste",
  "portable-atomic",
  "static_cell",
- "trouble-host",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,6 @@ dependencies = [
  "embedded-hal-async",
  "embedded-io 0.6.1",
  "embedded-storage-async",
- "trouble-host",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,6 @@ dependencies = [
  "defmt 1.1.1",
  "embassy-embedded-hal",
  "embassy-executor",
- "embassy-sync 0.7.2",
  "embassy-time",
  "embassy-time-driver",
  "embassy-time-queue-utils",
@@ -298,7 +297,6 @@ dependencies = [
  "paste",
  "portable-atomic",
  "static_cell",
- "trouble-host",
 ]
 
 [[package]]

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1392,6 +1392,7 @@ modules:
   - name: ble
     selects:
       - hw/ble
+      - hwrng
     env:
       global:
         FEATURES:
@@ -1409,7 +1410,6 @@ modules:
   - name: ble-cyw43
     selects:
       - has_ble_cyw43
-      - hwrng
     provides:
       - has_ble
     env:
@@ -1424,7 +1424,6 @@ modules:
   - name: ble-nrf
     selects:
       - has_ble_nrf
-      - hwrng
     provides:
       - has_ble
 
@@ -1696,7 +1695,6 @@ modules:
     selects:
       - alloc
       - has_ble_esp
-      - hwrng
     provides:
       - has_ble
     env:

--- a/src/ariel-os-embassy/src/ble.rs
+++ b/src/ariel-os-embassy/src/ble.rs
@@ -9,20 +9,37 @@
 //!
 //! The address is not currently rotated during execution; however this behavior may not be relied upon.
 
-use embassy_sync::once_lock::OnceLock;
+use ariel_os_embassy_common::cell::SameExecutorCell;
+use embassy_executor::Spawner;
+use embassy_sync::{
+    blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex, once_lock::OnceLock,
+};
 use futures_util::FutureExt as _;
+use static_cell::StaticCell;
 use trouble_host::{
-    Address,
-    prelude::{AddrKind, BdAddr},
+    Address, Stack,
+    prelude::{AddrKind, BdAddr, DefaultPacketPool},
 };
 
 use ariel_os_embassy_common::ble::Config;
 use ariel_os_log::debug;
 
-// Must be async and return &trouble_host::Stack<'static, impl Controller>
-pub use crate::hal::ble::ble_stack;
+use crate::hal::ble::BleController;
+
+/// The BLE Stack, representing access to this device's BLE controller.
+/// This type is returned by [`ble_stack()`].
+///
+/// It is a [`trouble_host::Stack`] configured with an appropriate BLE controller and the default
+/// packet pool.
+pub type BleStack = Stack<'static, BleController, DefaultPacketPool>;
 
 static CURRENT_ADDRESS: OnceLock<Address> = OnceLock::new();
+#[allow(dead_code)]
+static STACK: StaticCell<SameExecutorCell<BleStack>> = StaticCell::new();
+// The stack can effectively only be taken by a single application; once taken, the Option is None.
+static STACKREF: OnceLock<
+    Mutex<CriticalSectionRawMutex, Option<&'static mut SameExecutorCell<BleStack>>>,
+> = OnceLock::new();
 
 #[allow(dead_code, reason = "false positive during builds outside of laze")]
 pub(crate) fn config() -> Config {
@@ -68,4 +85,41 @@ fn get_random_addr() -> [u8; 6] {
         "CONFIG_BLE_STATIC_ADDRESS",
         "static address for BLE in format XX:XX:XX:XX:XX:XX",
     )
+}
+
+/// Returns the system BLE stack, [`BleStack`].
+///
+/// # Panics
+///
+/// For this function to succeed, it can only be called from the system executor, and only once:
+///
+/// - Panics if the stack was already taken.
+/// - Panics when not called from the system executor.
+#[doc(alias = "bluetooth_stack")]
+pub async fn ble_stack() -> &'static mut BleStack {
+    STACKREF
+        .get()
+        .await
+        .try_lock()
+        .expect("Two tasks racing for lock, one would fail the main-executor check")
+        .take()
+        .expect("Stack was already taken")
+        .get_mut_async()
+        .await
+        .expect("Stack needs to be taken from main executor")
+}
+
+#[allow(dead_code, reason = "false positive during builds outside of laze")]
+pub(crate) fn init_stack(controller: crate::hal::ble::BleController, spawner: Spawner) {
+    let config = config();
+    let mut rng = ariel_os_random::crypto_rng();
+
+    let resources = ariel_os_embassy_common::ble::get_ble_host_resources();
+
+    let stack = trouble_host::new(controller, resources)
+        .set_random_generator_seed(&mut rng)
+        .set_random_address(config.address);
+
+    let stackref = STACK.init(SameExecutorCell::new(stack, spawner));
+    let _ = STACKREF.init(Some(stackref).into());
 }

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -333,12 +333,16 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     #[cfg(all(feature = "ble", not(any(context = "esp", context = "rp"))))]
     let ble_controller = hal::ble::build_controller(&mut peripherals, spawner);
 
-    #[cfg(all(feature = "ble-cyw43", not(feature = "wifi-cyw43")))]
-    let _ = hal::cyw43::device(&mut peripherals, &spawner, ble_config).await;
-    #[cfg(all(feature = "wifi-cyw43", not(feature = "ble-cyw43")))]
-    let (device, control) = hal::cyw43::device(&mut peripherals, &spawner).await;
-    #[cfg(all(feature = "ble-cyw43", feature = "wifi-cyw43"))]
-    let (device, control) = hal::cyw43::device(&mut peripherals, &spawner, ble_config).await;
+    #[cfg(any(feature = "ble-cyw43", feature = "wifi-cyw43"))]
+    let hal::cyw43::Cyw43Device {
+        #[cfg(feature = "ble-cyw43")]
+        ble_controller,
+        #[cfg(feature = "wifi-cyw43")]
+            net_device: device,
+        #[cfg(feature = "wifi-cyw43")]
+            net_control: control,
+        ..
+    } = hal::cyw43::device(&mut peripherals, &spawner).await;
 
     #[cfg(all(feature = "ble", context = "esp"))]
     hal::ble::init(&mut peripherals, &ble_config, spawner).await;

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -352,6 +352,9 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     #[cfg(feature = "wifi-esp")]
     let device = hal::wifi::esp_wifi::init(&mut peripherals, spawner);
 
+    #[cfg(feature = "ble")]
+    ble::init_stack(ble_controller, spawner);
+
     #[cfg(feature = "tuntap")]
     let device = crate::hal::tuntap::create();
     #[cfg(feature = "ltem-nrf-modem")]

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -237,11 +237,6 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     #[cfg(all(feature = "usb", context = "nrf"))]
     hal::usb::init();
 
-    // Move out the peripherals required for drivers, so that tasks cannot mistakenly take them.
-
-    #[cfg(all(feature = "ble", not(any(context = "esp", context = "rp"))))]
-    let ble_peripherals = hal::ble::Peripherals::new(&mut peripherals);
-
     #[cfg(feature = "usb")]
     let usb_peripherals = hal::usb::Peripherals::new(&mut peripherals);
 
@@ -250,11 +245,6 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     for task in EMBASSY_TASKS {
         task(spawner, &mut peripherals);
     }
-
-    #[cfg(feature = "ble")]
-    let ble_config = ble::config();
-    #[cfg(all(feature = "ble", not(any(context = "esp", context = "rp"))))]
-    hal::ble::driver(ble_peripherals, spawner, ble_config);
 
     #[cfg(feature = "nrf91-modem")]
     {
@@ -339,6 +329,9 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
         let usb = usb_builder.build();
         spawner.spawn(usb::usb_task(usb)).unwrap();
     }
+
+    #[cfg(all(feature = "ble", not(any(context = "esp", context = "rp"))))]
+    let ble_controller = hal::ble::build_controller(&mut peripherals, spawner);
 
     #[cfg(all(feature = "ble-cyw43", not(feature = "wifi-cyw43")))]
     let _ = hal::cyw43::device(&mut peripherals, &spawner, ble_config).await;

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -330,7 +330,7 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
         spawner.spawn(usb::usb_task(usb)).unwrap();
     }
 
-    #[cfg(all(feature = "ble", not(any(context = "esp", context = "rp"))))]
+    #[cfg(all(feature = "ble", not(context = "rp")))]
     let ble_controller = hal::ble::build_controller(&mut peripherals, spawner);
 
     #[cfg(any(feature = "ble-cyw43", feature = "wifi-cyw43"))]
@@ -344,13 +344,11 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
         ..
     } = hal::cyw43::device(&mut peripherals, &spawner).await;
 
-    #[cfg(all(feature = "ble", context = "esp"))]
-    hal::ble::init(&mut peripherals, &ble_config, spawner).await;
-    #[cfg(feature = "wifi-esp")]
-    let device = hal::wifi::esp_wifi::init(&mut peripherals, spawner);
-
     #[cfg(feature = "ble")]
     ble::init_stack(ble_controller, spawner);
+
+    #[cfg(feature = "wifi-esp")]
+    let device = hal::wifi::esp_wifi::init(&mut peripherals, spawner);
 
     #[cfg(feature = "tuntap")]
     let device = crate::hal::tuntap::create();

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -48,8 +48,6 @@ static_cell = { workspace = true }
 
 # BLE dependencies
 bt-hci = { workspace = true, optional = true }
-embassy-sync = { workspace = true, optional = true }
-trouble-host = { workspace = true, optional = true }
 
 [target.'cfg(context = "esp32")'.dependencies]
 esp-bootloader-esp-idf = { workspace = true, features = ["esp32"] }
@@ -142,8 +140,6 @@ usb = []
 ## Enables BLE support.
 ble-esp = [
   "dep:bt-hci",
-  "dep:embassy-sync",
-  "dep:trouble-host",
   "_radio-esp",
   "ariel-os-embassy-common/ble",
   "ariel-os-random/csprng",

--- a/src/ariel-os-esp/src/ble.rs
+++ b/src/ariel-os-esp/src/ble.rs
@@ -1,60 +1,16 @@
 use bt_hci::controller::ExternalController;
 use embassy_executor::Spawner;
-use embassy_sync::{
-    blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex, once_lock::OnceLock,
-};
 use esp_radio::ble::controller::BleConnector;
-use static_cell::StaticCell;
-use trouble_host::prelude::DefaultPacketPool;
-
-use ariel_os_embassy_common::cell::SameExecutorCell;
 
 /// Number of command slots for the BLE driver.
 pub const SLOTS: usize = 10;
 
-pub type BleStack = trouble_host::Stack<
-    'static,
-    ExternalController<BleConnector<'static>, SLOTS>,
-    DefaultPacketPool,
->;
+pub type BleController = ExternalController<BleConnector<'static>, SLOTS>;
 
-pub(crate) static STACK: StaticCell<SameExecutorCell<BleStack>> = StaticCell::new();
-// The stack can effectively only be taken by a single application; once taken, the Option is None.
-pub(crate) static STACKREF: OnceLock<
-    Mutex<CriticalSectionRawMutex, Option<&'static mut SameExecutorCell<BleStack>>>,
-> = OnceLock::new();
-
-pub async fn init(
+pub fn build_controller<'a>(
     peripherals: &mut esp_hal::peripherals::OptionalPeripherals,
-    config: &ariel_os_embassy_common::ble::Config,
-    spawner: Spawner,
-) {
+    _spawner: Spawner,
+) -> BleController {
     let connector = BleConnector::new(peripherals.BT.take().unwrap(), Default::default()).unwrap();
-    let controller: ExternalController<_, SLOTS> = ExternalController::new(connector);
-    let resources = ariel_os_embassy_common::ble::get_ble_host_resources();
-    let mut rng = ariel_os_random::crypto_rng();
-    let stack = trouble_host::new(controller, resources)
-        .set_random_generator_seed(&mut rng)
-        .set_random_address(config.address);
-    let stackref = STACK.init(SameExecutorCell::new(stack, spawner));
-    // Error case is unreachable: just init'ed another once item.
-    let _ = STACKREF.init(Some(stackref).into());
-}
-
-/// Returns the system ble stack.
-///
-/// # Panics
-/// - panics if the stack was already taken
-/// - panics when not called from the main executor
-pub async fn ble_stack() -> &'static mut BleStack {
-    STACKREF
-        .get()
-        .await
-        .try_lock()
-        .expect("Two tasks racing for lock, one would fail the main-executor check")
-        .take()
-        .expect("Stack was already taken")
-        .get_mut_async()
-        .await
-        .expect("Stack needs to be taken from main executor")
+    ExternalController::new(connector)
 }

--- a/src/ariel-os-hal/Cargo.toml
+++ b/src/ariel-os-hal/Cargo.toml
@@ -43,7 +43,6 @@ ariel-os-embassy-common = { workspace = true }
 # For ble dummy implementation
 bt-hci = { workspace = true, optional = true }
 embedded-io = { workspace = true, optional = true }
-trouble-host = { workspace = true, optional = true }
 
 [features]
 external-interrupts = [
@@ -99,7 +98,6 @@ usb = [
 ble = [
   "dep:bt-hci",
   "dep:embedded-io",
-  "dep:trouble-host",
   "ariel-os-embassy-common/ble",
   "ariel-os-nrf/ble",
 ]

--- a/src/ariel-os-hal/src/hal/dummy/ble.rs
+++ b/src/ariel-os-hal/src/hal/dummy/ble.rs
@@ -3,30 +3,18 @@ use bt_hci::{
     controller::{ControllerCmdAsync, ControllerCmdSync},
 };
 use embassy_executor::Spawner;
-use trouble_host::{Stack, prelude::DefaultPacketPool};
 
-pub struct Peripherals {}
+// Export the BLE controller type for this device.
+pub type BleController = DummyController;
 
-impl Peripherals {
-    pub fn new(_peripherals: &mut crate::hal::OptionalPeripherals) -> Self {
-        unimplemented!();
-    }
-}
-
-/// Returns the system BLE stack, [`trouble_host::Stack`].
-///
-/// # Panics
-///
-/// For this function to succeed, it can only be called from the system executor, and only once:
-///
-/// - Panics if the stack was already taken.
-/// - Panics when not called from the system executor.
-#[doc(alias = "bluetooth_stack")]
-pub async fn ble_stack() -> &'static Stack<'static, DummyController, DefaultPacketPool> {
-    async { unimplemented!() }.await
-}
-
-pub fn driver(_p: Peripherals, _spawner: Spawner, _config: ariel_os_embassy_common::ble::Config) {
+// This is the function called by default by `ariel-os-embassy` to initialize the BLE driver,
+// if BLE initialization is tied to WiFi initialization, make a special case in `ariel-os-embassy`.
+/// Build a BLE controller for this device.
+#[must_use]
+pub fn build_controller(
+    _p: &mut crate::hal::OptionalPeripherals,
+    _spawner: Spawner,
+) -> BleController {
     unimplemented!();
 }
 

--- a/src/ariel-os-nrf/Cargo.toml
+++ b/src/ariel-os-nrf/Cargo.toml
@@ -30,7 +30,6 @@ paste = { workspace = true }
 portable-atomic = { workspace = true }
 static_cell = { workspace = true }
 tinyrlibc = { workspace = true, optional = true }
-trouble-host = { workspace = true, optional = true }
 
 embassy-futures = { workspace = true, optional = true }
 embassy-net = { workspace = true, optional = true }
@@ -99,7 +98,6 @@ usb = []
 ## Enables BLE support.
 ble = [
   "dep:nrf-sdc",
-  "dep:trouble-host",
   "ariel-os-embassy-common/ble",
   "ariel-os-random/csprng",
   "hwrng",

--- a/src/ariel-os-nrf/src/ble.rs
+++ b/src/ariel-os-nrf/src/ble.rs
@@ -1,28 +1,20 @@
 use embassy_executor::Spawner;
 use embassy_nrf::peripherals;
-use embassy_sync::{
-    blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex, once_lock::OnceLock,
-};
+
 use nrf_sdc::{
     self as sdc, SoftdeviceController,
     mpsl::{self, MultiprotocolServiceLayer},
 };
 
 use static_cell::StaticCell;
-use trouble_host::{Stack, prelude::DefaultPacketPool};
 
-use ariel_os_embassy_common::{ble::MTU, cell::SameExecutorCell};
+use ariel_os_embassy_common::ble::MTU;
 use ariel_os_log::debug;
 
 use crate::{irqs::Irqs, peripheral::Peri};
 
-pub type BleStack = Stack<'static, SoftdeviceController<'static>, DefaultPacketPool>;
+pub type BleController = SoftdeviceController<'static>;
 
-static STACK: StaticCell<SameExecutorCell<BleStack>> = StaticCell::new();
-// The stack can effectively only be taken by a single application; once taken, the Option is None.
-static STACKREF: OnceLock<
-    Mutex<CriticalSectionRawMutex, Option<&'static mut SameExecutorCell<BleStack>>>,
-> = OnceLock::new();
 static MPSL: StaticCell<MultiprotocolServiceLayer<'_>> = StaticCell::new();
 static SDC_MEM: StaticCell<sdc::Mem<SDC_MEM_SIZE>> = StaticCell::new();
 static RNG: StaticCell<ariel_os_random::CryptoRngSend> = StaticCell::new();
@@ -66,24 +58,6 @@ const SDC_MEM_SIZE: usize = 6080;
 const L2CAP_TXQ: u8 = 3;
 // Size of the RX buffer (number of packets), minimum is 1, SoftDevice default is 2 (SDC_DEFAULT_RX_PACKET_COUNT).
 const L2CAP_RXQ: u8 = 2;
-
-/// Returns the system ble stack.
-///
-/// # Panics
-/// - panics if the stack was already taken
-/// - panics when not called from the main executor
-pub async fn ble_stack() -> &'static mut BleStack {
-    STACKREF
-        .get()
-        .await
-        .try_lock()
-        .expect("Two tasks racing for lock, one would fail the main-executor check")
-        .take()
-        .expect("Stack was already taken")
-        .get_mut_async()
-        .await
-        .expect("Stack needs to be taken from main executor")
-}
 
 #[cfg(context = "nrf52")]
 pub struct Peripherals {
@@ -197,11 +171,12 @@ impl Peripherals {
 ///
 /// # Panics
 /// Panics if initialization fails on one of the components, such as MPSL or SDC.
-#[expect(
-    clippy::needless_pass_by_value,
-    reason = "keeping consistency with other initialization functions"
-)]
-pub fn driver(p: Peripherals, spawner: Spawner, config: ariel_os_embassy_common::ble::Config) {
+pub fn build_controller(
+    peripherals: &mut crate::OptionalPeripherals,
+    spawner: Spawner,
+) -> BleController {
+    let p = Peripherals::new(peripherals);
+
     debug!("Initializing nRF BLE driver");
     #[cfg(context = "nrf52")]
     let mpsl_p =
@@ -239,16 +214,7 @@ pub fn driver(p: Peripherals, spawner: Spawner, config: ariel_os_embassy_common:
 
     let sdc_mem = SDC_MEM.init(sdc::Mem::new());
 
-    let sdc = build_sdc(sdc_p, rng, mpsl, sdc_mem).expect("Failed to build SDC");
-
-    let resources = ariel_os_embassy_common::ble::get_ble_host_resources();
-
-    let stack = trouble_host::new(sdc, resources).set_random_address(config.address);
-    let stackref = STACK.init(SameExecutorCell::new(stack, spawner));
-    // Error case is unreachable: just init'ed another once item.
-    let _ = STACKREF.init(Some(stackref).into());
-
-    debug!("nRF BLE driver initialized");
+    build_sdc(sdc_p, rng, mpsl, sdc_mem).expect("Failed to build SDC")
 }
 
 #[embassy_executor::task]

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -33,8 +33,6 @@ cyw43-pio = { version = "0.8.0", optional = true }
 
 # BLE dependencies
 bt-hci = { workspace = true, optional = true }
-embassy-sync = { workspace = true, optional = true }
-trouble-host = { workspace = true, optional = true }
 
 [build-dependencies]
 ariel-os-buildutils = { workspace = true }
@@ -86,8 +84,6 @@ ble = ["ariel-os-embassy-common/ble"]
 
 ble-cyw43 = [
   "dep:bt-hci",
-  "dep:embassy-sync",
-  "dep:trouble-host",
   "_cyw43",
   "ariel-os-random/csprng",
   "ble",

--- a/src/ariel-os-rp/src/ble.rs
+++ b/src/ariel-os-rp/src/ble.rs
@@ -1,38 +1,7 @@
 use bt_hci::controller::ExternalController;
 use cyw43::bluetooth::BtDriver;
-use embassy_sync::{
-    blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex, once_lock::OnceLock,
-};
-use static_cell::StaticCell;
-use trouble_host::{Stack, prelude::DefaultPacketPool};
 
-use ariel_os_embassy_common::cell::SameExecutorCell;
-
-pub type BleStack = Stack<'static, ExternalController<BtDriver<'static>, SLOTS>, DefaultPacketPool>;
+pub type BleController = ExternalController<BtDriver<'static>, SLOTS>;
 
 /// Number of command slots for the Bluetooth driver.
 pub const SLOTS: usize = 10;
-
-pub(crate) static STACK: StaticCell<SameExecutorCell<BleStack>> = StaticCell::new();
-// The stack can effectively only be taken by a single application; once taken, the Option is None.
-pub(crate) static STACKREF: OnceLock<
-    Mutex<CriticalSectionRawMutex, Option<&'static mut SameExecutorCell<BleStack>>>,
-> = OnceLock::new();
-
-/// Returns the system ble stack.
-///
-/// # Panics
-/// - panics if the stack was already taken
-/// - panics when not called from the main executor
-pub async fn ble_stack() -> &'static mut BleStack {
-    STACKREF
-        .get()
-        .await
-        .try_lock()
-        .expect("Two tasks racing for lock, one would fail the main-executor check")
-        .take()
-        .expect("Stack was already taken")
-        .get_mut_async()
-        .await
-        .expect("Stack needs to be taken from main executor")
-}

--- a/src/ariel-os-rp/src/cyw43.rs
+++ b/src/ariel-os-rp/src/cyw43.rs
@@ -14,15 +14,9 @@ use rpi_pico_w::{CywSpi, DEFAULT_CLOCK_DIVIDER, Irqs};
 use static_cell::StaticCell;
 
 #[cfg(feature = "ble-cyw43")]
-use ariel_os_embassy_common::cell::SameExecutorCell;
-
-#[cfg(feature = "ble-cyw43")]
 use bt_hci::controller::ExternalController;
 #[cfg(feature = "wifi")]
 use cyw43::JoinOptions;
-
-#[cfg(feature = "ble-cyw43")]
-use crate::ble::{self, SLOTS};
 
 pub type NetworkDevice = cyw43::NetDriver<'static>;
 
@@ -56,14 +50,21 @@ async fn wifi_cyw43_task(runner: Runner<'static, Output<'static>, CywSpi>) -> ! 
     runner.run().await
 }
 
+/// Data structures returned by [`device()`].
+pub struct Cyw43Device<'b> {
+    pub net_device: embassy_net_driver_channel::Device<'b, 1514>,
+    pub net_control: Control<'b>,
+    #[cfg(feature = "ble-cyw43")]
+    pub ble_controller: crate::ble::BleController,
+}
+
 /// # Panics
 ///
 /// Panics if we fail to launch the cyw43 runner task.
 pub async fn device<'a, 'b: 'a>(
     peripherals: &'a mut crate::OptionalPeripherals,
     spawner: &Spawner,
-    #[cfg(feature = "ble-cyw43")] config: ariel_os_embassy_common::ble::Config,
-) -> (embassy_net_driver_channel::Device<'b, 1514>, Control<'b>) {
+) -> Cyw43Device<'b> {
     let pins = rpi_pico_w::take_pins(peripherals);
 
     let fw = cyw43_firmware::CYW43_43439A0;
@@ -93,24 +94,16 @@ pub async fn device<'a, 'b: 'a>(
     );
 
     #[cfg(not(feature = "ble-cyw43"))]
-    let (net_device, mut control, runner) =
+    let (net_device, mut net_control, runner) =
         cyw43::new(STATE.init_with(cyw43::State::new), pwr, spi, fw).await;
 
     #[cfg(feature = "ble-cyw43")]
-    let (net_device, mut control, runner) = {
+    let (net_device, mut net_control, runner, ble_controller) = {
         let (net_device, bt_device, control, runner) =
             cyw43::new_with_bluetooth(STATE.init_with(cyw43::State::new), pwr, spi, fw, btfw).await;
-        let controller: ExternalController<_, SLOTS> = ExternalController::new(bt_device);
-        let resources = ariel_os_embassy_common::ble::get_ble_host_resources();
-        let mut rng = ariel_os_random::crypto_rng();
-        let stack = trouble_host::new(controller, resources)
-            .set_random_generator_seed(&mut rng)
-            .set_random_address(config.address);
-        let stackref = ble::STACK.init(SameExecutorCell::new(stack, *spawner));
-        // Error case is unreachable: just init'ed another once item.
-        let _ = ble::STACKREF.init(Some(stackref).into());
+        let ble_controller = ExternalController::new(bt_device);
 
-        (net_device, control, runner)
+        (net_device, control, runner, ble_controller)
     };
 
     // control
@@ -120,7 +113,12 @@ pub async fn device<'a, 'b: 'a>(
     // this needs to be spawned here (before using `control`)
     spawner.spawn(wifi_cyw43_task(runner)).unwrap();
 
-    control.init(clm).await;
+    net_control.init(clm).await;
 
-    (net_device, control)
+    Cyw43Device {
+        net_device,
+        net_control,
+        #[cfg(feature = "ble-cyw43")]
+        ble_controller,
+    }
 }


### PR DESCRIPTION
# Description

This refactors how the BLE stack is managed in Ariel OS, drivers now have to provide the controller instead of the whole Stack.

This factors out the initialization of the stack, so its configuration can be done in one unique place in the code.

```
laze -C examples/ble-scanner/ build -b seeedstudio-xiao-esp32c6 run
laze -C examples/ble-scanner/ build -b rpi-pico-w run
laze -C examples/ble-scanner/ build -b nrf52840dk run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
