### PR TITLE
feat(log): add generic usb cdc acm logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "ariel-os-hal",
  "ariel-os-identity",
  "ariel-os-log",
+ "ariel-os-log-transport-driver",
  "ariel-os-macros",
  "ariel-os-nrf",
  "ariel-os-power",
@@ -408,6 +409,8 @@ dependencies = [
  "ariel-os-hal",
  "ariel-os-log",
  "embassy-executor",
+ "embassy-sync 0.7.2",
+ "esp-hal",
 ]
 
 [[package]]
@@ -2927,7 +2930,6 @@ dependencies = [
  "esp-metadata-generated",
  "esp-sync",
  "log",
- "portable-atomic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "ariel-os-hal",
  "ariel-os-identity",
  "ariel-os-log",
+ "ariel-os-log-transport-driver",
  "ariel-os-macros",
  "ariel-os-random",
  "ariel-os-rt",
@@ -398,6 +399,15 @@ dependencies = [
  "esp-println",
  "featurecomb",
  "log",
+]
+
+[[package]]
+name = "ariel-os-log-transport-driver"
+version = "0.5.0"
+dependencies = [
+ "ariel-os-hal",
+ "ariel-os-log",
+ "embassy-executor",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
   "src/ariel-os-hal",
   "src/ariel-os-identity",
   "src/ariel-os-log",
+  "src/ariel-os-log-transport-driver",
   "src/ariel-os-macros",
   "src/ariel-os-nrf",
   "src/ariel-os-power",
@@ -137,6 +138,7 @@ ariel-os-esp = { path = "src/ariel-os-esp" }
 ariel-os-hal = { path = "src/ariel-os-hal", default-features = false }
 ariel-os-identity = { path = "src/ariel-os-identity" }
 ariel-os-log = { path = "src/ariel-os-log", default-features = false }
+ariel-os-log-transport-driver = { path = "src/ariel-os-log-transport-driver" }
 ariel-os-macros = { path = "src/ariel-os-macros" }
 ariel-os-nrf = { path = "src/ariel-os-nrf" }
 ariel-os-power = { path = "src/ariel-os-power" }

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1935,16 +1935,22 @@ modules:
   - name: logging-over-usb
     help: use USB CDC-ACM as logging transport
     selects:
-      # Temporarily restricted to ESP32s having a USB CDC-ACM/JTAG USB peripheral.
-      - usb-cdc-acm-esp
-      - context::esp:
-          - esp-println
+      - ?logging-over-usb-cdc-acm-esp
+      - usb-log-transport
     provides_unique:
       - logging-transport
+
+  - name: logging-over-usb-cdc-acm-esp
+    context:
+      - esp
+    selects:
+      - usb-cdc-acm-esp
+    provides_unique:
+      - usb-log-transport
     env:
       global:
         FEATURES:
-          - ariel-os/logging-over-usb
+          - ariel-os/logging-over-usb-cdc-acm-esp
 
   - name: logging-over-uart
     help: use UART as logging transport

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -39,6 +39,7 @@ ariel-os-embassy-common = { workspace = true }
 ariel-os-hal = { path = "../ariel-os-hal" }
 ariel-os-identity = { path = "../ariel-os-identity" }
 ariel-os-log = { workspace = true }
+ariel-os-log-transport-driver = { workspace = true, optional = true }
 ariel-os-macros = { path = "../ariel-os-macros" }
 ariel-os-random = { path = "../ariel-os-random", optional = true }
 ariel-os-rt = { path = "../ariel-os-rt" }
@@ -224,6 +225,10 @@ defmt = [
   "usbd-hid?/defmt",
 ]
 log = ["ariel-os-hal/log"]
+
+# Use a log transport driver implemented in `ariel-os-log-transport-driver`.
+# The protocol used is selected with features in `ariel-os`.
+log-transport-driver = ["dep:ariel-os-log-transport-driver"]
 
 _test = ["dhcpv4", "external-interrupts", "i2c", "spi", "time"]
 

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -205,6 +205,8 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
 
     #[cfg(feature = "debug-uart")]
     debug_uart::init(&mut peripherals);
+    #[cfg(feature = "log-transport-driver")]
+    ariel_os_log_transport_driver::init(&mut peripherals, spawner);
 
     debug!("ariel-os-embassy::init_task()");
 

--- a/src/ariel-os-log-transport-driver/Cargo.toml
+++ b/src/ariel-os-log-transport-driver/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ariel-os-log-transport-driver"
+version = "0.5.0"
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+ariel-os-hal = { workspace = true }
+ariel-os-log = { workspace = true, features = ["custom-transport"] }
+embassy-executor = { workspace = true }
+
+[features]
+
+_test = []
+
+[lints]
+workspace = true

--- a/src/ariel-os-log-transport-driver/Cargo.toml
+++ b/src/ariel-os-log-transport-driver/Cargo.toml
@@ -10,8 +10,11 @@ license.workspace = true
 ariel-os-hal = { workspace = true }
 ariel-os-log = { workspace = true, features = ["custom-transport"] }
 embassy-executor = { workspace = true }
+embassy-sync = { workspace = true, optional = true }
+esp-hal = { workspace = true, optional = true }
 
 [features]
+usb-cdc-acm-esp = ["dep:embassy-sync", "dep:esp-hal"]
 
 _test = []
 

--- a/src/ariel-os-log-transport-driver/laze.yml
+++ b/src/ariel-os-log-transport-driver/laze.yml
@@ -1,0 +1,4 @@
+apps:
+  - name: crates/ariel-os-log-transport-driver
+    selects:
+      - host-test-only

--- a/src/ariel-os-log-transport-driver/src/dummy.rs
+++ b/src/ariel-os-log-transport-driver/src/dummy.rs
@@ -1,0 +1,12 @@
+use embassy_executor::Spawner;
+
+use ariel_os_hal::hal::OptionalPeripherals;
+
+pub(crate) fn write_bytes(_bytes: &[u8]) {}
+
+pub(crate) fn flush() {}
+
+/// Initialize the custom transport driver.
+pub fn init(_peripherals: &mut OptionalPeripherals, _spawner: Spawner) {
+    ariel_os_log::custom_transport::register_transport_fns(write_bytes, flush);
+}

--- a/src/ariel-os-log-transport-driver/src/lib.rs
+++ b/src/ariel-os-log-transport-driver/src/lib.rs
@@ -1,0 +1,12 @@
+//! Provides logging transport adapters.
+
+#![cfg_attr(not(test), no_std)]
+#![cfg_attr(nightly, feature(doc_cfg))]
+#![deny(missing_docs)]
+
+cfg_select! {
+    _ => {
+        mod dummy;
+        pub use dummy::init;
+    }
+}

--- a/src/ariel-os-log-transport-driver/src/lib.rs
+++ b/src/ariel-os-log-transport-driver/src/lib.rs
@@ -5,6 +5,10 @@
 #![deny(missing_docs)]
 
 cfg_select! {
+    feature = "usb-cdc-acm-esp" => {
+        mod usb_cdc_acm_esp;
+        pub use usb_cdc_acm_esp::init;
+    }
     _ => {
         mod dummy;
         pub use dummy::init;

--- a/src/ariel-os-log-transport-driver/src/usb_cdc_acm_esp.rs
+++ b/src/ariel-os-log-transport-driver/src/usb_cdc_acm_esp.rs
@@ -1,0 +1,33 @@
+use embassy_executor::Spawner;
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
+use esp_hal::{Blocking, usb_serial_jtag::UsbSerialJtag};
+
+use ariel_os_hal::hal::OptionalPeripherals;
+
+static WRITER: Mutex<CriticalSectionRawMutex, Option<UsbSerialJtag<'_, Blocking>>> =
+    Mutex::new(None);
+
+pub(crate) fn write_bytes(bytes: &[u8]) {
+    if let Ok(mut opt) = WRITER.try_lock()
+        && let Some(writer) = opt.as_mut()
+    {
+        writer.write(bytes);
+    }
+}
+pub(crate) fn flush() {
+    if let Ok(mut opt) = WRITER.try_lock()
+        && let Some(writer) = opt.as_mut()
+    {
+        writer.flush_tx();
+    }
+}
+
+/// Initialize the USB CDC ACM transport using the special jtag/serial ESP peripheral.
+pub fn init(peripherals: &mut OptionalPeripherals, _spawner: Spawner) {
+    let w = UsbSerialJtag::new(peripherals.USB_DEVICE.take().unwrap());
+
+    let mut writer = WRITER.try_lock().unwrap();
+    writer.replace(w);
+
+    ariel_os_log::custom_transport::register_transport_functions(write_bytes, flush);
+}

--- a/src/ariel-os-log/Cargo.toml
+++ b/src/ariel-os-log/Cargo.toml
@@ -12,7 +12,6 @@ logging-transport.xor = { features = [
   "custom-transport",
   "defmt-rtt",
   "logging-over-uart",
-  "logging-over-usb",
 ] }
 
 [dependencies]
@@ -63,8 +62,7 @@ defmt-rtt = ["dep:ariel-os-debug", "ariel-os-debug/defmt-rtt"]
 # Using the debug channel as the transport
 debug-channel = ["dep:ariel-os-debug"]
 logging-over-uart = ["esp-println?/uart"]
-logging-over-usb = ["esp-println?/jtag-serial"]
-custom-transport = []
+custom-transport = ["dep:embassy-sync"]
 std = []
 
 _test = []

--- a/src/ariel-os-log/Cargo.toml
+++ b/src/ariel-os-log/Cargo.toml
@@ -9,13 +9,14 @@ license.workspace = true
 [package.metadata.feature-groups]
 logging-facade.xor = { features = ["defmt", "log"] }
 logging-transport.xor = { features = [
+  "custom-transport",
   "defmt-rtt",
   "logging-over-uart",
   "logging-over-usb",
 ] }
 
 [dependencies]
-ariel-os-debug = { workspace = true }
+ariel-os-debug = { workspace = true, optional = true }
 ariel-os-utils = { workspace = true, optional = true }
 const-str = { workspace = true, optional = true }
 critical-section = { workspace = true, optional = true }
@@ -58,9 +59,12 @@ esp-println = ["dep:esp-println"]
 debug-uart = ["dep:embassy-sync", "logging-over-uart"]
 # `defmt-rtt` uses the debug channel as the logging transport, so it has to go
 # through this crate.
-defmt-rtt = ["ariel-os-debug/defmt-rtt"]
+defmt-rtt = ["dep:ariel-os-debug", "ariel-os-debug/defmt-rtt"]
+# Using the debug channel as the transport
+debug-channel = ["dep:ariel-os-debug"]
 logging-over-uart = ["esp-println?/uart"]
 logging-over-usb = ["esp-println?/jtag-serial"]
+custom-transport = []
 std = []
 
 _test = []

--- a/src/ariel-os-log/Cargo.toml
+++ b/src/ariel-os-log/Cargo.toml
@@ -48,7 +48,7 @@ esp-println = { workspace = true, optional = true, features = ["esp32s3"] }
 
 [features]
 ## Enables `defmt` as logging facade.
-defmt = ["dep:defmt", "esp-println?/defmt-espflash"]
+defmt = ["dep:critical-section", "dep:defmt", "esp-println?/defmt-espflash"]
 ## Enables `log` as logging facade.
 log = ["dep:ariel-os-utils", "dep:const-str", "dep:critical-section", "dep:log"]
 

--- a/src/ariel-os-log/src/custom_transport.rs
+++ b/src/ariel-os-log/src/custom_transport.rs
@@ -1,0 +1,59 @@
+//! Connector to custom logging transports.
+//!
+//! ## For implementors
+//!
+//!  Custom logging transport implementations end up depending on the HAL, that then depends on
+//! `ariel-os-log`, creating a circular dependency.
+//! To break this circle, the custom implementations have to register their `write_bytes` and `flush`
+//! implementation with [`register_transport_fns`]
+
+use embassy_sync::once_lock::OnceLock;
+
+static TRANSPORT_WRITE_BYTES_FN: OnceLock<fn(&[u8])> = OnceLock::new();
+static TRANSPORT_FLUSH_FN: OnceLock<fn()> = OnceLock::new();
+
+/// Register custom transport functions.
+pub fn register_transport_functions(write_bytes_fn: fn(&[u8]), flush_fn: fn()) {
+    let _ = TRANSPORT_WRITE_BYTES_FN.init(write_bytes_fn);
+    let _ = TRANSPORT_FLUSH_FN.init(flush_fn);
+}
+
+pub(crate) fn write_bytes(bytes: &[u8]) {
+    if let Some(write_fn) = TRANSPORT_WRITE_BYTES_FN.try_get() {
+        write_fn(bytes);
+    }
+}
+
+#[cfg(feature = "defmt")]
+pub(crate) fn flush() {
+    if let Some(flush_fn) = TRANSPORT_FLUSH_FN.try_get() {
+        flush_fn();
+    }
+}
+
+struct Transport;
+
+impl core::fmt::Write for Transport {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let bytes = s.as_bytes();
+        write_bytes(bytes);
+        Ok(())
+    }
+}
+
+// Based on <https://blog.m-ou.se/format-args/>.
+#[doc(hidden)]
+pub fn _print(args: core::fmt::Arguments<'_>) {
+    use core::fmt::Write as _;
+
+    Transport.write_fmt(args).unwrap();
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! transport_println {
+    ($($arg:tt)*) => {{
+        #[expect(clippy::used_underscore_items, reason = "consistency with std::println")]
+        $crate::custom_transport::_print(format_args!("{}\n", format_args!($($arg)*)));
+    }};
+}

--- a/src/ariel-os-log/src/defmt_logger.rs
+++ b/src/ariel-os-log/src/defmt_logger.rs
@@ -1,0 +1,77 @@
+#![expect(unsafe_code)]
+
+/// Implementation of a locking [`defmt::Logger`].
+// Most of the code is taken from [defmt-itm](https://github.com/knurling-rs/defmt/tree/main/firmware/defmt-itm) under Apache 2.0 license / MIT license.
+use core::sync::atomic::{AtomicBool, Ordering};
+
+#[defmt::global_logger]
+struct Logger;
+
+static TAKEN: AtomicBool = AtomicBool::new(false);
+static mut CS_RESTORE: critical_section::RestoreState = critical_section::RestoreState::invalid();
+static mut ENCODER: defmt::Encoder = defmt::Encoder::new();
+
+// safety: implementing an unsafe trait and following it's safety rules.
+unsafe impl defmt::Logger for Logger {
+    fn acquire() {
+        // safety: Must be paired with corresponding call to release(), see below
+        let restore = unsafe { critical_section::acquire() };
+
+        // safety: accessing the atomic without CAS is OK because we have acquired a critical section.
+        assert!(
+            !TAKEN.load(Ordering::Relaxed),
+            "defmt logger taken reentrantly"
+        );
+
+        // safety: accessing the atomic without CAS is OK because we have acquired a critical section.
+        TAKEN.store(true, Ordering::Relaxed);
+
+        // safety: accessing the `static mut` is OK because we have acquired a critical section.
+        unsafe { CS_RESTORE = restore };
+
+        // Espflash needs this to indicate the start of a defmt frame. This doesn't seem to cause
+        // issues with defmt-print.
+        #[cfg(context = "esp")]
+        do_write(&[0xFF, 0x00]);
+        // safety: accessing the `static mut` is OK because we have acquired a critical section.
+        unsafe {
+            let encoder: &mut defmt::Encoder = &mut *core::ptr::addr_of_mut!(ENCODER);
+            encoder.start_frame(do_write);
+        }
+    }
+
+    unsafe fn flush() {
+        crate::custom_transport::flush();
+    }
+
+    unsafe fn release() {
+        // safety: accessing the `static mut` is OK because we have acquired a critical section.
+        unsafe {
+            let encoder: &mut defmt::Encoder = &mut *core::ptr::addr_of_mut!(ENCODER);
+            encoder.end_frame(do_write);
+        }
+
+        // safety: accessing the atomic without CAS is OK because we have acquired a critical section.
+        TAKEN.store(false, Ordering::Relaxed);
+
+        // safety: accessing the `static mut` is OK because we have acquired a critical section.
+        let restore = unsafe { CS_RESTORE };
+
+        // safety: Must be paired with corresponding call to acquire(), see above
+        unsafe {
+            critical_section::release(restore);
+        }
+    }
+
+    unsafe fn write(bytes: &[u8]) {
+        // safety: accessing the `static mut` is OK because we have acquired a critical section.
+        unsafe {
+            let encoder: &mut defmt::Encoder = &mut *core::ptr::addr_of_mut!(ENCODER);
+            encoder.write(bytes, do_write);
+        }
+    }
+}
+
+fn do_write(bytes: &[u8]) {
+    crate::custom_transport::write_bytes(bytes);
+}

--- a/src/ariel-os-log/src/lib.rs
+++ b/src/ariel-os-log/src/lib.rs
@@ -21,6 +21,10 @@
 #[featurecomb::comb]
 mod _featurecomb {}
 
+#[doc(hidden)]
+#[cfg(feature = "custom-transport")]
+pub mod custom_transport;
+
 #[allow(unused, reason = "conditional compilation")]
 #[doc(hidden)]
 #[cfg(feature = "log")]
@@ -72,33 +76,36 @@ pub mod log {
     // adds/removes any items.
     pub use log::{debug, error, info, trace, warn};
 
-    #[cfg(all(
-        context = "ariel-os",
-        not(any(
-            feature = "esp-println",
-            feature = "logging-over-uart",
-            feature = "std"
-        ))
-    ))]
-    pub use ariel_os_debug::debug_channel_println as println;
-
-    #[cfg(feature = "esp-println")]
-    pub use esp_println::println;
-
-    #[cfg(feature = "std")]
-    pub use std::println;
-
-    #[cfg(feature = "debug-uart")]
-    pub use crate::uart_println as println;
-
-    /// Prints to the logging output, with a newline.
-    #[cfg(not(context = "ariel-os"))]
-    #[macro_export]
-    macro_rules! noop_println {
-        ($($arg:tt)*) => {};
+    cfg_select! {
+        feature = "debug-channel" => {
+            pub use ariel_os_debug::debug_channel_println as println;
+        }
+        feature = "debug-uart" => {
+           pub use crate::uart_println as println;
+        }
+        feature = "esp-println" => {
+            pub use esp_println::println;
+        }
+        feature = "std" => {
+            pub use std::println;
+        }
+        feature = "custom-transport" => {
+            pub use crate::transport_println as println;
+        }
+        not(context = "ariel-os") => {
+            pub use crate::noop_println as println;
+        }
+        _ => {
+            compile_error!("No logging transport available !");
+        }
     }
-    #[cfg(not(context = "ariel-os"))]
-    pub use crate::noop_println as println;
+}
+
+/// Prints to the logging output, with a newline.
+#[cfg(not(context = "ariel-os"))]
+#[macro_export]
+macro_rules! noop_println {
+    ($($arg:tt)*) => {};
 }
 
 // NOTE: this module is used both for `log` and when no logging facades are enabled.

--- a/src/ariel-os-log/src/lib.rs
+++ b/src/ariel-os-log/src/lib.rs
@@ -424,3 +424,32 @@ pub fn init() {
     #[cfg(feature = "log")]
     log_logger::init();
 }
+
+// From `esp-println`: espflash reads this metadata to know when to decode defmt.
+#[cfg(all(context = "esp", not(feature = "esp-println")))]
+#[expect(unsafe_code)]
+mod esp {
+    macro_rules! log_format {
+        ($value:expr) => {
+            #[unsafe(link_section = concat!(".espressif.metadata"))]
+            #[used]
+            #[unsafe(export_name = concat!("espflash.LOG_FORMAT"))]
+            static LOG_FORMAT: [u8; $value.len()] = const {
+                let val_bytes = $value.as_bytes();
+                let mut val_bytes_array = [0; $value.len()];
+                let mut i = 0;
+                while i < val_bytes.len() {
+                    val_bytes_array[i] = val_bytes[i];
+                    i += 1;
+                }
+                val_bytes_array
+            };
+        };
+    }
+
+    #[cfg(feature = "defmt")]
+    log_format!("defmt-espflash");
+
+    #[cfg(not(feature = "defmt"))]
+    log_format!("serial");
+}

--- a/src/ariel-os-log/src/lib.rs
+++ b/src/ariel-os-log/src/lib.rs
@@ -30,6 +30,9 @@ pub mod custom_transport;
 #[cfg(feature = "log")]
 mod log_logger;
 
+#[cfg(all(feature = "defmt", feature = "custom-transport"))]
+mod defmt_logger;
+
 // This module is hidden in the docs, but would still be imported by a wildcard import of this
 // crate's items.
 #[doc(hidden)]

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -199,7 +199,7 @@ timer-generic-queue-128 = ["ariel-os-embassy/timer-generic-queue-128"]
 
 #! ## Development and debugging
 # Enables the debug channel.
-debug-channel = ["ariel-os-rt/debug-channel"]
+debug-channel = ["ariel-os-log/debug-channel", "ariel-os-rt/debug-channel"]
 # Enables logging support through `defmt`, see [`log`].
 defmt = [
   "ariel-os-bench?/defmt",
@@ -226,6 +226,9 @@ rtt-target = ["ariel-os-debug/rtt-target"]
 defmt-rtt = ["ariel-os-log/defmt-rtt"]
 esp-println = ["ariel-os-log/esp-println"]
 semihosting = ["ariel-os-debug/semihosting"]
+
+# Use an Ariel OS log transport driver.
+log-transport-driver = ["ariel-os-embassy/log-transport-driver"]
 
 net = ["ariel-os-embassy/net"]
 

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -27,6 +27,7 @@ ariel-os-embassy = { path = "../ariel-os-embassy" }
 ariel-os-hal = { workspace = true }
 ariel-os-identity = { workspace = true }
 ariel-os-log = { workspace = true }
+ariel-os-log-transport-driver = { workspace = true, optional = true }
 ariel-os-macros = { path = "../ariel-os-macros" }
 ariel-os-nrf = { path = "../ariel-os-nrf", optional = true }
 ariel-os-power = { path = "../ariel-os-power" }
@@ -221,7 +222,10 @@ no-boards = ["ariel-os-boards/no-boards", "ariel-os-embassy/no-boards"]
 # These are selected by laze
 debug-uart = ["ariel-os-embassy/debug-uart", "ariel-os-log/debug-uart"]
 logging-over-uart = ["ariel-os-log/logging-over-uart"]
-logging-over-usb = ["ariel-os-log/logging-over-usb"]
+logging-over-usb-cdc-acm-esp = [
+  "ariel-os-log-transport-driver/usb-cdc-acm-esp",
+  "log-transport-driver",
+]
 rtt-target = ["ariel-os-debug/rtt-target"]
 defmt-rtt = ["ariel-os-log/defmt-rtt"]
 esp-println = ["ariel-os-log/esp-println"]


### PR DESCRIPTION
# Description

This adds a way to transmit logs over a cdc acm USB class on boards that support USB.

## Testing

Run an example and collect the logs with `defmt-print` (for `defmt` facade) or `picocom` (for `log` facade). You may have to change the `/dev/ttyACM0` serial port to match your setup. 

```
laze -C examples/ble-scanner build -b rpi-pico-w -s logging-over-usb -s defmt run
defmt-print -e build/bin/rpi-pico-w/cargo/thumbv6m-none-eabi/release/ble-scanner serial --path /dev/ttyACM0
```

```
laze -C examples/ble-scanner build -b rpi-pico-w -s logging-over-usb -s log run
picocom --imap lfcrlf /dev/ttyACM0
```


## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

- Depends on #2196 

## Open Questions

Early boot logs and logs from applications that end quickly (`examples/log`, `examples/hello-world`) are not reliably transmitted. Should this be worked on ? 

Also there is an issue with no logging facade being selected when `logging-over-usb`. It seems to be an issue with how the laze file is structured. This needs to be addressed in another PR.

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
Added the USB cdc-acm log transport for boards with USB functionality. 
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
