### PR TITLE
feat(esp32): Add PSRAM support

### DIFF
--- a/boards/espressif-esp32-s3-devkitc-1.yaml
+++ b/boards/espressif-esp32-s3-devkitc-1.yaml
@@ -5,6 +5,18 @@ targets:
     flags:
       - has_usb_cdc_acm_port
       - has_usb_device_port
+    ariel:
+      global_env:
+        CARGO_ENV:
+          # All current official ordering codes for this board (N8R8,
+          # N8R8U, N32R16V) ship an ESP32-S3-WROOM-1/-2 module with Octal
+          # SPI PSRAM. Other WROOM-1 variants (e.g. the older, no longer
+          # listed N8R2) have Quad SPI PSRAM instead, which needs
+          # `ESP_HAL_CONFIG_PSRAM_MODE=quad`: the two are electrically
+          # different and esp-hal cannot detect which one is present, so
+          # every board with PSRAM must set this explicitly to match its
+          # actual module variant.
+          - ESP_HAL_CONFIG_PSRAM_MODE=octal
     buttons:
       # button0
       - pin: GPIO0

--- a/book/src/adding-board-support.md
+++ b/book/src/adding-board-support.md
@@ -79,6 +79,10 @@ sbd-gen generate-ariel boards -o src/ariel-os-boards --mode update
 ### `esp32`
 
 - Some ancillary esp-hal crates require a chip-specific feature to be enabled. You will need to add a device-specific dependency section to `ariel-os-debug`, and `ariel-os-esp`, similar to the existing ones.
+- If the board has PSRAM and enables the `psram` feature, set `ESP_HAL_CONFIG_PSRAM_MODE` to `quad` or `octal` in `targets.<board_name>.ariel.global_env.CARGO_ENV`, matching the board's actual PSRAM chip.
+  esp-hal cannot detect which SPI mode a populated chip needs, and driving one in the wrong mode does not fail visibly: the chip responds and boots normally, and size auto-detection can even report a plausible-looking (wrong) value, but every real PSRAM read/write beyond what fits in the CPU's data cache silently returns corrupted data.
+  Small, cache-resident accesses read back fine regardless, which makes this easy to misdiagnose as a driver or hardware bug rather than a protocol mismatch — always verify with an allocation large enough to force real cache evictions (at least a few times the chip's D-cache size) before trusting a PSRAM port.
+  Check the exact module part number/ordering code (not just the module family): PSRAM SPI mode varies by variant, not by chip family — e.g. ESP32-S3-WROOM-1 modules ship with either Quad or Octal PSRAM depending on the ordering code (`R2` = Quad, `R8`/`R16` = Octal).
 
 ## Adding Support for an MCU from a Supported MCU family
 

--- a/src/ariel-os-boards/laze.yml
+++ b/src/ariel-os-boards/laze.yml
@@ -69,8 +69,12 @@ builders:
   parent: esp32-s3-wroom-1
   provides:
   - has_buttons
+  - has_psram
   - has_usb_cdc_acm_port
   - has_usb_device_port
+  env:
+    CARGO_ENV:
+    - ESP_HAL_CONFIG_PSRAM_MODE=octal
 - name: heltec-wifi-lora-32-v3
   parent: esp32s3fx8
   provides:

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -100,6 +100,9 @@ uart = ["ariel-os-embassy-common/uart", "ariel-os-hal/uart"]
 usb = ["dep:embassy-usb", "ariel-os-hal/usb"]
 usb-hid = ["dep:usbd-hid", "embassy-usb?/usbd-hid", "usb"]
 
+## Enables PSRAM as additional heap memory (ESP32-only, currently).
+psram = ["ariel-os-hal/psram"]
+
 # `embassy-net` requires a time driver, which HALs provide.
 net = ["dep:embassy-net", "ariel-os-hal/time"]
 # NOTE: `time` is only needed on STM32 for the workaround.

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -107,6 +107,18 @@ spi = ["dep:embassy-embedded-hal", "dep:fugit", "ariel-os-embassy-common/spi"]
 ## Enables UART support.
 uart = ["dep:embedded-io-async", "ariel-os-embassy-common/uart"]
 
+## Enables PSRAM as additional heap memory.
+##
+## Boards enabling this feature must also set `ESP_HAL_CONFIG_PSRAM_MODE` to
+## `quad` or `octal` to match their actual PSRAM chip (e.g. via
+## `ariel.global_env.CARGO_ENV` in the board's SBD yaml) — esp-hal cannot
+## detect which SPI mode the populated chip needs, and driving an
+## Octal-wired chip with Quad commands (or vice versa) does not fail
+## visibly: the chip responds and boots, but every real PSRAM read/write
+## beyond what fits in cache silently returns corrupted data. See the
+## `esp32` section of the board porting guide (`book/src/adding-board-support.md`).
+psram = ["dep:esp-alloc", "esp-hal/psram"]
+
 ## Enables threading support.
 threading = [
   "dep:ariel-os-threads",

--- a/src/ariel-os-esp/src/lib.rs
+++ b/src/ariel-os-esp/src/lib.rs
@@ -118,6 +118,13 @@ pub fn init() -> OptionalPeripherals {
         crate::time_driver::init(embassy_timer);
     }
 
+    #[cfg(feature = "psram")]
+    {
+        ariel_os_log::debug!("initializing psram");
+        esp_alloc::psram_allocator!(peripherals.PSRAM.take().unwrap(), esp_hal::psram);
+        ariel_os_log::debug!("psram: {} bytes free", esp_alloc::HEAP.free());
+    }
+
     peripherals
 }
 

--- a/src/ariel-os-esp/src/lib.rs
+++ b/src/ariel-os-esp/src/lib.rs
@@ -78,6 +78,11 @@ pub trait IntoPeripheral<'a, T> {
     fn into_hal_peripheral(self) -> T;
 }
 
