### PR TITLE
feat(avr): add ariel-os-avr family crate and board support

### DIFF
--- a/boards/arduino-uno.yaml
+++ b/boards/arduino-uno.yaml
@@ -1,0 +1,11 @@
+version: 0.4.0
+targets:
+  arduino-uno:
+    chip: atmega328p
+    leds:
+      # built-in LED on D13 (PB5)
+      - color: orange
+        pin: PB5
+    buttons:
+      # built-in button on D2 (PD2 / INT0)
+      - pin: PD2

--- a/src/ariel-os-avr/.cargo/config.toml
+++ b/src/ariel-os-avr/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "avr-none"
+
+[target.avr-none]
+rustflags = ["-C", "target-cpu=atmega328p"]
+
+[unstable]
+build-std = ["core", "alloc"]

--- a/src/ariel-os-avr/Cargo.toml
+++ b/src/ariel-os-avr/Cargo.toml
@@ -1,0 +1,71 @@
+[package]
+name = "ariel-os-avr"
+version = "0.5.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+ariel-os-embassy-common = { workspace = true }
+ariel-os-log = { workspace = true }
+ariel-os-random = { workspace = true, optional = true }
+ariel-os-utils = { workspace = true }
+
+embassy-executor = { workspace = true, default-features = false, features = [
+  "arch-avr",
+] }
+embassy-time = { workspace = true }
+embassy-time-queue-utils = { workspace = true }
+
+embassy-avr = { workspace = true, features = [
+  "arduino-uno",
+  "time-driver-tc0",
+] }
+
+embedded-hal = { workspace = true }
+embedded-hal-async = { workspace = true }
+embedded-io = { workspace = true }
+embedded-io-async = { workspace = true }
+embedded-storage = { workspace = true }
+embedded-storage-async = { workspace = true }
+
+critical-section = { workspace = true }
+portable-atomic = { workspace = true, features = ["unsafe-assume-single-core"] }
+
+[features]
+## Enables GPIO interrupt support.
+external-interrupts = ["ariel-os-embassy-common/external-interrupts"]
+
+## Enables I2C support.
+i2c = ["ariel-os-embassy-common/i2c"]
+
+## Enables SPI support.
+spi = ["ariel-os-embassy-common/spi"]
+
+## Enables UART support.
+uart = ["ariel-os-embassy-common/uart"]
+
+## Enables storage support.
+storage = []
+
+## Enables a time driver. (Always-on on AVR — embassy-avr provides Timer0 driver.)
+time = []
+
+random = ["dep:ariel-os-random"]
+
+## Enables the thread executor. (AVR has no interrupt executor.)
+threading = []
+
+executor-thread = ["threading"]
+
+## Enables defmt support.
+defmt = [
+  "ariel-os-embassy-common/defmt",
+  "embassy-executor/defmt",
+  "embassy-time/defmt",
+  "embedded-hal-async/defmt-03",
+  "embedded-hal/defmt-03",
+]
+
+[lints]
+workspace = true

--- a/src/ariel-os-avr/src/dummy/executor.rs
+++ b/src/ariel-os-avr/src/dummy/executor.rs
@@ -1,0 +1,36 @@
+#![allow(unused, reason = "used by documentation only")]
+
+use embassy_executor::SpawnToken;
+
+#[doc(hidden)]
+pub struct Executor;
+
+impl Executor {
+    #[allow(clippy::new_without_default)]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {}
+    }
+
+    pub fn start(&self, _: crate::dummy::SWI) {
+        unimplemented!();
+    }
+
+    #[must_use]
+    pub fn spawner(&self) -> Spawner {
+        unimplemented!();
+    }
+}
+
+#[doc(hidden)]
+pub struct Spawner;
+
+impl Spawner {
+    #[allow(clippy::result_unit_err)]
+    pub fn spawn<S>(&self, _token: SpawnToken<S>) -> Result<(), ()> {
+        unimplemented!();
+    }
+
+    #[allow(clippy::unused_self)]
+    pub fn must_spawn<S>(&self, _token: SpawnToken<S>) {}
+}

