### PR TITLE
feat(esp)!: Add DeviceId implementation based on efuse base mac address

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -363,6 +363,7 @@ contexts:
     selects:
       - ?espflash
     provides:
+      - has_device_identity
       - has_hwrng
     env:
       esp_wifi_heapsize_required: $(72*1024)

--- a/src/ariel-os-esp/src/identity.rs
+++ b/src/ariel-os-esp/src/identity.rs
@@ -1,0 +1,20 @@
+use ariel_os_embassy_common::identity;
+
+/// The device's factory-programmed base MAC address, read from eFuse.
+pub struct DeviceId([u8; 6]);
+
+impl identity::DeviceId for DeviceId {
+    type Bytes = [u8; 6];
+
+    #[expect(
+        refining_impl_trait_reachable,
+        reason = "making this fallible would be a breaking API change for Ariel OS"
+    )]
+    fn get() -> Result<Self, core::convert::Infallible> {
+        Ok(Self(esp_hal::efuse::Efuse::read_base_mac_address()))
+    }
+
+    fn bytes(&self) -> Self::Bytes {
+        self.0
+    }
+}

--- a/src/ariel-os-esp/src/lib.rs
+++ b/src/ariel-os-esp/src/lib.rs
@@ -38,11 +38,7 @@ pub mod hwrng {
 pub mod i2c;
 
 #[doc(hidden)]
-pub mod identity {
-    use ariel_os_embassy_common::identity;
-
-    pub type DeviceId = identity::NoDeviceId<identity::NotImplemented>;
-}
+pub mod identity;
 
 #[cfg(feature = "spi")]
 pub mod spi;


### PR DESCRIPTION
# Description

I'm trying to add support for the ESP32-S3 ETH from Waveshare, which uses a WIZnet chip. However, to connect to the WIZnet, I need to provide a MAC address. Without this change, `ariel_os_identity::interface_eui48(0)` just returns zeros.

<!-- A summary of your changes and why you made them. -->

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

Flashed it to my board and got `client_identifier: Some(42-04-01-7a-9f-b7)`

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

- [read_base_mac_address](https://docs.rs/esp-hal/1.0.0/esp_hal/efuse/struct.Efuse.html#method.read_base_mac_address) or [mac_address](https://docs.rs/esp-hal/1.0.0/esp_hal/efuse/struct.Efuse.html#method.mac_address), I chose `read_base_mac_address` because it's changeable with `set_mac_address`, but I don't know if that's desired
- It seems that the latest version of ESP-HAL has changed the API.

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The device ID for ESP boards is now backed by the eFuse MAC address
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
