### PR TITLE
[codex] Make wildcard exports explicit

### DIFF
--- a/src/ariel-os/src/lib.rs
+++ b/src/ariel-os/src/lib.rs
@@ -33,8 +33,14 @@ pub use ariel_os_buildinfo as buildinfo;
 pub use ariel_os_coap as coap;
 #[doc(inline)]
 pub use ariel_os_debug as debug;
+#[cfg(feature = "i2c")]
 #[doc(inline)]
-pub use ariel_os_hal::api::*;
+pub use ariel_os_hal::api::i2c;
+#[cfg(feature = "uart")]
+#[doc(inline)]
+pub use ariel_os_hal::api::uart;
+#[doc(inline)]
+pub use ariel_os_hal::api::{gpio, hal};
 #[doc(inline)]
 pub use ariel_os_identity as identity;
 #[doc(inline)]
@@ -60,7 +66,17 @@ pub use ariel_os_macros::task;
 #[cfg(any(feature = "threading", doc))]
 pub use ariel_os_macros::thread;
 
-pub use ariel_os_embassy::api::*;
+#[cfg(feature = "ble")]
+pub use ariel_os_embassy::api::ble;
+#[cfg(feature = "net")]
+pub use ariel_os_embassy::api::net;
+#[cfg(feature = "spi")]
+pub use ariel_os_embassy::api::spi;
+#[cfg(feature = "time")]
+pub use ariel_os_embassy::api::time;
+#[cfg(feature = "usb")]
+pub use ariel_os_embassy::api::usb;
+pub use ariel_os_embassy::api::{EMBASSY_TASKS, asynch, cell, delegate};
 
 pub mod config {
     //! Provides configuration to the system and the application.


### PR DESCRIPTION
## Summary

- replace the wildcard re-exports from `ariel_os_hal::api` and `ariel_os_embassy::api` with explicit exports
- apply the matching Ariel OS feature gate to each optional API module
- preserve the unconditional exports for the always-available APIs

## Why

Wildcard re-exports hide the relevant `cfg` metadata from downstream compiler diagnostics. Putting the feature gates on the `ariel-os` facade exports lets Rust explain that a missing API was configured out and name the feature required to enable it.

## Validation

- `cargo fmt --check --all -- --config format_generated_files=false`
- positive consumer compile importing all 13 explicit exports with their required features enabled
- negative consumer compile without `net`, confirming the diagnostic says the item was configured out and is gated behind the `net` feature
- `git diff --check`

Closes #2099