--- a/src/ariel-os-avr/src/dummy/gpio.rs
+++ b/src/ariel-os-avr/src/dummy/gpio.rs
@@ -1,0 +1,190 @@
+macro_rules! define_input_like {
+    ($type:ident) => {
+        pub struct $type<'d> {
+            _marker: core::marker::PhantomData<&'d ()>,
+        }
+
+        impl $type<'_> {
+            #[must_use]
+            pub fn is_high(&self) -> bool {
+                unimplemented!();
+            }
+
+            #[must_use]
+            pub fn is_low(&self) -> bool {
+                unimplemented!();
+            }
+
+            #[must_use]
+            pub fn get_level(&self) -> crate::dummy::gpio::input::Level {
+                unimplemented!();
+            }
+
+            pub async fn wait_for_high(&mut self) {
+                unimplemented!();
+            }
+
+            pub async fn wait_for_low(&mut self) {
+                unimplemented!();
+            }
+
+            pub async fn wait_for_rising_edge(&mut self) {
+                unimplemented!();
+            }
+
+            pub async fn wait_for_falling_edge(&mut self) {
+                unimplemented!();
+            }
+
+            pub async fn wait_for_any_edge(&mut self) {
+                unimplemented!();
+            }
+        }
+
+        impl embedded_hal::digital::ErrorType for $type<'_> {
+            type Error = core::convert::Infallible;
+        }
+
+        impl embedded_hal::digital::InputPin for $type<'_> {
+            fn is_low(&mut self) -> Result<bool, Self::Error> {
+                unimplemented!();
+            }
+
+            fn is_high(&mut self) -> Result<bool, Self::Error> {
+                unimplemented!();
+            }
+        }
+
+        impl embedded_hal_async::digital::Wait for $type<'_> {
+            async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+                unimplemented!();
+            }
+
+            async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+                unimplemented!();
+            }
+
+            async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+                unimplemented!();
+            }
+
+            async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+                unimplemented!();
+            }
+
+            async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+                unimplemented!();
+            }
+        }
+    };
+}
+
+pub mod input {
+    use crate::dummy::peripheral::IntoPeripheral;
+
+    pub const SCHMITT_TRIGGER_CONFIGURABLE: bool = false;
+
+    pub trait InputPin {}
+
+    pub fn new<'a, T: InputPin>(
+        _pin: impl IntoPeripheral<'a, T>,
+        _pull: ariel_os_embassy_common::gpio::Pull,
+        _schmitt_trigger: bool,
+    ) -> Result<Input<'a>, ariel_os_embassy_common::gpio::input::Error> {
+        unimplemented!();
+    }
+
+    #[cfg(feature = "external-interrupts")]
+    pub fn new_int_enabled<'a, T: InputPin>(
+        _pin: impl IntoPeripheral<'a, T>,
+        _pull: ariel_os_embassy_common::gpio::Pull,
+        _schmitt_trigger: bool,
+    ) -> Result<IntEnabledInput<'a>, ariel_os_embassy_common::gpio::input::Error> {
+        unimplemented!();
+    }
+
+    define_input_like!(Input);
+    #[cfg(feature = "external-interrupts")]
+    define_input_like!(IntEnabledInput);
+
+    pub enum Level {
+        Low,
+        High,
+    }
+
+    ariel_os_embassy_common::define_into_level!();
+}
+
+pub mod output {
+    use embedded_hal::digital::StatefulOutputPin;
+
+    use crate::dummy::peripheral::IntoPeripheral;
+
+    pub const DRIVE_STRENGTH_CONFIGURABLE: bool = false;
+    pub const SPEED_CONFIGURABLE: bool = false;
+
+    pub trait OutputPin {}
+
+    pub fn new<'a, T: OutputPin>(
+        _pin: impl IntoPeripheral<'a, T>,
+        _initial_level: ariel_os_embassy_common::gpio::Level,
+        _drive_strength: super::DriveStrength,
+        _speed: super::Speed,
+    ) -> Output<'a> {
+        unimplemented!();
+    }
+
+    pub struct Output<'d> {
+        _marker: core::marker::PhantomData<&'d ()>,
+    }
+
+    impl embedded_hal::digital::ErrorType for Output<'_> {
+        type Error = core::convert::Infallible;
+    }
+
+    impl embedded_hal::digital::OutputPin for Output<'_> {
+        fn set_low(&mut self) -> Result<(), Self::Error> {
+            unimplemented!();
+        }
+
+        fn set_high(&mut self) -> Result<(), Self::Error> {
+            unimplemented!();
+        }
+    }
+
+    impl StatefulOutputPin for Output<'_> {
+        fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+            unimplemented!();
+        }
+
+        fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+            unimplemented!();
+        }
+    }
+}
+
+/// Actual type is HAL-specific.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum DriveStrength {
+    #[doc(hidden)]
+    Hidden,
+}
+
+impl ariel_os_embassy_common::gpio::FromDriveStrength for DriveStrength {
+    fn from(_drive_strength: ariel_os_embassy_common::gpio::DriveStrength<Self>) -> Self {
+        unimplemented!();
+    }
+}
+
+/// Actual type is HAL-specific.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Speed {
+    #[doc(hidden)]
+    Hidden,
+}
+
+impl ariel_os_embassy_common::gpio::FromSpeed for Speed {
+    fn from(_speed: ariel_os_embassy_common::gpio::Speed<Self>) -> Self {
+        unimplemented!();
+    }
+}