+#[cfg(feature = "psram")]
+mod psram;
+#[cfg(feature = "psram")]
+pub use psram::PSRAM_HEAP;
+
 #[doc(hidden)]
 impl<T> IntoPeripheral<'_, T> for T {
     fn into_hal_peripheral(self) -> T {
@@ -121,8 +126,8 @@ pub fn init() -> OptionalPeripherals {
     #[cfg(feature = "psram")]
     {
         ariel_os_log::debug!("initializing psram");
-        esp_alloc::psram_allocator!(peripherals.PSRAM.take().unwrap(), esp_hal::psram);
-        ariel_os_log::debug!("psram: {} bytes free", esp_alloc::HEAP.free());
+        psram::init(peripherals.PSRAM.take().unwrap());
+        ariel_os_log::debug!("psram: {} bytes free", psram::PSRAM_HEAP.free());
     }
 
     peripherals

--- a/src/ariel-os-esp/src/psram.rs
+++ b/src/ariel-os-esp/src/psram.rs
@@ -1,0 +1,46 @@
+//! Opt-in allocator wiring for PSRAM (external SPI RAM).
+#![expect(unsafe_code, reason = "registers PSRAM as a heap region")]
+
+/// Opt-in allocator for PSRAM (external SPI RAM).
+///
+/// This is a separate [`esp_alloc::EspHeap`] instance, deliberately kept off
+/// the default global allocator (`esp_alloc::HEAP`). `esp_alloc::EspHeap`'s
+/// `GlobalAlloc::alloc` allocates with an empty capability filter, which
+/// matches *any* registered region regardless of its
+/// [`esp_alloc::MemoryCapability`] tag — so a region registered on the
+/// global heap is reachable from plain, unqualified `Box`/`Vec`/etc. calls
+/// even if it is tagged `External`. Keeping PSRAM on its own heap guarantees
+/// unqualified allocations can never land here, which matters because
+/// atomic instructions do not work correctly on memory located in PSRAM on
+/// ESP32, ESP32-S2 and ESP32-S3 (see `esp_alloc::psram_allocator!`'s
+/// documentation).
+///
+/// Because `esp_alloc::EspHeap` implements `allocator_api2::alloc::Allocator`
+/// unconditionally, code that wants to allocate specifically in PSRAM can
+/// use this directly, e.g. `allocator_api2::boxed::Box::new_in(x, &PSRAM_HEAP)`
+/// or `allocator_api2::vec::Vec::new_in(&PSRAM_HEAP)`.
+///
+/// Empty (no regions registered) until [`init`] runs.
+pub static PSRAM_HEAP: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
+
+/// Registers `psram`'s raw memory as the sole region of [`PSRAM_HEAP`].
+///
+/// Takes the `PSRAM` peripheral by value rather than requiring the caller to
+/// justify a `# Safety` contract: `esp_hal::init()` is the only way to
+/// obtain a `PSRAM` token, and it runs at most once per program (from
+/// `crate::init()`), so receiving one here is itself proof that this region
+/// isn't already in use elsewhere.
+pub(crate) fn init(psram: esp_hal::peripherals::PSRAM<'_>) {
+    let (start, size) = esp_hal::psram::psram_raw_parts(&psram);
+    // SAFETY: `psram` is owned by this function, and the only source of a
+    // `PSRAM` token — `esp_hal::init()` — runs at most once per program, so
+    // this region is exclusively ours for the remainder of the program;
+    // `size` is non-zero whenever PSRAM hardware is actually present.
+    unsafe {
+        PSRAM_HEAP.add_region(esp_alloc::HeapRegion::new(
+            start,
+            size,
+            esp_alloc::MemoryCapability::External.into(),
+        ));
+    }
+}

--- a/src/ariel-os-hal/Cargo.toml
+++ b/src/ariel-os-hal/Cargo.toml
@@ -96,6 +96,9 @@ usb = [
   "ariel-os-stm32/usb",
 ]
 
+## Enables PSRAM as additional heap memory (ESP32-only, currently).
+psram = ["ariel-os-esp/psram"]
+
 ble = [
   "dep:bt-hci",
   "dep:embedded-io",

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -47,6 +47,8 @@ default = ["ariel-os-rt/_panic-handler"]
 #! ## System functionality
 # Enables a global system allocator.
 alloc = ["ariel-os-rt/alloc"]
+## Enables PSRAM as additional heap memory (ESP32-only, currently).
+psram = ["ariel-os-embassy/psram"]
 ## Enables GPIO interrupt support.
 external-interrupts = ["ariel-os-embassy/external-interrupts"]
 # Enables storage support.


### PR DESCRIPTION
# Description
Some of the ESP32 boards ship with additional PSRAM. Esp-hal has support for this, we just need enable the feature, set one additional constant and initialize the PSRAM at the right moment.

One caveat is that either QSPI or OSPI has to be selected and this **must** match the actual board wiring. If the wrong type is selected, everything will compile, init, alloc and write without any issue, but reading beyond the internal buffer of the ESP32 will return garbage data (and confidently so, still no error). This makes the feature a little sensitive to proper board configuration. This PR describes this in the suggested documentation change.

## Testing
This was tested on a PCB that resembles the [Espressif ESP32-S3-DevKitC-1](https://ariel-os.github.io/ariel-os/dev/docs/book/boards/espressif-esp32-s3-devkitc-1.html), with a N16R8 memory configuration (16MiB additional flash, 8MiB additional PSRAM). This memory is wired up as OSPI.

To test this feature, alloc a substantial buffer (few MiB) and fill it with a known pattern. Then read it back and verify the pattern. If a QSPI chip is called with an OSPI driver or the other way around, data will be garbage (even though the alloc will succeed). If the right configuration is used, data wil read back as expected.

## Issues/PRs References

## Open Questions
This now only targets the board I can test here, but more candidates are available for this feature:
- unihiker-k10
- waveshare-esp32-s3-matrix
- espressif-esp32-s2-devkitc-1 (I think, though this is an older chip that doesn't even have octal mode, so unsure how to configure this properly)

Please advise on adding this now or only somehow noting this for future reference but leaving it unavailable until it can be confirmed.

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(ESP32) PSRAM support is available on
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
