### PR TITLE
fix(hal): qualify the peripheral path in define_peripherals!() aliases

### DIFF
--- a/src/ariel-os-hal/src/hal/define_peripherals.rs
+++ b/src/ariel-os-hal/src/hal/define_peripherals.rs
@@ -14,7 +14,7 @@ macro_rules! define_peripherals {
         $peripherals:ident {
             $(
                 $(#[$inner:meta])*
-                $peripheral_name:ident : $peripheral_field:ident $(=$peripheral_alias:ident)?
+                $peripheral_name:ident : $peripheral_field:ident
             ),*
             $(,)?
         }
@@ -27,11 +27,6 @@ macro_rules! define_peripherals {
                 pub $peripheral_name: $crate::__peripheral_ty!($peripheral_field),
             )*
         }
-
-        $($(
-            #[allow(missing_docs, non_camel_case_types)]
-            pub type $peripheral_alias = peripherals::$peripheral_field;
-        )?)*
 
         impl $crate::hal::TakePeripherals<$peripherals> for &mut $crate::hal::OptionalPeripherals {
             fn take_peripherals(&mut self) -> $peripherals {

--- a/src/ariel-os-hal/src/hal/define_peripherals.rs
+++ b/src/ariel-os-hal/src/hal/define_peripherals.rs
@@ -14,7 +14,7 @@ macro_rules! define_peripherals {
         $peripherals:ident {
             $(
                 $(#[$inner:meta])*
-                $peripheral_name:ident : $peripheral_field:ident
+                $peripheral_name:ident : $peripheral_field:ident $(=$peripheral_alias:ident)?
             ),*
             $(,)?
         }
@@ -27,6 +27,11 @@ macro_rules! define_peripherals {
                 pub $peripheral_name: $crate::__peripheral_ty!($peripheral_field),
             )*
         }
+
+        $($(
+            #[allow(missing_docs, non_camel_case_types)]
+            pub type $peripheral_alias = $crate::__peripheral_alias_ty!($peripheral_field);
+        )?)*
 
         impl $crate::hal::TakePeripherals<$peripherals> for &mut $crate::hal::OptionalPeripherals {
             fn take_peripherals(&mut self) -> $peripherals {
@@ -62,6 +67,28 @@ macro_rules! __peripheral_ty {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __peripheral_ty {
+    ($field:ident) => {
+        $crate::hal::peripherals::$field<'static>
+    };
+}
+
+// This helper macro creates the type a peripheral alias refers to. The alias names the peripheral
+// itself and not the embassy hal `Peri` wrapper. For `esp-hal` however, it does alias the
+// peripheral with its lifetime parameter, as there is no distinction between a peripheral and the
+// exclusive access to it, making it identical to `__peripheral_ty!()`.
+#[cfg(not(context = "esp"))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __peripheral_alias_ty {
+    ($field:ident) => {
+        $crate::hal::peripherals::$field
+    };
+}
+
+#[cfg(context = "esp")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __peripheral_alias_ty {
     ($field:ident) => {
         $crate::hal::peripherals::$field<'static>
     };


### PR DESCRIPTION
# Description

Fixes the aliasing syntax from the `define_peripherals!()` macro by qualifying the path using a helper `__peripheral_alias_ty` macro.

## Testing

Checked the `examples/hello-world` example for multiple platforms (nrf52840dk, rpi-pico, st-nucleo-f042k6, espressif-esp32-c6-devkitc-1).

The feature itself is not being currently used anywhere in the repo. I've tested it building a simple example and using the alias feature without importing `hal::peripheral`.

```Rust
ariel_os::hal::define_peripherals!(LedPeripherals { led: P0_13 = Led });
```

## Issues/PRs References

Closes #2033 

## Open Questions


## Changelog Entry

<!-- changelog:begin -->
The aliasing syntax of the `define_peripherals!()` macro has been fixed. It originally comes from the [assign_resources! macro](https://crates.io/crates/assign-resources/0.5.0) , but it has not been used nor documented.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