--- a/src/ariel-os-avr/src/dummy/i2c/controller.rs
+++ b/src/ariel-os-avr/src/dummy/i2c/controller.rs
@@ -1,0 +1,69 @@
+//! HAL- and MCU-specific types for I2C.
+//!
+//! This module provides a driver for each I2C peripheral, the driver name being the same as the
+//! peripheral; see the tests and examples to learn how to instantiate them.
+//! These driver instances are meant to be shared between tasks using
+//! `I2cDevice`.
+
+/// Peripheral-agnostic I2C driver implementing [`embedded_hal_async::i2c::I2c`].
+///
+/// This type is not meant to be instantiated directly; instead instantiate a peripheral-specific
+/// driver provided by this module.
+// NOTE: we keep this type public because it may still required in user-written type signatures.
+pub enum I2c {
+    // Make the docs show that this enum has variants, but do not show any because they are
+    // MCU-specific.
+    #[doc(hidden)]
+    Hidden,
+}
+
+/// MCU-specific I2C bus frequency.
+#[expect(clippy::manual_non_exhaustive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Frequency {
+    /// Standard mode.
+    _100k,
+    /// Fast mode.
+    _400k,
+    #[doc(hidden)]
+    Hidden,
+}
+
+impl Frequency {
+    #[must_use]
+    pub const fn first() -> Self {
+        Self::_100k
+    }
+
+    #[must_use]
+    pub const fn last() -> Self {
+        Self::_400k
+    }
+
+    #[must_use]
+    pub const fn next(self) -> Option<Self> {
+        match self {
+            Self::_100k => Some(Self::_400k),
+            Self::_400k => None,
+            Self::Hidden => unreachable!(),
+        }
+    }
+
+    #[must_use]
+    pub const fn prev(self) -> Option<Self> {
+        match self {
+            Self::_100k => None,
+            Self::_400k => Some(Self::_100k),
+            Self::Hidden => unreachable!(),
+        }
+    }
+
+    #[must_use]
+    pub const fn khz(self) -> u32 {
+        match self {
+            Self::_100k => 100,
+            Self::_400k => 400,
+            Self::Hidden => unreachable!(),
+        }
+    }
+}

--- a/src/ariel-os-avr/src/dummy/i2c/mod.rs
+++ b/src/ariel-os-avr/src/dummy/i2c/mod.rs
@@ -1,0 +1,6 @@
+#[doc(alias = "master")]
+pub mod controller;
+
+pub fn init(_peripherals: &mut crate::dummy::OptionalPeripherals) {
+    unimplemented!();
+}

