### PR TITLE
feat(avr): decouple executor-thread from threading, add AVR arch to ariel-os-rt

### DIFF
--- a/boards/arduino-uno.yaml
+++ b/boards/arduino-uno.yaml
@@ -1,0 +1,11 @@
+version: 0.4.0
+targets:
+  arduino-uno:
+    chip: atmega328p
+    leds:
+      # built-in LED on D13 (PB5)
+      - color: orange
+        pin: PB5
+    buttons:
+      # built-in button on D2 (PD2 / INT0)
+      - pin: PD2

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -358,10 +358,62 @@ contexts:
         cmd:
           - picotool load -u -v -x -t elf ${out} $@
 
+  - name: avr
+    help: AVR MCU support (based on embassy-avr, currently ATmega328P / Arduino Uno)
+    parent: ariel-os
+    selects:
+      # AVR requires nightly (no stable AVR target support)
+      - nightly
+      # ATmega328P has 2 KB SRAM — select ram-tiny for small stacks
+      - ram-tiny
+      # AVR only supports the thread executor (no SWI/interrupt executor)
+      - executor-thread
+    provides:
+      - has_device_identity
+    env:
+      global:
+        RUSTC_TARGET: avr-none
+        CARGO_TARGET_PREFIX: CARGO_TARGET_AVR_NONE
+        RUSTFLAGS:
+          - --cfg context="avr"
+          - -C target-cpu=atmega328p
+        CARGO_WRAPPER: ""
+        # Force build-std because the AVR target's core/alloc are not pre-built
+        # in some installations.
+        CARGO_ARGS:
+          - -Zbuild-std=core,alloc
+
+  - name: atmega328p
+    parent: avr
+    provides:
+      - has_leds
+      - has_storage_support
+    env:
+      global:
+        RUSTFLAGS:
+          - --cfg context="atmega328p"
+
+  - name: arduino-uno
+    help: Arduino Uno (ATmega328P, 16 MHz, 32 KB flash, 2 KB SRAM)
+    parent: atmega328p
+    provides:
+      - has_leds
+      - has_storage_support
+    tasks:
+      flash:
+        help: flash the target using avrdude
+        cmd:
+          - avrdude -c arduino -p atmega328p -P /dev/ttyACM0 -U flash:w:${out}:e
+      flash-15:
+        help: flash the target using avrdude on an Arduino Uno R4 (programmer stk500v1, baud 115200)
+        cmd:
+          - avrdude -c stk500v1 -p atmega328p -P /dev/ttyACM0 -b 115200 -U flash:w:${out}:e
+
   - name: esp
     parent: ariel-os
     selects:
       - ?espflash
+      - sw/threading
     provides:
       - has_hwrng
     env:
@@ -506,6 +558,7 @@ contexts:
       # NOTE: semantically this should only be enabled when `logging` is
       # enabled, but laze does not support conditions on contexts.
       - logging-over-stdout
+      - sw/threading
     provides:
       - has_device_identity
       - has_hwrng
@@ -530,6 +583,7 @@ contexts:
     parent: ariel-os
     selects:
       - ?probe-rs
+      - sw/threading
     provides:
       - has_device_identity
       - sw/benchmark

--- a/src/ariel-os-avr/.cargo/config.toml
+++ b/src/ariel-os-avr/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "avr-none"
+
+[target.avr-none]
+rustflags = ["-C", "target-cpu=atmega328p"]
+
+[unstable]
+build-std = ["core", "alloc"]

--- a/src/ariel-os-avr/Cargo.toml
+++ b/src/ariel-os-avr/Cargo.toml
@@ -1,0 +1,71 @@
+[package]
+name = "ariel-os-avr"
+version = "0.5.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+ariel-os-embassy-common = { workspace = true }
+ariel-os-log = { workspace = true }
+ariel-os-random = { workspace = true, optional = true }
+ariel-os-utils = { workspace = true }
+
+embassy-executor = { workspace = true, default-features = false, features = [
+  "arch-avr",
+] }
+embassy-time = { workspace = true }
+embassy-time-queue-utils = { workspace = true }
+
+embassy-avr = { workspace = true, features = [
+  "arduino-uno",
+  "time-driver-tc0",
+] }
+
+embedded-hal = { workspace = true }
+embedded-hal-async = { workspace = true }
+embedded-io = { workspace = true }
+embedded-io-async = { workspace = true }
+embedded-storage = { workspace = true }
+embedded-storage-async = { workspace = true }
+
+critical-section = { workspace = true }
+portable-atomic = { workspace = true, features = ["unsafe-assume-single-core"] }
+
+[features]
+## Enables GPIO interrupt support.
+external-interrupts = ["ariel-os-embassy-common/external-interrupts"]
+
+## Enables I2C support.
+i2c = ["ariel-os-embassy-common/i2c"]
+
+## Enables SPI support.
+spi = ["ariel-os-embassy-common/spi"]
+
+## Enables UART support.
+uart = ["ariel-os-embassy-common/uart"]
+
+## Enables storage support.
+storage = []
+
+## Enables a time driver. (Always-on on AVR — embassy-avr provides Timer0 driver.)
+time = []
+
+random = ["dep:ariel-os-random"]
+
+## Enables the thread executor. (AVR has no interrupt executor.)
+threading = []
+
+executor-thread = ["threading"]
+
+## Enables defmt support.
+defmt = [
+  "ariel-os-embassy-common/defmt",
+  "embassy-executor/defmt",
+  "embassy-time/defmt",
+  "embedded-hal-async/defmt-03",
+  "embedded-hal/defmt-03",
+]
+
+[lints]
+workspace = true

