### PR TITLE
docs(book): add a page about Ethernet support

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -106,6 +106,7 @@
 - [Clocks](./clocks.md)
 - [Global Allocator](./global-allocator.md)
 - [Networking](./networking.md)
+- [Ethernet](./ethernet.md)
 - [USB](./usb.md)
 - [Bluetooth Low Energy](./bluetooth.md)
 - [Randomness and Entropy](./randomness.md)

--- a/book/src/chips/stm32h753zi.md
+++ b/book/src/chips/stm32h753zi.md
@@ -14,7 +14,7 @@
 |I2C Controller Mode|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 |SPI Main Mode|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
 |UART|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>|
-|Ethernet|<span title="supported with some caveats">☑️</span>[^currently-only-supported-on-a-limited-set-of-boards]|
+|Ethernet|<span title="supported with some caveats">☑️</span>[^the-pinout-of-the-rmii-is-currently-fixed-ethernet-md-using-microcontrollers-with-built-in-ethernet-mac]|
 |User USB|<span title="supported">✅</span>|
 |Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>[^usb-does-not-enumerate-https-github-com-embassy-rs-embassy-issues-2376-workaround-https-github-com-ariel-os-ariel-os-pull-1126]|
 |Wi-Fi|<span title="not available on this piece of hardware">–</span>|