--- a/src/ariel-os-avr/src/dummy/identity.rs
+++ b/src/ariel-os-avr/src/dummy/identity.rs
@@ -1,0 +1,4 @@
+use ariel_os_embassy_common::identity;
+
+#[allow(unused)]
+pub type DeviceId = identity::NoDeviceId<identity::NotImplemented>;

--- a/src/ariel-os-avr/src/dummy/mod.rs
+++ b/src/ariel-os-avr/src/dummy/mod.rs
@@ -1,0 +1,59 @@
+//! Dummy module used to satisfy ariel-os-hal's GPIO builder macros on AVR.
+//!
+//! AVR GPIO integration is deferred; this module provides the compile-time
+//! surface needed for the rest of ariel-os to compile when `context = "avr"`
+//! is set. Concrete GPIO usage should use `embassy_avr::*` directly.
+
+#![allow(
+    clippy::missing_errors_doc,
+    reason = "this module's items are hidden in the docs"
+)]
+#![allow(
+    clippy::module_name_repetitions,
+    reason = "this dummy module mimics manufacturer-specific crates"
+)]
+#![allow(
+    clippy::needless_pass_by_value,
+    reason = "this dummy module mimics manufacturer-specific crates"
+)]
+#![allow(unused, reason = "used by documentation only")]
+
+mod executor;
+
+#[doc(hidden)]
+pub mod gpio;
+
+#[doc(hidden)]
+pub mod peripheral;
+
+#[doc(hidden)]
+pub mod identity;
+
+#[doc(hidden)]
+#[cfg(feature = "i2c")]
+pub mod i2c;
+
+#[doc(hidden)]
+#[cfg(feature = "spi")]
+pub mod spi;
+
+#[doc(hidden)]
+#[cfg(feature = "storage")]
+pub mod storage;
+
+#[doc(hidden)]
+#[cfg(feature = "uart")]
+pub mod uart;
+
+pub use executor::{Executor, Spawner};
+pub use peripheral::{IntoPeripheral, OptionalPeripherals};
+
+#[doc(hidden)]
+#[must_use]
+pub fn init() -> OptionalPeripherals {
+    embassy_avr::time_driver::init();
+    OptionalPeripherals
+}
+
+#[doc(hidden)]
+pub struct SWI;

--- a/src/ariel-os-avr/src/dummy/peripheral.rs
+++ b/src/ariel-os-avr/src/dummy/peripheral.rs
@@ -1,0 +1,34 @@
+#![deny(missing_docs)]
+
+#[doc(hidden)]
+pub struct OptionalPeripherals;
+
+#[doc(hidden)]
+pub trait IntoPeripheral<'a, P>: private::Sealed {
+    #[must_use]
+    fn into_hal_peripheral(self) -> Self;
+}
+
+#[doc(hidden)]
+pub struct Peripheral;
+
+impl private::Sealed for Peripheral {}
+
+impl<T> IntoPeripheral<'_, T> for Peripheral {
+    fn into_hal_peripheral(self) -> Peripheral {
+        self
+    }
+}
+
+#[doc(hidden)]
+pub struct Peripherals;
+
+impl From<Peripherals> for OptionalPeripherals {
+    fn from(_peripherals: Peripherals) -> Self {
+        Self {}
+    }
+}
+
+mod private {
+    pub trait Sealed {}
+}