--- a/src/ariel-os-avr/src/dummy/executor.rs
+++ b/src/ariel-os-avr/src/dummy/executor.rs
@@ -1,0 +1,36 @@
+#![allow(unused, reason = "used by documentation only")]
+
+use embassy_executor::SpawnToken;
+
+#[doc(hidden)]
+pub struct Executor;
+
+impl Executor {
+    #[allow(clippy::new_without_default)]
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {}
+    }
+
+    pub fn start(&self, _: crate::dummy::SWI) {
+        unimplemented!();
+    }
+
+    #[must_use]
+    pub fn spawner(&self) -> Spawner {
+        unimplemented!();
+    }
+}
+
+#[doc(hidden)]
+pub struct Spawner;
+
+impl Spawner {
+    #[allow(clippy::result_unit_err)]
+    pub fn spawn<S>(&self, _token: SpawnToken<S>) -> Result<(), ()> {
+        unimplemented!();
+    }
+
+    #[allow(clippy::unused_self)]
+    pub fn must_spawn<S>(&self, _token: SpawnToken<S>) {}
+}

--- a/src/ariel-os-avr/src/dummy/gpio.rs
+++ b/src/ariel-os-avr/src/dummy/gpio.rs
@@ -1,0 +1,190 @@
+macro_rules! define_input_like {
+    ($type:ident) => {
+        pub struct $type<'d> {
+            _marker: core::marker::PhantomData<&'d ()>,
+        }
+
+        impl $type<'_> {
+            #[must_use]
+            pub fn is_high(&self) -> bool {
+                unimplemented!();
+            }
+
+            #[must_use]
+            pub fn is_low(&self) -> bool {
+                unimplemented!();
+            }
+
+            #[must_use]
+            pub fn get_level(&self) -> crate::dummy::gpio::input::Level {
+                unimplemented!();
+            }
+
+            pub async fn wait_for_high(&mut self) {
+                unimplemented!();
+            }
+
+            pub async fn wait_for_low(&mut self) {
+                unimplemented!();
+            }
+
+            pub async fn wait_for_rising_edge(&mut self) {
+                unimplemented!();
+            }
+
+            pub async fn wait_for_falling_edge(&mut self) {
+                unimplemented!();
+            }
+
+            pub async fn wait_for_any_edge(&mut self) {
+                unimplemented!();
+            }
+        }
+
+        impl embedded_hal::digital::ErrorType for $type<'_> {
+            type Error = core::convert::Infallible;
+        }
+
+        impl embedded_hal::digital::InputPin for $type<'_> {
+            fn is_low(&mut self) -> Result<bool, Self::Error> {
+                unimplemented!();
+            }
+
+            fn is_high(&mut self) -> Result<bool, Self::Error> {
+                unimplemented!();
+            }
+        }
+
+        impl embedded_hal_async::digital::Wait for $type<'_> {
+            async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+                unimplemented!();
+            }
+
+            async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+                unimplemented!();
+            }
+
+            async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+                unimplemented!();
+            }
+
+            async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+                unimplemented!();
+            }
+
+            async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+                unimplemented!();
+            }
+        }
+    };
+}
+
+pub mod input {
+    use crate::dummy::peripheral::IntoPeripheral;
+
+    pub const SCHMITT_TRIGGER_CONFIGURABLE: bool = false;
+
+    pub trait InputPin {}
+
+    pub fn new<'a, T: InputPin>(
+        _pin: impl IntoPeripheral<'a, T>,
+        _pull: ariel_os_embassy_common::gpio::Pull,
+        _schmitt_trigger: bool,
+    ) -> Result<Input<'a>, ariel_os_embassy_common::gpio::input::Error> {
+        unimplemented!();
+    }
+
+    #[cfg(feature = "external-interrupts")]
+    pub fn new_int_enabled<'a, T: InputPin>(
+        _pin: impl IntoPeripheral<'a, T>,
+        _pull: ariel_os_embassy_common::gpio::Pull,
+        _schmitt_trigger: bool,
+    ) -> Result<IntEnabledInput<'a>, ariel_os_embassy_common::gpio::input::Error> {
+        unimplemented!();
+    }
+
+    define_input_like!(Input);
+    #[cfg(feature = "external-interrupts")]
+    define_input_like!(IntEnabledInput);
+
+    pub enum Level {
+        Low,
+        High,
+    }
+
+    ariel_os_embassy_common::define_into_level!();
+}
+
+pub mod output {
+    use embedded_hal::digital::StatefulOutputPin;
+
+    use crate::dummy::peripheral::IntoPeripheral;
+
+    pub const DRIVE_STRENGTH_CONFIGURABLE: bool = false;
+    pub const SPEED_CONFIGURABLE: bool = false;
+
+    pub trait OutputPin {}
+
+    pub fn new<'a, T: OutputPin>(
+        _pin: impl IntoPeripheral<'a, T>,
+        _initial_level: ariel_os_embassy_common::gpio::Level,
+        _drive_strength: super::DriveStrength,
+        _speed: super::Speed,
+    ) -> Output<'a> {
+        unimplemented!();
+    }
+
+    pub struct Output<'d> {
+        _marker: core::marker::PhantomData<&'d ()>,
+    }
+
+    impl embedded_hal::digital::ErrorType for Output<'_> {
+        type Error = core::convert::Infallible;
+    }
+
+    impl embedded_hal::digital::OutputPin for Output<'_> {
+        fn set_low(&mut self) -> Result<(), Self::Error> {
+            unimplemented!();
+        }
+
+        fn set_high(&mut self) -> Result<(), Self::Error> {
+            unimplemented!();
+        }
+    }
+
+    impl StatefulOutputPin for Output<'_> {
+        fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+            unimplemented!();
+        }
+
+        fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+            unimplemented!();
+        }
+    }
+}
+
+/// Actual type is HAL-specific.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum DriveStrength {
+    #[doc(hidden)]
+    Hidden,
+}
+
+impl ariel_os_embassy_common::gpio::FromDriveStrength for DriveStrength {
+    fn from(_drive_strength: ariel_os_embassy_common::gpio::DriveStrength<Self>) -> Self {
+        unimplemented!();
+    }
+}
+
+/// Actual type is HAL-specific.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Speed {
+    #[doc(hidden)]
+    Hidden,
+}
+
+impl ariel_os_embassy_common::gpio::FromSpeed for Speed {
+    fn from(_speed: ariel_os_embassy_common::gpio::Speed<Self>) -> Self {
+        unimplemented!();
+    }
+}

