### PR TITLE
feat(net): Add generic support for WIZnet SPI Ethernet chips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "embassy-futures",
  "embassy-hal-internal",
  "embassy-net",
+ "embassy-net-wiznet",
  "embassy-nrf",
  "embassy-rp",
  "embassy-stm32",
@@ -2083,6 +2084,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a07d2eb9f05a6fc876500949856ea1be40773d866d8cb99384f72d0ae4568c16"
 dependencies = [
+ "defmt 1.1.1",
  "embassy-futures",
  "embassy-net-driver",
  "embassy-sync 0.8.0",
@@ -2098,6 +2100,20 @@ dependencies = [
  "embassy-net-driver",
  "libc",
  "log",
+]
+
+[[package]]
+name = "embassy-net-wiznet"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336e290ec0eedc19e9d0a948d2f715ea187de79da517a0a24e55553c1a185ab8"
+dependencies = [
+ "defmt 1.1.1",
+ "embassy-futures",
+ "embassy-net-driver-channel 0.4.0",
+ "embassy-time",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ embassy-futures = { version = "0.1.2", default-features = false }
 embassy-hal-internal = { version = "0.3.0", default-features = false }
 embassy-net = { version = "0.9.1", default-features = false }
 embassy-net-driver-channel = { version = "0.3.2", default-features = false }
+embassy-net-wiznet = { version = "0.3.0", default-features = false }
 embassy-nrf = { version = "0.8.0", default-features = false }
 embassy-rp = { version = "0.8", default-features = false }
 embassy-stm32 = { version = "0.4", default-features = false }

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1378,6 +1378,70 @@ modules:
     selects:
       - doc-only
 
+  - name: ethernet-wiznet-w5500
+    selects:
+      - has_ethernet_w5500
+      - network
+    provides_unique:
+      - network_device
+      - wiznet_chip
+    env:
+      global:
+        FEATURES:
+          - ariel-os/wiznet-w5500
+
+  - name: has_ethernet_w5500
+    selects:
+      - doc-only
+
+  - name: ethernet-wiznet-w5100s
+    selects:
+      - has_ethernet_w5100s
+      - network
+    provides_unique:
+      - network_device
+      - wiznet_chip
+    env:
+      global:
+        FEATURES:
+          - ariel-os/wiznet-w5100s
+
+  - name: has_ethernet_w5100s
+    selects:
+      - doc-only
+
+  - name: ethernet-wiznet-w6100
+    selects:
+      - has_ethernet_w6100
+      - network
+    provides_unique:
+      - network_device
+      - wiznet_chip
+    env:
+      global:
+        FEATURES:
+          - ariel-os/wiznet-w6100
+
+  - name: has_ethernet_w6100
+    selects:
+      - doc-only
+
+  - name: ethernet-wiznet-w6300
+    selects:
+      - has_ethernet_w6300
+      - network
+    provides_unique:
+      - network_device
+      - wiznet_chip
+    env:
+      global:
+        FEATURES:
+          - ariel-os/wiznet-w6300
+
+  - name: has_ethernet_w6300
+    selects:
+      - doc-only
+
   - name: usb-ethernet
     provides_unique:
       - network_device

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -24,6 +24,7 @@ embassy-net = { workspace = true, optional = true, features = [
   "auto-icmp-echo-reply",
   "medium-ethernet",
 ] }
+embassy-net-wiznet = { workspace = true, optional = true }
 embassy-sync = { workspace = true }
 embassy-time = { workspace = true, optional = true }
 embassy-time-queue-utils = { workspace = true, optional = true }
@@ -146,6 +147,23 @@ wifi-esp = ["ariel-os-hal/wifi-esp", "net", "wifi"]
 
 ethernet = []
 ethernet-stm32 = ["ariel-os-hal/ethernet-stm32", "ethernet", "net"]
+## Enables support for WIZnet SPI Ethernet chips. This backend is HAL-agnostic (it only needs
+## generic SPI/GPIO support), so it lives here rather than in a per-chip HAL crate.
+ethernet-wiznet = [
+  "dep:embassy-net-wiznet",
+  "ethernet",
+  "external-interrupts",
+  "net",
+  "spi",
+]
+## Selects the W5500 as the WIZnet chip in use.
+wiznet-w5500 = ["ethernet-wiznet"]
+## Selects the W5100S as the WIZnet chip in use.
+wiznet-w5100s = ["ethernet-wiznet"]
+## Selects the W6100 as the WIZnet chip in use.
+wiznet-w6100 = ["ethernet-wiznet"]
+## Selects the W6300 as the WIZnet chip in use.
+wiznet-w6300 = ["ethernet-wiznet"]
 
 ltem-nrf-modem = [
   "ariel-os-hal/ltem-nrf-modem",
@@ -213,6 +231,7 @@ defmt = [
   "ariel-os-embassy-common/defmt",
   "ariel-os-hal/defmt",
   "embassy-executor/defmt",
+  "embassy-net-wiznet?/defmt",
   "embassy-net?/defmt",
   "embassy-time?/defmt",
   "embassy-usb?/defmt",

--- a/src/ariel-os-embassy/src/ethernet.rs
+++ b/src/ariel-os-embassy/src/ethernet.rs
@@ -1,2 +1,7 @@
 #[cfg(feature = "ethernet-stm32")]
 pub(crate) use crate::hal::ethernet::NetworkDevice;
+
+#[cfg(feature = "ethernet-wiznet")]
+pub(crate) mod wiznet;
+#[cfg(feature = "ethernet-wiznet")]
+pub(crate) use wiznet::NetworkDevice;

--- a/src/ariel-os-embassy/src/ethernet/wiznet.rs
+++ b/src/ariel-os-embassy/src/ethernet/wiznet.rs
@@ -1,0 +1,124 @@
+//! Provides support for WIZnet SPI Ethernet chips (W5500, W5100S, W6100, W6300).
+//!
+//! This backend is HAL-agnostic: it only relies on generic SPI/GPIO abstractions, so it works
+//! identically on any MCU family. Only the board-specific pin mapping needs to be added per board.
+
+cfg_select! {
+    // Add a `#[path = "wiznet/<board>.rs"] mod board;` arm here, gated on
+    // `context = "<board>"`, for each additional board that wires up a WIZnet chip.
+    context = "ariel-os" => {
+        compile_error!(
+            "no pin mapping for the WIZnet Ethernet driver is known for this board; add one to \
+             ariel-os-embassy/src/ethernet/wiznet.rs"
+        );
+    }
+    _ => {}
+}
+
+use embassy_executor::Spawner;
+use embassy_net_wiznet::{Runner, State};
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
+use static_cell::StaticCell;
+
+use ariel_os_hal::gpio;
+
+use crate::{
+    hal,
+    spi::main::{Kilohertz, SpiDevice, highest_freq_in},
+};
+
+/// Maximum SPI clock frequency to communicate with the WIZnet chip.
+///
+/// WIZnet chips are specified to support faster SPI clocks, but using the MCU's maximum
+/// available frequency (as [`hal::spi::main::Config::default()`] does) has been observed to
+/// corrupt reads (e.g. the chip version check failing) on at least the ESP32-S3. 20 MHz matches
+/// the clock speed used by Espressif's own W5500 examples and is a safe, well-tested choice.
+const MAX_WIZNET_SPI_FREQUENCY: Kilohertz = Kilohertz::MHz(20);
+
+cfg_select! {
+    feature = "wiznet-w5500" => {
+        pub use embassy_net_wiznet::chip::W5500 as WiznetChip;
+    }
+    feature = "wiznet-w5100s" => {
+        pub use embassy_net_wiznet::chip::W5100S as WiznetChip;
+    }
+    feature = "wiznet-w6100" => {
+        pub use embassy_net_wiznet::chip::W6100 as WiznetChip;
+    }
+    feature = "wiznet-w6300" => {
+        pub use embassy_net_wiznet::chip::W6300 as WiznetChip;
+    }
+    context = "ariel-os" => {
+        compile_error!(
+            "no WIZnet chip selected for the `ethernet-wiznet` backend; select exactly one of \
+             `wiznet-w5500`, `wiznet-w5100s`, `wiznet-w6100`, `wiznet-w6300`"
+        );
+    }
+    _ => {}
+}
+
+/// Number of packet buffers held by the driver in each direction.
+const N_RX: usize = 8;
+const N_TX: usize = 8;
+
+/// The [`embassy_net`](https://docs.rs/embassy-net) driver for this Ethernet chip.
+pub type NetworkDevice = embassy_net_wiznet::Device<'static>;
+
+#[embassy_executor::task]
+async fn ethernet_wiznet_task(
+    runner: Runner<
+        'static,
+        WiznetChip,
+        SpiDevice<'static>,
+        gpio::IntEnabledInput<'static>,
+        gpio::Output<'static>,
+    >,
+) -> ! {
+    runner.run().await
+}
+
+/// Initializes the WIZnet Ethernet chip and returns the [`NetworkDevice`] to be used by
+/// `embassy-net`.
+///
+/// # Panics
+///
+/// Panics if the chip does not respond as expected over SPI (e.g., because of a wiring issue),
+/// or if launching the driver task fails.
+pub(crate) async fn device(
+    peripherals: &mut hal::OptionalPeripherals,
+    spawner: Spawner,
+) -> NetworkDevice {
+    let pins = board::take_pins(peripherals);
+
+    let mut spi_config = hal::spi::main::Config::default();
+    spi_config.frequency = const { highest_freq_in(Kilohertz::kHz(1)..=MAX_WIZNET_SPI_FREQUENCY) };
+
+    let spi = board::WiznetSpi::new(pins.spi_sck, pins.spi_miso, pins.spi_mosi, spi_config);
+
+    static SPI_BUS: StaticCell<Mutex<CriticalSectionRawMutex, hal::spi::main::Spi>> =
+        StaticCell::new();
+    let spi_bus = SPI_BUS.init(Mutex::new(spi));
+    let cs = gpio::Output::new(pins.cs, gpio::Level::High);
+    let spi_dev = SpiDevice::new(spi_bus, cs);
+
+    let reset = gpio::Output::new(pins.reset, gpio::Level::High);
+    let int = gpio::Input::builder(pins.int, gpio::Pull::Up)
+        .build_with_interrupt()
+        .unwrap();
+
+    static STATE: StaticCell<State<N_RX, N_TX>> = StaticCell::new();
+    let state = STATE.init(State::new());
+
+    let mac_addr = ariel_os_identity::interface_eui48(0)
+        .expect("Should provide a valid MAC address")
+        .0;
+
+    let (device, runner) =
+        embassy_net_wiznet::new::<_, _, WiznetChip, _, _, _>(mac_addr, state, spi_dev, int, reset)
+            .await
+            .unwrap();
+
+    spawner.spawn(ethernet_wiznet_task(runner)).unwrap();
+
+    device
+}

--- a/src/ariel-os-embassy/src/ethernet/wiznet.rs
+++ b/src/ariel-os-embassy/src/ethernet/wiznet.rs
@@ -34,9 +34,9 @@ const MIN_WIZNET_SPI_FREQUENCY: Kilohertz = Kilohertz::MHz(10);
 ///
 /// WIZnet chips are specified to support faster SPI clocks, but using the MCU's maximum
 /// available frequency (as [`hal::spi::main::Config::default()`] does) has been observed to
-/// corrupt reads (e.g. the chip version check failing) on at least the ESP32-S3. 20 MHz matches
-/// the clock speed used by Espressif's own W5500 examples and is a safe, well-tested choice.
-const MAX_WIZNET_SPI_FREQUENCY: Kilohertz = Kilohertz::MHz(20);
+/// corrupt reads (e.g. the chip version check failing) on at least the ESP32-S3. Espressif's
+/// own W5500 examples use 20 MHz, but 30 MHz has been tested to work reliably as well.
+const MAX_WIZNET_SPI_FREQUENCY: Kilohertz = Kilohertz::MHz(30);
 
 cfg_select! {
     feature = "wiznet-w5500" => {

--- a/src/ariel-os-embassy/src/ethernet/wiznet.rs
+++ b/src/ariel-os-embassy/src/ethernet/wiznet.rs
@@ -27,6 +27,9 @@ use crate::{
     spi::main::{Kilohertz, SpiDevice, highest_freq_in},
 };
 
+/// Minimum SPI clock frequency to communicate with the WIZnet chip.
+const MIN_WIZNET_SPI_FREQUENCY: Kilohertz = Kilohertz::MHz(10);
+
 /// Maximum SPI clock frequency to communicate with the WIZnet chip.
 ///
 /// WIZnet chips are specified to support faster SPI clocks, but using the MCU's maximum
@@ -91,7 +94,9 @@ pub(crate) async fn device(
     let pins = board::take_pins(peripherals);
 
     let mut spi_config = hal::spi::main::Config::default();
-    spi_config.frequency = const { highest_freq_in(Kilohertz::kHz(1)..=MAX_WIZNET_SPI_FREQUENCY) };
+    spi_config.mode = crate::spi::Mode::Mode0;
+    spi_config.frequency =
+        const { highest_freq_in(MIN_WIZNET_SPI_FREQUENCY..=MAX_WIZNET_SPI_FREQUENCY) };
 
     let spi = board::WiznetSpi::new(pins.spi_sck, pins.spi_miso, pins.spi_mosi, spi_config);
 

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -318,6 +318,9 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     #[cfg(feature = "ethernet-stm32")]
     let device = hal::ethernet::device(&mut peripherals);
 
+    #[cfg(feature = "ethernet-wiznet")]
+    let device = ethernet::wiznet::device(&mut peripherals, spawner).await;
+
     #[cfg(feature = "usb")]
     {
         for hook in usb::USB_BUILDER_HOOKS {

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -159,6 +159,16 @@ wifi-cyw43 = ["ariel-os-embassy/wifi-cyw43"]
 wifi-esp = ["ariel-os-embassy/wifi-esp"]
 # Selects STM32 Ethernet
 ethernet-stm32 = ["ariel-os-embassy/ethernet-stm32"]
+# Selects Ethernet via a WIZnet SPI chip.
+ethernet-wiznet = ["ariel-os-embassy/ethernet-wiznet"]
+# Selects the W5500 as the WIZnet chip in use.
+wiznet-w5500 = ["ariel-os-embassy/wiznet-w5500"]
+# Selects the W5100S as the WIZnet chip in use.
+wiznet-w5100s = ["ariel-os-embassy/wiznet-w5100s"]
+# Selects the W6100 as the WIZnet chip in use.
+wiznet-w6100 = ["ariel-os-embassy/wiznet-w6100"]
+# Selects the W6300 as the WIZnet chip in use.
+wiznet-w6300 = ["ariel-os-embassy/wiznet-w6300"]
 # Selects the network backend that goes through tun/tap (native only).
 tuntap = ["ariel-os-embassy/tuntap"]
 # Selects LTE-M on nRF SiPs (currently only available on nRF91 SiPs).

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -553,6 +553,10 @@ criteria = "safe-to-deploy"
 version = "0.4.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.embassy-net-wiznet]]
+version = "0.3.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.embassy-nrf]]
 version = "0.8.0@git:3940a79a29ae578a35625cae949bea473abf21d1"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->

I'm trying to add support for the ESP32-S3 ETH from Waveshare, which uses a WIZnet chip. This wires up the embassy-net-wiznet driver. Later, I will make the PR for the board itself.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

I already tested it on my board and it works

## Issues/PRs References

This fix is needed for it to work: https://github.com/embassy-rs/embassy/commit/4aeb9c9966a9559a212e6690ccb625e2aada8e4a

For a unique MAC address on ESP ariel-os/ariel-os#2236 is needed

Would be cool to integrate with ariel-os/sbd#134, but it's almost half a year open

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

Without an additional 'select' in the 'run' command (`laze build -b waveshare-esp32-s3-eth -s ethernet-wiznet-w5500 run`), it seems that Laze still uses/enables Wifi-Esp. I don't know if this should be included in the scope of this PR.

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
WIZnet Ethernet chips connected via SPI are now supported
<!-- changelog:end -->
We'll skip the changelog for now, until we also land the docs (which we should only do after bumping `embassy-embedded-hal`).

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