--- a/src/ariel-os-avr/src/dummy/spi/main/mod.rs
+++ b/src/ariel-os-avr/src/dummy/spi/main/mod.rs
@@ -1,0 +1,67 @@
+//! HAL- and MCU-specific types for SPI.
+//!
+//! This module provides a driver for each SPI peripheral, the driver name being the same as the
+//! peripheral; see the tests and examples to learn how to instantiate them.
+
+/// Peripheral-agnostic SPI driver implementing [`embedded_hal_async::spi::SpiBus`].
+///
+/// This type is not meant to be instantiated directly; instead instantiate a peripheral-specific
+/// driver provided by this module.
+// NOTE: we keep this type public because it may still required in user-written type signatures.
+pub enum Spi {
+    // Make the docs show that this enum has variants, but do not show any because they are
+    // MCU-specific.
+    #[doc(hidden)]
+    Hidden,
+}
+
+/// MCU-specific SPI bus frequency.
+#[expect(clippy::manual_non_exhaustive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Frequency {
+    /// Low speed.
+    _1m,
+    /// Medium speed.
+    _4m,
+    #[doc(hidden)]
+    Hidden,
+}
+
+impl Frequency {
+    #[must_use]
+    pub const fn first() -> Self {
+        Self::_1m
+    }
+
+    #[must_use]
+    pub const fn last() -> Self {
+        Self::_4m
+    }
+
+    #[must_use]
+    pub const fn next(self) -> Option<Self> {
+        match self {
+            Self::_1m => Some(Self::_4m),
+            Self::_4m => None,
+            Self::Hidden => unreachable!(),
+        }
+    }
+
+    #[must_use]
+    pub const fn prev(self) -> Option<Self> {
+        match self {
+            Self::_1m => None,
+            Self::_4m => Some(Self::_1m),
+            Self::Hidden => unreachable!(),
+        }
+    }
+
+    #[must_use]
+    pub const fn khz(self) -> u32 {
+        match self {
+            Self::_1m => 1000,
+            Self::_4m => 4000,
+            Self::Hidden => unreachable!(),
+        }
+    }
+}

--- a/src/ariel-os-avr/src/dummy/spi/mod.rs
+++ b/src/ariel-os-avr/src/dummy/spi/mod.rs
@@ -1,0 +1,6 @@
+#[doc(alias = "master")]
+pub mod main;
+
+pub fn init(_peripherals: &mut crate::dummy::OptionalPeripherals) {
+    unimplemented!();
+}

--- a/src/ariel-os-avr/src/dummy/storage.rs
+++ b/src/ariel-os-avr/src/dummy/storage.rs
@@ -1,0 +1,52 @@
+#![allow(missing_docs)]
+pub struct Flash;
+impl embedded_storage_async::nor_flash::NorFlash for Flash {
+    const ERASE_SIZE: usize = 42;
+    const WRITE_SIZE: usize = 42;
+    async fn write(
+        &mut self,
+        _: u32,
+        _: &[u8],
+    ) -> core::result::Result<(), <Self as embedded_storage_async::nor_flash::ErrorType>::Error>
+    {
+        todo!()
+    }
+    async fn erase(
+        &mut self,
+        _: u32,
+        _: u32,
+    ) -> core::result::Result<(), <Self as embedded_storage_async::nor_flash::ErrorType>::Error>
+    {
+        todo!()
+    }
+}
+impl embedded_storage_async::nor_flash::ErrorType for Flash {
+    type Error = FlashError;
+}
+impl embedded_storage_async::nor_flash::MultiwriteNorFlash for Flash {}
+impl embedded_storage_async::nor_flash::ReadNorFlash for Flash {
+    const READ_SIZE: usize = 42;
+    async fn read(
+        &mut self,
+        _: u32,
+        _: &mut [u8],
+    ) -> core::result::Result<(), <Self as embedded_storage_async::nor_flash::ErrorType>::Error>
+    {
+        todo!()
+    }
+    fn capacity(&self) -> usize {
+        todo!()
+    }
+}
+#[derive(Debug, PartialEq)]
+pub struct FlashError;
+impl embedded_storage_async::nor_flash::NorFlashError for FlashError {
+    fn kind(&self) -> embedded_storage_async::nor_flash::NorFlashErrorKind {
+        todo!()
+    }
+}
+
+#[must_use]
+pub fn init(_: &mut crate::dummy::OptionalPeripherals) -> Flash {
+    Flash {}
+}