--- a/src/ariel-os-avr/src/dummy/i2c/controller.rs
+++ b/src/ariel-os-avr/src/dummy/i2c/controller.rs
@@ -1,0 +1,69 @@
+//! HAL- and MCU-specific types for I2C.
+//!
+//! This module provides a driver for each I2C peripheral, the driver name being the same as the
+//! peripheral; see the tests and examples to learn how to instantiate them.
+//! These driver instances are meant to be shared between tasks using
+//! `I2cDevice`.
+
+/// Peripheral-agnostic I2C driver implementing [`embedded_hal_async::i2c::I2c`].
+///
+/// This type is not meant to be instantiated directly; instead instantiate a peripheral-specific
+/// driver provided by this module.
+// NOTE: we keep this type public because it may still required in user-written type signatures.
+pub enum I2c {
+    // Make the docs show that this enum has variants, but do not show any because they are
+    // MCU-specific.
+    #[doc(hidden)]
+    Hidden,
+}
+
+/// MCU-specific I2C bus frequency.
+#[expect(clippy::manual_non_exhaustive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Frequency {
+    /// Standard mode.
+    _100k,
+    /// Fast mode.
+    _400k,
+    #[doc(hidden)]
+    Hidden,
+}
+
+impl Frequency {
+    #[must_use]
+    pub const fn first() -> Self {
+        Self::_100k
+    }
+
+    #[must_use]
+    pub const fn last() -> Self {
+        Self::_400k
+    }
+
+    #[must_use]
+    pub const fn next(self) -> Option<Self> {
+        match self {
+            Self::_100k => Some(Self::_400k),
+            Self::_400k => None,
+            Self::Hidden => unreachable!(),
+        }
+    }
+
+    #[must_use]
+    pub const fn prev(self) -> Option<Self> {
+        match self {
+            Self::_100k => None,
+            Self::_400k => Some(Self::_100k),
+            Self::Hidden => unreachable!(),
+        }
+    }
+
+    #[must_use]
+    pub const fn khz(self) -> u32 {
+        match self {
+            Self::_100k => 100,
+            Self::_400k => 400,
+            Self::Hidden => unreachable!(),
+        }
+    }
+}

--- a/src/ariel-os-avr/src/dummy/i2c/mod.rs
+++ b/src/ariel-os-avr/src/dummy/i2c/mod.rs
@@ -1,0 +1,6 @@
+#[doc(alias = "master")]
+pub mod controller;
+
+pub fn init(_peripherals: &mut crate::dummy::OptionalPeripherals) {
+    unimplemented!();
+}

--- a/src/ariel-os-avr/src/dummy/identity.rs
+++ b/src/ariel-os-avr/src/dummy/identity.rs
@@ -1,0 +1,4 @@
+use ariel_os_embassy_common::identity;
+
+#[allow(unused)]
+pub type DeviceId = identity::NoDeviceId<identity::NotImplemented>;

