### PR TITLE
refactor(log): add custom transport connector

### DIFF
--- a/src/ariel-os-log/Cargo.toml
+++ b/src/ariel-os-log/Cargo.toml
@@ -10,9 +10,15 @@ license.workspace = true
 logging-facade.xor = { features = ["defmt", "log"] }
 logging-transport.xor = { features = [
   "logging-over-debug-channel",
+  "internal-transport-driver",
+  "custom-transport-driver",
   "logging-over-uart",
   "logging-over-usb",
 ] }
+
+# Temporary, refuse to have defmt as a frontend when we use a pluggable transport.
+# Remove this when a defmt logger is implemented for pluggable transports.
+transport-defmt-conflict.xor = { features = ["defmt", "_pluggable-transport"] }
 
 [package.metadata.feature-groups.features]
 defmt-rtt.requires = { features = ["logging-over-debug-channel"] }
@@ -58,6 +64,9 @@ log = ["dep:ariel-os-utils", "dep:const-str", "dep:critical-section", "dep:log"]
 # Enables the `esp-println` crate.
 esp-println = ["dep:esp-println"]
 
+# Pluggable transport, has to be enabled by other features like "internal-transport-driver".
+_pluggable-transport = ["dep:embassy-sync"]
+
 # Logging transports.
 debug-uart = ["dep:embassy-sync", "logging-over-uart"]
 # `defmt-rtt` uses the debug channel as the logging transport, so it has to go
@@ -67,6 +76,11 @@ defmt-rtt = ["ariel-os-debug/defmt-rtt"]
 logging-over-debug-channel = ["dep:ariel-os-debug"]
 logging-over-uart = ["esp-println?/uart"]
 logging-over-usb = ["esp-println?/jtag-serial"]
+# Connect log transports that are implemented inside Ariel OS' repo.
+internal-transport-driver = ["_pluggable-transport"]
+# Connect log transports implemented in an application.
+custom-transport-driver = ["_pluggable-transport"]
+
 std = []
 
 _test = []

--- a/src/ariel-os-log/src/lib.rs
+++ b/src/ariel-os-log/src/lib.rs
@@ -21,6 +21,10 @@
 #[featurecomb::comb]
 mod _featurecomb {}
 
+#[doc(hidden)]
+#[cfg(feature = "_pluggable-transport")]
+pub mod transport;
+
 #[allow(unused, reason = "conditional compilation")]
 #[doc(hidden)]
 #[cfg(feature = "log")]
@@ -91,6 +95,9 @@ pub mod log {
         }
         feature = "std" => {
             pub use std::println;
+        }
+        feature = "custom-transport" => {
+            pub use crate::transport_println as println;
         }
         not(context = "ariel-os") => {
             pub use crate::noop_println as println;

--- a/src/ariel-os-log/src/transport.rs
+++ b/src/ariel-os-log/src/transport.rs
@@ -1,0 +1,78 @@
+//! Connector to logging transports.
+//!
+//! ## For implementors
+//!
+//! Log transport implementations outside of this crate have to register their `write_bytes` and `flush`
+//! functions using [`register_transport_functions`].
+//!
+//! Those functions should not wait for interrupts when called as they may be ran in a
+//! critical section context. The execution of those functions should not trigger calls to the
+//! logging facade as that would create an infinite logging cycle (or a crash in the case of defmt).
+
+// Custom logging transport implementations end up depending on the HAL, that then depends on
+// `ariel-os-log`, creating a circular dependency. Connecting log transports like this helps break
+// the cycle.
+
+use embassy_sync::once_lock::OnceLock;
+
+static TRANSPORT_WRITE_BYTES_FN: OnceLock<fn(&[u8])> = OnceLock::new();
+static TRANSPORT_FLUSH_FN: OnceLock<fn()> = OnceLock::new();
+
+/// Register custom transport functions.
+///
+/// - `write_bytes_fn` is used to write bytes to the transport. Depending on the logging facade it
+///   may be UTF-8 encoded text or raw binary data.
+/// - `flush_fn` is used to flush the data in the transport. Currently it is only used when defmt is
+///   the logging facade.
+///
+/// ## Critical section
+///
+/// `write_bytes_fn` and `flush_fn` may be executed inside a critical section, disabling interrupts.
+/// They should not wait for interrupts and should not trigger calls to the logging facade.
+pub fn register_transport_functions(write_bytes_fn: fn(&[u8]), flush_fn: fn()) {
+    let _ = TRANSPORT_WRITE_BYTES_FN.init(write_bytes_fn);
+    let _ = TRANSPORT_FLUSH_FN.init(flush_fn);
+}
+
+// Write bytes to the transport if available.
+pub(crate) fn write_bytes(bytes: &[u8]) {
+    if let Some(write_fn) = TRANSPORT_WRITE_BYTES_FN.try_get() {
+        write_fn(bytes);
+    }
+}
+
+#[allow(unused, reason = "conditional compilation")]
+#[cfg(feature = "defmt")]
+// Flush the data in the transport if available.
+pub(crate) fn flush() {
+    if let Some(flush_fn) = TRANSPORT_FLUSH_FN.try_get() {
+        flush_fn();
+    }
+}
+
+struct Transport;
+
+impl core::fmt::Write for Transport {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let bytes = s.as_bytes();
+        write_bytes(bytes);
+        Ok(())
+    }
+}
+
+// Based on <https://blog.m-ou.se/format-args/>.
+#[doc(hidden)]
+pub fn _print(args: core::fmt::Arguments<'_>) {
+    use core::fmt::Write as _;
+
+    Transport.write_fmt(args).unwrap();
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! transport_println {
+    ($($arg:tt)*) => {{
+        #[expect(clippy::used_underscore_items, reason = "consistency with std::println")]
+        $crate::custom_transport::_print(format_args!("{}\n", format_args!($($arg)*)));
+    }};
+}


### PR DESCRIPTION
# Description

This adds the `ariel-os-log-transport` crate where the log transport implementations should be implemented.

## Testing

This doesn't change the behavior, there is no new implementation. You can test that everything is working as before: 

```
laze -C examples/log/ build -b nrf52840dk run     
laze -C examples/log/ build -b nrf52840dk -s log run 
laze -C examples/log/ build -b espressif-esp32-c6-devkitc-1 run
laze -C examples/log/ build -b espressif-esp32-c6-devkitc-1 -s log run
```
 
## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

~~Do we want to give the option for applications to set up out of tree logging transports ?
That would mean that there would be no logs until the application is started and it has registered the custom logging transport functions.~~ => Will be implemented in another PR.


## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
