### PR TITLE
chore(cargo-deny): weakly ban non-Jiff time-related crates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -57,6 +57,16 @@ deny = [
   { crate = "pico-args", reason = "CLI argument parsing crate", wrappers = [
     "lalrpop", # This exception is only needed for `pio-parser`.
   ] },
+  # We favor Jiff over other time-related crates, as the ecosystem is moving
+  # towards it, and to avoid dependency duplication.
+  # `chrono` is now soft-deprecated: <https://github.com/chronotope/chrono/issues/1768>.
+  { crate = "chrono", use-instead = "jiff", reason = "avoids duplication of time-related crates", wrappers = [
+    "cbor-edn",
+    "cbor-diag",
+  ] },
+  { crate = "time", use-instead = "jiff", reason = "avoids duplication of time-related crates", wrappers = [
+    "der", # Only needed for `embedded-tls` until removed upstream.
+  ] },
 ]
 
 # This section is considered when running `cargo deny check sources`.


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Similarly to #2202, and following #2219, this adds weak bans on `chrono` and `time`, with three exceptions. The motivation is detailed in #2208.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Partially completes #2208

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