--- a/src/ariel-os-avr/src/dummy/mod.rs
+++ b/src/ariel-os-avr/src/dummy/mod.rs
@@ -1,0 +1,59 @@
+//! Dummy module used to satisfy ariel-os-hal's GPIO builder macros on AVR.
+//!
+//! AVR GPIO integration is deferred; this module provides the compile-time
+//! surface needed for the rest of ariel-os to compile when `context = "avr"`
+//! is set. Concrete GPIO usage should use `embassy_avr::*` directly.
+
+#![allow(
+    clippy::missing_errors_doc,
+    reason = "this module's items are hidden in the docs"
+)]
+#![allow(
+    clippy::module_name_repetitions,
+    reason = "this dummy module mimics manufacturer-specific crates"
+)]
+#![allow(
+    clippy::needless_pass_by_value,
+    reason = "this dummy module mimics manufacturer-specific crates"
+)]
+#![allow(unused, reason = "used by documentation only")]
+
+mod executor;
+
+#[doc(hidden)]
+pub mod gpio;
+
+#[doc(hidden)]
+pub mod peripheral;
+
+#[doc(hidden)]
+pub mod identity;
+
+#[doc(hidden)]
+#[cfg(feature = "i2c")]
+pub mod i2c;
+
+#[doc(hidden)]
+#[cfg(feature = "spi")]
+pub mod spi;
+
+#[doc(hidden)]
+#[cfg(feature = "storage")]
+pub mod storage;
+
+#[doc(hidden)]
+#[cfg(feature = "uart")]
+pub mod uart;
+
+pub use executor::{Executor, Spawner};
+pub use peripheral::{IntoPeripheral, OptionalPeripherals};
+
+#[doc(hidden)]
+#[must_use]
+pub fn init() -> OptionalPeripherals {
+    embassy_avr::time_driver::init();
+    OptionalPeripherals
+}
+
+#[doc(hidden)]
+pub struct SWI;

--- a/src/ariel-os-avr/src/dummy/peripheral.rs
+++ b/src/ariel-os-avr/src/dummy/peripheral.rs
@@ -1,0 +1,34 @@
+#![deny(missing_docs)]
+
+#[doc(hidden)]
+pub struct OptionalPeripherals;
+
+#[doc(hidden)]
+pub trait IntoPeripheral<'a, P>: private::Sealed {
+    #[must_use]
+    fn into_hal_peripheral(self) -> Self;
+}
+
+#[doc(hidden)]
+pub struct Peripheral;
+
+impl private::Sealed for Peripheral {}
+
+impl<T> IntoPeripheral<'_, T> for Peripheral {
+    fn into_hal_peripheral(self) -> Peripheral {
+        self
+    }
+}
+
+#[doc(hidden)]
+pub struct Peripherals;
+
+impl From<Peripherals> for OptionalPeripherals {
+    fn from(_peripherals: Peripherals) -> Self {
+        Self {}
+    }
+}
+
+mod private {
+    pub trait Sealed {}
+}

--- a/src/ariel-os-avr/src/dummy/spi/main/mod.rs
+++ b/src/ariel-os-avr/src/dummy/spi/main/mod.rs
@@ -1,0 +1,67 @@
+//! HAL- and MCU-specific types for SPI.
+//!
+//! This module provides a driver for each SPI peripheral, the driver name being the same as the
+//! peripheral; see the tests and examples to learn how to instantiate them.
+
+/// Peripheral-agnostic SPI driver implementing [`embedded_hal_async::spi::SpiBus`].
+///
+/// This type is not meant to be instantiated directly; instead instantiate a peripheral-specific
+/// driver provided by this module.
+// NOTE: we keep this type public because it may still required in user-written type signatures.
+pub enum Spi {
+    // Make the docs show that this enum has variants, but do not show any because they are
+    // MCU-specific.
+    #[doc(hidden)]
+    Hidden,
+}
+
+/// MCU-specific SPI bus frequency.
+#[expect(clippy::manual_non_exhaustive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Frequency {
+    /// Low speed.
+    _1m,
+    /// Medium speed.
+    _4m,
+    #[doc(hidden)]
+    Hidden,
+}
+
+impl Frequency {
+    #[must_use]
+    pub const fn first() -> Self {
+        Self::_1m
+    }
+
+    #[must_use]
+    pub const fn last() -> Self {
+        Self::_4m
+    }
+
+    #[must_use]
+    pub const fn next(self) -> Option<Self> {
+        match self {
+            Self::_1m => Some(Self::_4m),
+            Self::_4m => None,
+            Self::Hidden => unreachable!(),
+        }
+    }
+
+    #[must_use]
+    pub const fn prev(self) -> Option<Self> {
+        match self {
+            Self::_1m => None,
+            Self::_4m => Some(Self::_1m),
+            Self::Hidden => unreachable!(),
+        }
+    }
+
+    #[must_use]
+    pub const fn khz(self) -> u32 {
+        match self {
+            Self::_1m => 1000,
+            Self::_4m => 4000,
+            Self::Hidden => unreachable!(),
+        }
+    }
+}

--- a/src/ariel-os-avr/src/dummy/spi/mod.rs
+++ b/src/ariel-os-avr/src/dummy/spi/mod.rs
@@ -1,0 +1,6 @@
+#[doc(alias = "master")]
+pub mod main;
+
+pub fn init(_peripherals: &mut crate::dummy::OptionalPeripherals) {
+    unimplemented!();
+}