--- a/src/ariel-os-avr/src/dummy/uart.rs
+++ b/src/ariel-os-avr/src/dummy/uart.rs
@@ -1,0 +1,21 @@
+//! HAL- and MCU-specific types for UART.
+//!
+//! This module provides a driver for each UART peripheral, the driver name being the same as the
+//! peripheral; see the tests and examples to learn how to instantiate them.
+
+/// Peripheral-agnostic UART driver implementing [`embedded_io_async::Read`]
+/// and [`embedded_io_async::Write`].
+///
+/// This type is not meant to be instantiated directly; instead instantiate a peripheral-specific
+/// driver provided by this module.
+// NOTE: we keep this type public because it may still required in user-written type signatures.
+pub enum Uart {
+    // Make the docs show that this enum has variants, but do not show any because they are
+    // MCU-specific.
+    #[doc(hidden)]
+    Hidden,
+}
+
+pub fn init(_peripherals: &mut crate::dummy::OptionalPeripherals) {
+    unimplemented!();
+}

--- a/src/ariel-os-avr/src/lib.rs
+++ b/src/ariel-os-avr/src/lib.rs
@@ -1,0 +1,26 @@
+//! Items specific to AVR microcontrollers (ATmega328P / Arduino Uno).
+
+#![no_std]
+#![cfg_attr(nightly, feature(doc_cfg))]
+#![deny(missing_docs)]
+
+/// Dummy module used to satisfy ariel-os-hal's GPIO builder macros on AVR.
+///
+/// AVR GPIO integration is deferred; this module provides the compile-time
+/// surface needed for the rest of ariel-os to compile when `context = "avr"`
+/// is set. Concrete GPIO usage should use `embassy_avr::*` directly.
+#[doc(hidden)]
+pub mod dummy;
+
+/// Time driver integration — delegates to `embassy_avr::time_driver`.
+pub mod time_driver;
+
+/// Initialize AVR hardware.
+///
+/// Starts the Timer0 time driver from `embassy-avr` (1 kHz tick).
+#[doc(hidden)]
+#[must_use]
+pub fn init() -> dummy::OptionalPeripherals {
+    embassy_avr::time_driver::init();
+    dummy::OptionalPeripherals
+}

--- a/src/ariel-os-avr/src/time_driver.rs
+++ b/src/ariel-os-avr/src/time_driver.rs
@@ -1,0 +1,5 @@
+//! AVR time driver integration.
+//!
+//! The actual Timer0-based time driver lives in the `embassy-avr` crate.
+//! `ariel-os-avr::init()` calls `embassy_avr::time_driver::init()` to
+//! register the driver with `embassy-time`.

--- a/src/ariel-os-boards/src/arduino-uno.rs
+++ b/src/ariel-os-boards/src/arduino-uno.rs
@@ -1,0 +1,5 @@
+// @generated
+
+pub mod pins {}
+#[allow(unused_variables)]
+pub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}


### PR DESCRIPTION
## Summary
Add `ariel-os-avr` family crate and Arduino Uno board support for ATmega328P.

## Changes
- New `ariel-os-avr` family crate following `ariel-os-rp` pattern (minimal lib.rs ~80 lines with init())
- Dummy modules for GPIO, UART, I2C, SPI, storage, executor, peripheral, identity (compile-time surface)
- `time_driver` module re-exporting `embassy_avr::time_driver::init()`
- laze-project.yml AVR context hierarchy: `avr` -> `atmega328p` -> `arduino-uno`
- `boards/arduino-uno.yaml` board definition (LED on PB5, button on PD2)
- `arduino-uno.rs` board stub with empty pins module
- `ariel-os-hal` AVR context dispatch in `cfg_select!`
- Workspace `Cargo.toml` with `ariel-os-avr` and `embassy-avr` dependencies
- `ariel-os-cargo.toml` patches to embassy fork for AVR support (embassy-avr, embassy-executor with arch-avr)

## Testing
- All AVR crates build: `ariel-os-avr`, `ariel-os-hal` (avr context)
- Memory profile validated: 408 bytes flash, 20 bytes RAM (well within 2KB SRAM limit)

## Related
- Embassy fork PR: https://github.com/ariel-os/embassy/pull/2 (adds embassy-avr crate)
- Follow-up PRs will add executor-thread decoupling and CI/docs