### PR TITLE
feat(nrf91-gnss): switch to jiff for time handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,10 +547,10 @@ dependencies = [
  "embassy-futures",
  "embassy-sync 0.7.2",
  "futures-util",
+ "jiff",
  "libm",
  "nrf-modem",
  "portable-atomic",
- "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ defmt-rtt = { version = "1.1.0" }
 document-features = "0.2.8"
 fugit = { version = "0.3.7", default-features = false }
 heapless = { version = "0.9.1", default-features = false }
+jiff = { version = "0.2", default-features = false }
 ld-memory = { version = "0.2.9" }
 log = { version = "0.4.20", default-features = false }
 once_cell = { version = "1.21.3", default-features = false, features = [
@@ -190,7 +191,6 @@ nrf-sdc = { git = "https://github.com/alexmoon/nrf-sdc", rev = "e64ad081a6948b34
 
 futures-util = { version = "0.3.32", default-features = false }
 nrf-modem = { version = "0.10.2" }
-time = { version = "0.3.47", default-features = false }
 tinyrlibc = "0.5.0"
 
 [workspace.lints.rust]

--- a/src/sensors/ariel-os-sensor-nrf91-gnss/Cargo.toml
+++ b/src/sensors/ariel-os-sensor-nrf91-gnss/Cargo.toml
@@ -17,10 +17,10 @@ defmt = { workspace = true, optional = true }
 embassy-futures = { workspace = true }
 embassy-sync = { workspace = true }
 futures-util = { workspace = true, default-features = false }
+jiff = { workspace = true }
 libm = "0.2.15"
 nrf-modem = { workspace = true, features = ["modem-log"] }
 portable-atomic = { workspace = true }
-time = { workspace = true }
 
 [features]
 defmt = ["dep:defmt", "ariel-os-sensors/defmt", "nrf-modem/defmt"]

--- a/src/sensors/ariel-os-sensor-nrf91-gnss/src/lib.rs
+++ b/src/sensors/ariel-os-sensor-nrf91-gnss/src/lib.rs
@@ -26,8 +26,8 @@ use embassy_sync::{
     blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel, once_lock::OnceLock,
 };
 use futures_util::StreamExt as _;
+use jiff::{civil::DateTime, tz::TimeZone};
 use nrf_modem::{Gnss, GnssData, GnssStream};
-use time::{Date, Month, Time, UtcDateTime};
 
 use ariel_os_log::{Debug2Format, debug, error, warn};
 use ariel_os_sensors::{
@@ -233,27 +233,24 @@ impl Nrf91Gnss {
     fn convert_to_time_parts(
         data: &nrf_modem::nrfxlib_sys::nrf_modem_gnss_pvt_data_frame,
     ) -> Option<(i32, i32)> {
-        let parsed_date = Date::from_calendar_date(
-            data.datetime.year.into(),
-            Month::try_from(data.datetime.month).ok()?,
-            data.datetime.day,
-        )
-        .ok()?;
-
-        let time = Time::from_hms_milli(
-            data.datetime.hour,
-            data.datetime.minute,
-            data.datetime.seconds,
-            data.datetime.ms,
-        )
-        .ok()?;
-
         // Default year when no GNSS fix.
         if data.datetime.year == 1980 {
             return None;
         }
+        let parsed_date_time = DateTime::new(
+            data.datetime.year.cast_signed(),
+            data.datetime.month.cast_signed(),
+            data.datetime.day.cast_signed(),
+            data.datetime.hour.cast_signed(),
+            data.datetime.minute.cast_signed(),
+            data.datetime.seconds.cast_signed(),
+            i32::from(data.datetime.ms) * 1_000_000,
+        )
+        .ok()?
+        .to_zoned(TimeZone::UTC)
+        .ok()?;
 
-        let timestamp = UtcDateTime::new(parsed_date, time).unix_timestamp_nanos();
+        let timestamp = parsed_date_time.timestamp().as_nanosecond();
 
         Some(ariel_os_sensors_gnss_time_ext::convert_datetime_to_parts(timestamp).unwrap())
     }


### PR DESCRIPTION
# Description

Swich to `jiff` to remove the dependency on `time`.

## Testing

```
laze -C examples/sensors-debug/ build -b nrf9160dk-nrf9160 run   
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions


## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