--- a/src/ariel-os-avr/src/dummy/storage.rs
+++ b/src/ariel-os-avr/src/dummy/storage.rs
@@ -1,0 +1,52 @@
+#![allow(missing_docs)]
+pub struct Flash;
+impl embedded_storage_async::nor_flash::NorFlash for Flash {
+    const ERASE_SIZE: usize = 42;
+    const WRITE_SIZE: usize = 42;
+    async fn write(
+        &mut self,
+        _: u32,
+        _: &[u8],
+    ) -> core::result::Result<(), <Self as embedded_storage_async::nor_flash::ErrorType>::Error>
+    {
+        todo!()
+    }
+    async fn erase(
+        &mut self,
+        _: u32,
+        _: u32,
+    ) -> core::result::Result<(), <Self as embedded_storage_async::nor_flash::ErrorType>::Error>
+    {
+        todo!()
+    }
+}
+impl embedded_storage_async::nor_flash::ErrorType for Flash {
+    type Error = FlashError;
+}
+impl embedded_storage_async::nor_flash::MultiwriteNorFlash for Flash {}
+impl embedded_storage_async::nor_flash::ReadNorFlash for Flash {
+    const READ_SIZE: usize = 42;
+    async fn read(
+        &mut self,
+        _: u32,
+        _: &mut [u8],
+    ) -> core::result::Result<(), <Self as embedded_storage_async::nor_flash::ErrorType>::Error>
+    {
+        todo!()
+    }
+    fn capacity(&self) -> usize {
+        todo!()
+    }
+}
+#[derive(Debug, PartialEq)]
+pub struct FlashError;
+impl embedded_storage_async::nor_flash::NorFlashError for FlashError {
+    fn kind(&self) -> embedded_storage_async::nor_flash::NorFlashErrorKind {
+        todo!()
+    }
+}
+
+#[must_use]
+pub fn init(_: &mut crate::dummy::OptionalPeripherals) -> Flash {
+    Flash {}
+}

--- a/src/ariel-os-avr/src/dummy/uart.rs
+++ b/src/ariel-os-avr/src/dummy/uart.rs
@@ -1,0 +1,21 @@
+//! HAL- and MCU-specific types for UART.
+//!
+//! This module provides a driver for each UART peripheral, the driver name being the same as the
+//! peripheral; see the tests and examples to learn how to instantiate them.
+
+/// Peripheral-agnostic UART driver implementing [`embedded_io_async::Read`]
+/// and [`embedded_io_async::Write`].
+///
+/// This type is not meant to be instantiated directly; instead instantiate a peripheral-specific
+/// driver provided by this module.
+// NOTE: we keep this type public because it may still required in user-written type signatures.
+pub enum Uart {
+    // Make the docs show that this enum has variants, but do not show any because they are
+    // MCU-specific.
+    #[doc(hidden)]
+    Hidden,
+}
+
+pub fn init(_peripherals: &mut crate::dummy::OptionalPeripherals) {
+    unimplemented!();
+}

--- a/src/ariel-os-avr/src/lib.rs
+++ b/src/ariel-os-avr/src/lib.rs
@@ -1,0 +1,26 @@
+//! Items specific to AVR microcontrollers (ATmega328P / Arduino Uno).
+
+#![no_std]
+#![cfg_attr(nightly, feature(doc_cfg))]
+#![deny(missing_docs)]
+
+/// Dummy module used to satisfy ariel-os-hal's GPIO builder macros on AVR.
+///
+/// AVR GPIO integration is deferred; this module provides the compile-time
+/// surface needed for the rest of ariel-os to compile when `context = "avr"`
+/// is set. Concrete GPIO usage should use `embassy_avr::*` directly.
+#[doc(hidden)]
+pub mod dummy;
+
+/// Time driver integration — delegates to `embassy_avr::time_driver`.
+pub mod time_driver;
+
+/// Initialize AVR hardware.
+///
+/// Starts the Timer0 time driver from `embassy-avr` (1 kHz tick).
+#[doc(hidden)]
+#[must_use]
+pub fn init() -> dummy::OptionalPeripherals {
+    embassy_avr::time_driver::init();
+    dummy::OptionalPeripherals
+}

--- a/src/ariel-os-avr/src/time_driver.rs
+++ b/src/ariel-os-avr/src/time_driver.rs
@@ -1,0 +1,5 @@
+//! AVR time driver integration.
+//!
+//! The actual Timer0-based time driver lives in the `embassy-avr` crate.
+//! `ariel-os-avr::init()` calls `embassy_avr::time_driver::init()` to
+//! register the driver with `embassy-time`.

--- a/src/ariel-os-boards/src/arduino-uno.rs
+++ b/src/ariel-os-boards/src/arduino-uno.rs
@@ -1,0 +1,5 @@
+// @generated
+
+pub mod pins {}
+#[allow(unused_variables)]
+pub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -72,6 +72,13 @@ embedded-io = { workspace = true }
 embassy-stm32 = { workspace = true }
 embedded-io = { workspace = true }
 
