### PR TITLE
ci(cargo-deny): weakly ban CLI argument parsing crates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -45,6 +45,18 @@ exceptions = [
 deny = [
   { crate = "proc-macro-error", reason = "unmaintained: https://rustsec.org/advisories/RUSTSEC-2024-0370" },
   { crate = "serde_yml", reason = "unsound and unmaintained" },
+  # Weak bans: the bans below are considered "weak": they may be disabled
+  # (ideally only transiently) for a good reason.
+  # There is usually no good reasons for CLI argument parsing crates to be part
+  # of the dependency tree, even just as build-dependencies or dev-dependencies,
+  # as Ariel OS only contains libraries.
+  # Sometimes it may be needed to go upstream to feature-gate them.
+  { crate = "argh", reason = "CLI argument parsing crate" },
+  { crate = "clap", reason = "CLI argument parsing crate" },
+  { crate = "lexopt", reason = "CLI argument parsing crate" },
+  { crate = "pico-args", reason = "CLI argument parsing crate", wrappers = [
+    "lalrpop", # This exception is only needed for `pio-parser`.
+  ] },
 ]
 
 # This section is considered when running `cargo deny check sources`.


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This adds a weak ban on CLI argument parsing crates, as they should be unneeded in the case of Ariel OS but may still inadvertently pop up in the dependency tree (see #2203).


## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
This PR is opened before #2203 is merged, showing the CI failure as `clap` is currently part of the tree.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Depends on #2203

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
