### PR TITLE
fix(sensors-debug): only use nrf-modem is feature is enabled

### DIFF
--- a/examples/sensors-debug/src/sensors.rs
+++ b/examples/sensors-debug/src/sensors.rs
@@ -11,7 +11,7 @@ pub async fn init() {
     #[cfg(any(context = "st-steval-mkboxpro", context = "stm32u083c-dk"))]
     stts22h::init().await;
 
-    #[cfg(context = "nrf91")]
+    #[cfg(feature = "nrf-modem")]
     nrf91::init().await;
 
     #[cfg(any(context = "unihiker-k10"))]
@@ -131,7 +131,7 @@ mod stts22h {
 #[cfg(any(context = "st-steval-mkboxpro", context = "stm32u083c-dk"))]
 pub use stts22h::STTS22H_I2C;
 
-#[cfg(context = "nrf91")]
+#[cfg(feature = "nrf-modem")]
 mod nrf91 {
     use ariel_os_sensor_nrf91_gnss::{Nrf91Gnss, config::Config};
 


### PR DESCRIPTION
# Description

Currently disabling `nrf91-modem-sensor` on `examples/sensors-debug` when building for a board with an nrf91 MCU will error out because the code tries to use a dependency that is included only if the feature `nrf-modem` is enabled (automatically enabled by the `nrf91-modem-sensor` module).

## Testing

```
laze -C examples/sensors-debug build -b nrf9160dk-nrf9160 -d nrf91-modem-sensor run    
```

Should run and read no sensors.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(nRF91) The `sensors-debug` example now builds successfully when disabling the `nrf91-modem-sensor` laze module.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