+[target.'cfg(context = "avr")'.dependencies]
+embassy-executor = { workspace = true, default-features = false, features = [
+  "arch-avr",
+  "executor-thread",
+] }
+embassy-avr = { workspace = true }
+
 [features]
 ## Enables GPIO interrupt support.
 external-interrupts = [
@@ -204,7 +211,11 @@ override-usb-config = []
 rcc-config-override = ["ariel-os-hal/rcc-config-override"]
 
 executor-interrupt = ["ariel-os-hal/executor-interrupt"]
-executor-thread = ["ariel-os-embassy-common/executor-thread", "threading"]
+# NOTE: `threading` is NOT included here; it is added separately via the
+# laze `sw/threading` module.  This allows AVR (which cannot use the
+# threading runtime) to use `executor-thread` without pulling in
+# `ariel-os-threads`.
+executor-thread = ["ariel-os-embassy-common/executor-thread"]
 
 # Allows to have no built-in board selected.
 no-boards = []

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -175,7 +175,11 @@ pub(crate) fn init() {
     EXECUTOR.run(|spawner| spawner.must_spawn(init_task(p)));
 }
 
-#[cfg(feature = "executor-thread")]
+#[cfg(all(
+    feature = "executor-thread",
+    feature = "threading",
+    not(context = "avr")
+))]
 #[ariel_os_macros::thread(autostart, no_wait, stacksize = executor_thread::STACKSIZE, priority = executor_thread::PRIORITY)]
 fn init() {
     use static_cell::StaticCell;
@@ -189,6 +193,28 @@ fn init() {
     static EXECUTOR: StaticCell<thread_executor::Executor> = StaticCell::new();
     EXECUTOR
         .init_with(thread_executor::Executor::new)
+        .run(|spawner| spawner.must_spawn(init_task(p)));
+}
+
+/// AVR-specific init path: thread-mode executor WITHOUT the threading runtime.
+///
+/// Used when `executor-thread` feature is enabled but `threading` is not.
+/// This is for architectures like AVR that cannot support the full threading
+/// runtime (ariel-os-threads) but can use embassy-executor's thread-mode executor.
+#[cfg(all(
+    feature = "executor-thread",
+    not(feature = "threading"),
+    context = "avr"
+))]
+#[distributed_slice(ariel_os_rt::INIT_FUNCS)]
+pub(crate) fn init() {
+    debug!("ariel-os-embassy::init(): using embassy-executor thread mode (AVR)");
+    let p = hal::init();
+
+    use crate::api::cell::StaticCell;
+    static EXECUTOR: StaticCell<embassy_executor::Executor> = StaticCell::new();
+    EXECUTOR
+        .init_with(embassy_executor::Executor::new)
         .run(|spawner| spawner.must_spawn(init_task(p)));
 }
 

--- a/src/ariel-os-embassy/src/thread_executor.rs
+++ b/src/ariel-os-embassy/src/thread_executor.rs
@@ -2,79 +2,87 @@
 #![deny(missing_docs)]
 #![expect(unsafe_code)]
 
