### PR TITLE
feat(identity)!: add support for reading the chip ID on RP235x

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -345,6 +345,7 @@ contexts:
     selects:
       - cortex-m33f
     provides:
+      - has_device_identity
       - has_multi_core_support
       - has_storage_support
     env:

--- a/src/ariel-os-rp/src/identity.rs
+++ b/src/ariel-os-rp/src/identity.rs
@@ -1,0 +1,15 @@
+cfg_select! {
+    context = "rp2040" => {
+        mod identity_rp2040;
+
+        pub use identity_rp2040::*;
+    }
+    context = "rp235xa" => {
+        mod identity_rp235x;
+
+        pub use identity_rp235x::*;
+    }
+    _ => {
+        compile_error!("this RP chip is not supported");
+    }
+}

--- a/src/ariel-os-rp/src/identity/identity_rp2040.rs
+++ b/src/ariel-os-rp/src/identity/identity_rp2040.rs
@@ -1,0 +1,3 @@
+use ariel_os_embassy_common::identity;
+
+pub type DeviceId = identity::NoDeviceId<identity::NotImplemented>;

--- a/src/ariel-os-rp/src/identity/identity_rp235x.rs
+++ b/src/ariel-os-rp/src/identity/identity_rp235x.rs
@@ -1,0 +1,51 @@
+use embassy_rp::otp;
+
+pub struct DeviceId(u64);
+
+impl ariel_os_embassy_common::identity::DeviceId for DeviceId {
+    type Bytes = [u8; 8];
+
+    fn get() -> Result<Self, impl core::error::Error> {
+        // The chip ID is considered to be globally unique.
+        let res = embassy_rp::otp::get_chipid();
+
+        match res {
+            Ok(id) => Ok(Self(id)),
+            Err(err) => match err {
+                // OTP page 0, which contains the chip ID, is hard locked (i.e., locked in OTP) to
+                // read-only during manufacturing; however it still seems possible to soft lock it
+                // to "inaccessible" (see the datasheet's section about permissions on blank
+                // devices).
+                otp::Error::InvalidPermissions => Err(Error::InvalidPermissions),
+                // Not a write operation to OTP.
+                otp::Error::UnsupportedModification | otp::Error::Overflow => unreachable!(),
+                // OTP indices are hard-coded when reading the chip ID.
+                otp::Error::InvalidIndex => unreachable!(),
+                // Cannot happen when reading the chip ID.
+                otp::Error::UnexpectedFailure(_) => unreachable!(),
+            },
+        }
+    }
+
+    fn bytes(&self) -> Self::Bytes {
+        self.0.to_le_bytes()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    InvalidPermissions,
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidPermissions => {
+                write!(f, "invalid permissions when reading the chip ID in OTP")
+            }
+        }
+    }
+}
+
+impl core::error::Error for Error {}

--- a/src/ariel-os-rp/src/lib.rs
+++ b/src/ariel-os-rp/src/lib.rs
@@ -32,11 +32,7 @@ pub mod hwrng;
 pub mod i2c;
 
 #[doc(hidden)]
-pub mod identity {
-    use ariel_os_embassy_common::identity;
-
-    pub type DeviceId = identity::NoDeviceId<identity::NotImplemented>;
-}
+pub mod identity;
 
 #[cfg(feature = "spi")]
 pub mod spi;


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This adds support for `identity::DeviceId` on RP235xA (because we don't [support the RP235xB](#1780) yet) by reading the unique chip ID stored in OTP.
My understanding is that reading the chip ID may fail when it is soft locked (the datasheet mentions that it cannot be hard locked), so this is the first example of a fallible implementation of `DeviceId`.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

Successfully tested with the following:

```sh
laze -C examples/device-metadata/ build -b rpi-pico2-w
```

which does print a stable ID.

The following still returns "Device ID is unavailable." as expected:

```sh
laze -C examples/device-metadata/ build -b rpi-pico-w run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(RP235xA) Support for obtaining a unique device identifier has been added, by retrieving the chip ID stored in OTP.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
