### PR TITLE
docs(spi): clarify that `SpiDevice`'s CS output should be high initially

### DIFF
--- a/src/ariel-os-embassy/src/spi/main/mod.rs
+++ b/src/ariel-os-embassy/src/spi/main/mod.rs
@@ -12,6 +12,7 @@ pub use ariel_os_embassy_common::spi::main::*;
 /// Needs to be provided with an MCU-specific SPI driver tied to a specific SPI peripheral,
 /// obtainable from the [`hal::spi::main`] module.
 /// It also requires a [`gpio::Output`] for the chip select (CS) signal.
+/// The output should be set to high initially, as CS is an active-low signal.
 ///
 /// See [`embedded_hal::spi`] to learn more about the distinction between an
 /// [`SpiBus`](embedded_hal::spi::SpiBus) and an
@@ -23,6 +24,8 @@ pub use ariel_os_embassy_common::spi::main::*;
 /// However, it cannot block indefinitely as a timeout is implemented, either by leveraging
 /// SPI-specific hardware capabilities or through a generic software timeout.
 // TODO: do we actually need a CriticalSectionRawMutex here?
+// NOTE: the inner `SpiDevice` does not initially set the output's level, so it should already be
+// set to the proper level when given to the constructor.
 pub type SpiDevice<'a> =
     InnerSpiDevice<'a, CriticalSectionRawMutex, hal::spi::main::Spi, gpio::Output<'a>>;
 


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
As mentioned in https://github.com/ariel-os/ariel-os/pull/2224#discussion_r3781956694, this clarifies that CS should be set to high initially.

My reading of [`embassy_embedded_hal::shared_bus::async::spi::SpiDevice`'s implementation](https://crates.io/crates/embassy-embedded-hal/0.6.0/code/src/shared_bus/asynch/spi.rs) is that nothing sets CS to high explicitly (only to low when starting a transaction, and to high to end one or on Drop), so I think it's important it's set to the proper level, as that would otherwise likely not work properly when using multiple SPI subs and could result in a higher power draw overall even if a single sub is present. (I have not actually tested that on hardware however.)

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The documentation of `SpiDevice` has been clarified to mention that the CS output should be set to high initially.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