-// This is based on the upstream embassy cortex-m interrupt executor.
+// This module is only available on non-AVR targets, as AVR uses the direct
+// embassy-executor thread mode executor instead of the thread-based executor.
+#[cfg(all(feature = "threading", not(context = "avr")))]
+mod thread_executor_inner {
+    use core::marker::PhantomData;
 
-use core::marker::PhantomData;
+    use ariel_os_threads::{ThreadId, current_tid, thread_flags, thread_flags::ThreadFlags};
+    use embassy_executor::{Spawner, raw};
 
-use ariel_os_threads::{ThreadId, current_tid, thread_flags, thread_flags::ThreadFlags};
-use embassy_executor::{Spawner, raw};
+    // This is based on the upstream embassy cortex-m interrupt executor.
 
-// This is only used between `__pender` and `Executor::run( )`, actual flag
-// doesn't matter.
-const THREAD_FLAG_WAKEUP: ThreadFlags = 0x01;
+    // This is only used between `__pender` and `Executor::run( )`, actual flag
+    // doesn't matter.
+    const THREAD_FLAG_WAKEUP: ThreadFlags = 0x01;
 
-// SAFETY: this name is required by embassy-executor and the function signature matches the
-// expected one.
-#[unsafe(no_mangle)]
-fn __pender(context: *mut ()) {
-    // SAFETY: `context` is a `ThreadId` passed by `ThreadExecutor::new`.
-    let thread_id = ThreadId::new(context as usize as u8);
+    // SAFETY: this name is required by embassy-executor and the function signature matches the
+    // expected one.
+    #[unsafe(no_mangle)]
+    fn __pender(context: *mut ()) {
+        // SAFETY: `context` is a `ThreadId` passed by `ThreadExecutor::new`.
+        let thread_id = ThreadId::new(context as usize as u8);
 
-    thread_flags::set(thread_id, THREAD_FLAG_WAKEUP);
-}
-
-/// Thread mode executor for Ariel OS threads.
-pub struct Executor {
-    inner: raw::Executor,
-    // This executor is tied to a specific thread by storing the `ThreadId` inside
-    // the inner `raw::Executor`. It thus cannot be `Send`.
-    not_send: PhantomData<*mut ()>,
-}
-
-impl Executor {
-    /// Creates a new [`Executor`].
-    ///
-    /// This must be called from the thread that will actually poll the executor.
-    /// Otherwise, the internally used thread flag will be sent to the wrong thread,
-    /// causing the executor thread to never wake up.
-    ///
-    /// # Panics
-    ///
-    /// This function panics when called without a running thread.
-    #[expect(clippy::new_without_default)]
-    pub fn new() -> Self {
-        let current_thread = current_tid().unwrap();
-        Self {
-            inner: raw::Executor::new(usize::from(current_thread) as *mut ()),
-            not_send: PhantomData,
-        }
+        thread_flags::set(thread_id, THREAD_FLAG_WAKEUP);
     }
 
-    /// Runs the executor.
-    ///
-    /// The `init` closure is called with a [`Spawner`] that spawns tasks on
-    /// this executor. Use it to spawn the initial task(s). After `init` returns,
-    /// the executor starts running the tasks.
-    ///
-    /// To spawn more tasks later, you may keep copies of the [`Spawner`] (it is `Copy`),
-    /// for example by passing it as an argument to the initial tasks.
-    ///
-    /// This function requires `&'static mut self`. This means you have to store the
-    /// [`Executor`] instance in a place where it'll live forever and grants you mutable
-    /// access. There's a few ways to do this:
-    ///
-    /// - a [`StaticCell`](https://docs.rs/static_cell/latest/static_cell/) (safe)
-    /// - a `static mut` (unsafe)
-    /// - a local variable in a function you know never returns (like `fn main() -> !`), upgrading its lifetime with `transmute`. (unsafe)
-    pub fn run(&'static mut self, init: impl FnOnce(Spawner)) -> ! {
-        init(self.inner.spawner());
+    /// Thread mode executor for Ariel OS threads.
+    pub struct Executor {
+        inner: raw::Executor,
+        // This executor is tied to a specific thread by storing the `ThreadId` inside
+        // the inner `raw::Executor`. It thus cannot be `Send`.
+        not_send: PhantomData<*mut ()>,
+    }
 
-        loop {
-            // SAFETY: `poll()` may net be called reentrantly on the same executor, which we don't.
-            unsafe {
-                self.inner.poll();
-            };
-            thread_flags::wait_any(THREAD_FLAG_WAKEUP);
+    impl Executor {
+        /// Creates a new [`Executor`].
+        ///
+        /// This must be called from the thread that will actually poll the executor.
+        /// Otherwise, the internally used thread flag will be sent to the wrong thread,
+        /// causing the executor thread to never wake up.
+        ///
+        /// # Panics
+        ///
+        /// This function panics when called without a running thread.
+        #[expect(clippy::new_without_default)]
+        pub fn new() -> Self {
+            let current_thread = current_tid().unwrap();
+            Self {
+                inner: raw::Executor::new(usize::from(current_thread) as *mut ()),
+                not_send: PhantomData,
+            }
+        }
+
+        /// Runs the executor.
+        ///
+        /// The `init` closure is called with a [`Spawner`] that spawns tasks on
+        /// this executor. Use it to spawn the initial task(s). After `init` returns,
+        /// the executor starts running the tasks.
+        ///
+        /// To spawn more tasks later, you may keep copies of the [`Spawner`] (it is `Copy`),
+        /// for example by passing it as an argument to the initial tasks.
+        ///
+        /// This function requires `&'static mut self`. This means you have to store the
+        /// [`Executor`] instance in a place where it'll live forever and grants you mutable
+        /// access. There's a few ways to do this:
+        ///
+        /// - a [`StaticCell`](https://docs.rs/static_cell/latest/static_cell/) (safe)
+        /// - a `static mut` (unsafe)
+        /// - a local variable in a function you know never returns (like `fn main() -> !`), upgrading its lifetime with `transmute`. (unsafe)
+        pub fn run(&'static mut self, init: impl FnOnce(Spawner)) -> ! {
+            init(self.inner.spawner());
+
+            loop {
+                // SAFETY: `poll()` may net be called reentrantly on the same executor, which we don't.
+                unsafe {
+                    self.inner.poll();
+                };
+                thread_flags::wait_any(THREAD_FLAG_WAKEUP);
+            }
         }
     }
 }
+
+#[cfg(all(feature = "threading", not(context = "avr")))]
+pub use thread_executor_inner::Executor;

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -47,6 +47,13 @@ riscv = { workspace = true }
 [target.'cfg(context = "stm32")'.dependencies]
 cortex-m = { workspace = true, features = ["critical-section-single-core"] }
 
+[target.'cfg(context = "avr")'.dependencies]
+avr-device = { workspace = true, features = ["rt"] }
+
+# Enable atmega328p device support when building for atmega328p context
+[target.'cfg(all(context = "avr", context = "atmega328p"))'.dependencies]
+avr-device = { workspace = true, features = ["rt", "atmega328p"] }
+
 [features]
 alloc = ["dep:ariel-os-alloc"]
 threading = ["dep:ariel-os-threads"]

--- a/src/ariel-os-rt/src/avr.rs
+++ b/src/ariel-os-rt/src/avr.rs
@@ -1,0 +1,39 @@
+#![expect(unsafe_code)]
+
+// AVR-specific runtime initialization and entry point.
+// Uses avr-device's `entry` macro (enabled via `rt` feature) to provide
+// the reset handler which initializes .bss/.data and sets up the stack,
+// then calls `main()` which invokes `crate::startup()`.
+
+use avr_device::asm;
+
+/// Entry point for AVR — called by the reset vector after .bss/.data init.
+///
+/// The `avr-device` crate with the `rt` feature provides the `#[entry]`
+/// macro which generates the appropriate reset vector entry point and
+/// performs standard startup initialization (zeroing .bss, copying .data
+/// from flash, setting up the stack pointer).
+#[cfg(not(feature = "embedded-test"))]
+#[avr_device::entry]
+fn main() -> ! {
+    crate::startup();
+}
+
+pub fn init() {}
+
+/// Wait for interrupt — puts the AVR into sleep mode until an interrupt occurs.
+///
+/// This is the AVR equivalent of `wfi` (wait for interrupt) on ARM.
+/// Used by the idle loop in `startup()` when the `threading` feature is not enabled.
+pub fn wfi() {
+    asm::sleep();
+}
+
+pub(crate) fn sp() -> usize {
+    0
+}
+
+use crate::stack::Stack;
+pub(crate) fn stack() -> crate::stack::Stack {
+    Stack::default()
+}

--- a/src/ariel-os-rt/src/lib.rs
+++ b/src/ariel-os-rt/src/lib.rs
@@ -36,6 +36,10 @@ cfg_select! {
         mod native;
         use native as arch;
     }
+    context = "avr" => {
+        mod avr;
+        use avr as arch;
+    }
     context = "ariel-os" => {
         // When run with laze but the MCU family is not supported
         compile_error!("no runtime is defined for this MCU family");

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -237,13 +237,22 @@ executor-interrupt = [
   "ariel-os-rt/executor-interrupt",
 ]
 # Enables the ariel-os-threading thread executor.
-executor-thread = ["ariel-os-embassy/executor-thread", "threading"]
+# NOTE: `threading` is NOT included here — it must be selected separately
+# (e.g. via the laze `sw/threading` module).  This allows architectures
+# like AVR that cannot support the full threading runtime (ariel-os-threads)
+# to use `executor-thread` without pulling in `ariel-os-threads`.
+executor-thread = ["ariel-os-embassy/executor-thread"]
 
 # Enables embedded-test support. Selected by laze.
 embedded-test = ["ariel-os-rt/embedded-test"]
 
 # Enables idle threads. Selected by laze if needed.
-idle-threads = ["ariel-os-threads/idle-threads"]
+idle-threads = [
+  "dep:ariel-os-threads",
+  "ariel-os-threads/idle-threads",
+  "ariel-os-embassy/threading",
+  "ariel-os-rt/threading",
+]
 
 # features needed for `cargo test`
 _test = [


### PR DESCRIPTION
## Summary
Decouple `executor-thread` feature from `threading` to enable AVR support using Embassy thread-mode executor directly without the full threading runtime.

## Changes
- **ariel-os/Cargo.toml**: `executor-thread = ["ariel-os-embassy/executor-thread"]` (removed `threading`)
- **ariel-os-embassy/Cargo.toml**: `executor-thread = ["ariel-os-embassy-common/executor-thread"]` (removed `threading`); added `[target.'cfg(context = "avr")'.dependencies]` with `embassy-executor` (arch-avr) + `embassy-avr` (time-driver-tc0)
- **ariel-os-embassy/src/lib.rs**: AVR-specific init path using `INIT_FUNCS` + `embassy_executor::Executor::new()` directly (non-threading)
- **ariel-os-embassy/src/thread_executor.rs**: Gated with `#[cfg(all(feature = "threading", not(context = "avr")))]`
- **ariel-os-rt/src/lib.rs**: Added AVR context to `cfg_select!` dispatch
- **ariel-os-rt/src/avr.rs** (new): AVR arch module with `#[avr_device::entry]` entry point, `init()`, `wfi()`, `sp()`, `stack()`
- **ariel-os-rt/Cargo.toml**: AVR target deps with `avr-device` + `atmega328p` feature
- **laze-project.yml**: Added `sw/threading` to `esp`, `stm32`, `native-chip` contexts (preserve threading for non-AVR)
- **ariel-os-avr/src/dummy/spi/main/mod.rs**: Added `Spi` enum and `Frequency` enum for SPI support

## Testing
- All AVR crates build: `ariel-os-avr`, `ariel-os-hal` (avr context), `ariel-os-embassy` (executor-thread), `ariel-os-rt` (atmega328p)
- Non-AVR `ariel-os-embassy` with `executor-thread` still builds
- Memory profile: 408 bytes flash, 20 bytes RAM

## Depends on
- PR #2230 (ariel-os-avr family crate)

## Related
- Embassy fork PR: https://github.com/ariel-os/embassy/pull/2