@@ -177,6 +177,6 @@ The Ethernet MAC address is derived from the device identity using [`if_index` `
 A different index should therefore be used to generate other EUI-48 identifiers.
 
 
-[^currently-only-supported-on-a-limited-set-of-boards]: Currently only supported on a limited set of boards.
+[^the-pinout-of-the-rmii-is-currently-fixed-ethernet-md-using-microcontrollers-with-built-in-ethernet-mac]: The pinout of [the RMII is currently fixed](../ethernet.md#using-microcontrollers-with-built-in-ethernet-mac).
 [^usb-does-not-enumerate-https-github-com-embassy-rs-embassy-issues-2376-workaround-https-github-com-ariel-os-ariel-os-pull-1126]: [USB does not enumerate](https://github.com/embassy-rs/embassy/issues/2376), [workaround](https://github.com/ariel-os/ariel-os/pull/1126).
 [^removing-items-not-supported]: Removing items not supported.

--- a/book/src/chips/stm32h753zi.md
+++ b/book/src/chips/stm32h753zi.md
@@ -169,13 +169,6 @@ dt, dd {
 </style>
 
 
-## Additional Notes
-
-### Ethernet Link
-
-The Ethernet MAC address is derived from the device identity using [`if_index` `0`](https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/identity/fn.interface_eui48.html).
-A different index should therefore be used to generate other EUI-48 identifiers.
-
 
 [^the-pinout-of-the-rmii-is-currently-fixed-ethernet-md-using-microcontrollers-with-built-in-ethernet-mac]: The pinout of [the RMII is currently fixed](../ethernet.md#using-microcontrollers-with-built-in-ethernet-mac).
 [^usb-does-not-enumerate-https-github-com-embassy-rs-embassy-issues-2376-workaround-https-github-com-ariel-os-ariel-os-pull-1126]: [USB does not enumerate](https://github.com/embassy-rs/embassy/issues/2376), [workaround](https://github.com/ariel-os/ariel-os/pull/1126).

--- a/book/src/chips/stm32h755zi.md
+++ b/book/src/chips/stm32h755zi.md
@@ -14,7 +14,7 @@
 |I2C Controller Mode|<span title="supported">✅</span>|
 |SPI Main Mode|<span title="supported">✅</span>|
 |UART|<span title="supported">✅</span>|
-|Ethernet|<span title="supported with some caveats">☑️</span>[^currently-only-supported-on-a-limited-set-of-boards]|
+|Ethernet|<span title="supported with some caveats">☑️</span>[^the-pinout-of-the-rmii-is-currently-fixed-ethernet-md-using-microcontrollers-with-built-in-ethernet-mac]|
 |User USB|<span title="supported">✅</span>|
 |Ethernet over USB|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>[^usb-does-not-enumerate-https-github-com-embassy-rs-embassy-issues-2376-workaround-https-github-com-ariel-os-ariel-os-pull-1126]|
 |Wi-Fi|<span title="not available on this piece of hardware">–</span>|
@@ -177,6 +177,6 @@ The Ethernet MAC address is derived from the device identity using [`if_index` `
 A different index should therefore be used to generate other EUI-48 identifiers.
 
 
-[^currently-only-supported-on-a-limited-set-of-boards]: Currently only supported on a limited set of boards.
+[^the-pinout-of-the-rmii-is-currently-fixed-ethernet-md-using-microcontrollers-with-built-in-ethernet-mac]: The pinout of [the RMII is currently fixed](../ethernet.md#using-microcontrollers-with-built-in-ethernet-mac).
 [^usb-does-not-enumerate-https-github-com-embassy-rs-embassy-issues-2376-workaround-https-github-com-ariel-os-ariel-os-pull-1126]: [USB does not enumerate](https://github.com/embassy-rs/embassy/issues/2376), [workaround](https://github.com/ariel-os/ariel-os/pull/1126).
 [^removing-items-not-supported]: Removing items not supported.

--- a/book/src/chips/stm32h755zi.md
+++ b/book/src/chips/stm32h755zi.md
@@ -169,13 +169,6 @@ dt, dd {
 </style>
 
 
-## Additional Notes
-
-### Ethernet Link
-
-The Ethernet MAC address is derived from the device identity using [`if_index` `0`](https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/identity/fn.interface_eui48.html).
-A different index should therefore be used to generate other EUI-48 identifiers.
-
 
 [^the-pinout-of-the-rmii-is-currently-fixed-ethernet-md-using-microcontrollers-with-built-in-ethernet-mac]: The pinout of [the RMII is currently fixed](../ethernet.md#using-microcontrollers-with-built-in-ethernet-mac).
 [^usb-does-not-enumerate-https-github-com-embassy-rs-embassy-issues-2376-workaround-https-github-com-ariel-os-ariel-os-pull-1126]: [USB does not enumerate](https://github.com/embassy-rs/embassy/issues/2376), [workaround](https://github.com/ariel-os/ariel-os/pull/1126).

--- a/book/src/ethernet.md
+++ b/book/src/ethernet.md
@@ -2,6 +2,11 @@
 
 Ariel OS supports Ethernet (IEEE 802.3) on specific microcontrollers and hardware configurations.
 
+## MAC Address Used for the Ethernet Link
+
+The MAC address used for the Ethernet link is derived from the device identity using [`if_index 0`][identity-interface-eui48-rustdoc].
+A different index should therefore be used to generate other EUI-48 identifiers.
+
 ## Using Microcontrollers With Built-in Ethernet MAC
 
 Some microcontrollers include an Ethernet MAC peripheral, which requires an external PHY chip for the board to support Ethernet.
@@ -14,6 +19,7 @@ Using Ethernet as the network link is enabled by selecting the [`ethernet-stm32`
 > [!NOTE]
 > The built-in Ethernet MAC can be used on other boards, as long as the same pinout is used.
 
+[identity-interface-eui48-rustdoc]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/identity/fn.interface_eui48.html
 [mii-wikipedia]: https://en.wikipedia.org/wiki/Media-independent_interface
 [rmii-wikipedia]: https://en.wikipedia.org/wiki/Media-independent_interface#Reduced_media-independent_interface
 [ethernet-stm32-networking-book]: ./networking.md#:~:text=ethernet%2Dstm32

--- a/book/src/ethernet.md
+++ b/book/src/ethernet.md
@@ -1,0 +1,20 @@
+# Ethernet
+
+Ariel OS supports Ethernet (IEEE 802.3) on specific microcontrollers and hardware configurations.
+
+## Using Microcontrollers With Built-in Ethernet MAC
+
+Some microcontrollers include an Ethernet MAC peripheral, which requires an external PHY chip for the board to support Ethernet.
+The MAC communicates with the external PHY using the [media-independent interface][mii-wikipedia] (MII) or the [reduced media-independent interface][rmii-wikipedia] (RMII), which is almost functionally identical to the MII but requires half the signals between the MAC and the PHY.
+
+Currently, among the set of MCUs supported by Ariel OS, only some STM32 microcontrollers feature a built-in Ethernet MAC.
+On these MCUs, only the RMII is currently supported: its pinout is currently fixed, and is the same as the one used by the manufacturer's development kit demonstrating Ethernet functionality.
+Using Ethernet as the network link is enabled by selecting the [`ethernet-stm32`][ethernet-stm32-networking-book] [laze-module][laze-modules-book].
+
+> [!NOTE]
+> The built-in Ethernet MAC can be used on other boards, as long as the same pinout is used.
+
+[mii-wikipedia]: https://en.wikipedia.org/wiki/Media-independent_interface
+[rmii-wikipedia]: https://en.wikipedia.org/wiki/Media-independent_interface#Reduced_media-independent_interface
+[ethernet-stm32-networking-book]: ./networking.md#:~:text=ethernet%2Dstm32
+[laze-modules-book]: ./build-system.md#laze-modules

--- a/book/src/networking.md
+++ b/book/src/networking.md
@@ -14,8 +14,7 @@ Boards may support all of them, only some of them, or none of them. However, cur
 Which link layer is used for networking is selected at compile time,
 through [laze modules][laze-modules-book].
 
-- `ethernet-stm32`: Selects Ethernet on STM32 chips.
-  Currently only the reduced media-independent interface (RMII) is supported.
+- `ethernet-stm32`: Selects [Ethernet on STM32 chips][ethernet-builtin-mac-book], through the built-in MAC.
 - `ltem-nrf-modem`: Selects LTE-M on nRF91 MCUs.
 - `usb-ethernet`: Selects Ethernet over USB (currently using USB CDC-NCM).
 - `wifi-cyw43`: Selects Wi-Fi using the CYW43 chip along an RP2040 or RP235x MCU (e.g., on the Raspberry Pi Pico W or Pico 2 W).
@@ -136,6 +135,7 @@ For Ethernet over USB, ensure that, in addition to the USB cable used for flashi
 and debugging, the *user* USB port is also connected to the host computer with
 a second cable.
 
+[ethernet-builtin-mac-book]: ./ethernet.md#using-microcontrollers-with-built-in-ethernet-mac
 [rustdoc-homepage]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/index.html
 [config-attr-macro-rustdoc]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/attr.config.html
 [network-stack-rustdoc]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/net/fn.network_stack.html

--- a/book/templates/SUMMARY.md.tmpl
+++ b/book/templates/SUMMARY.md.tmpl
@@ -27,6 +27,7 @@
 - [Clocks](./clocks.md)
 - [Global Allocator](./global-allocator.md)
 - [Networking](./networking.md)
+- [Ethernet](./ethernet.md)
 - [USB](./usb.md)
 - [Bluetooth Low Energy](./bluetooth.md)
 - [Randomness and Entropy](./randomness.md)

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -764,7 +764,7 @@ chips:
       ethernet:
         status: supported_with_caveats
         comments:
-          - currently only supported on a limited set of boards
+          - the pinout of [the RMII is currently fixed](../ethernet.md#using-microcontrollers-with-built-in-ethernet-mac)
       ethernet_over_usb:
         status: not_currently_supported
         comments:
@@ -792,7 +792,7 @@ chips:
       ethernet:
         status: supported_with_caveats
         comments:
-          - currently only supported on a limited set of boards
+          - the pinout of [the RMII is currently fixed](../ethernet.md#using-microcontrollers-with-built-in-ethernet-mac)
       ethernet_over_usb:
         status: not_currently_supported
         comments:

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -78,12 +78,6 @@ functionalities:
     description:
 
 note_snippets:
-  - name: ethernet-identity-based-mac-address
-    content: |-
-      ### Ethernet Link
-
-      The Ethernet MAC address is derived from the device identity using [`if_index` `0`](https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/identity/fn.interface_eui48.html).
-      A different index should therefore be used to generate other EUI-48 identifiers.
   - name: espressif-devkit-two-usb-ports-only-usb-otg
     content: |-
       ##### USB Ports
@@ -780,8 +774,6 @@ chips:
           - removing items not supported
       wifi: not_available
       ble: not_available
-    note_snippets:
-      - ethernet-identity-based-mac-address
 
   stm32h755zi:
     name: STM32H755ZI
@@ -808,8 +800,6 @@ chips:
           - removing items not supported
       wifi: not_available
       ble: not_available
-    note_snippets:
-      - ethernet-identity-based-mac-address
 
   stm32l475vg:
     name: STM32L475VG


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This adds a book page about Ethernet support. The main motivation is to have a follow-up PR that documents support for external Ethernet MAC chips (see #2237). *This* PR only documents the current state, which is the support of the built-in Ethernet MAC on STM32 chips (with the RMII pinout being hard-coded).

## Future Work

This is only intended as a first version, the page could use some more background to be more beginner-friendly.

In addition, the following could be done in follow-up:

- Documenting typical supported Ethernet speeds
- Documenting the clock configuration required for the built-in Ethernet MAC on STM32
- Documenting power management considerations, especially Wake on LAN capabilities and [EEE](https://en.wikipedia.org/wiki/Energy-Efficient_Ethernet) (if relevant) 

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
A page dedicated to Ethernet support has been added to the book.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
