### PR TITLE
feat(esp): generate esp partition table using memsolve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,7 @@ dependencies = [
 name = "ariel-os-esp"
 version = "0.5.0"
 dependencies = [
+ "ariel-os-buildutils",
  "ariel-os-embassy-common",
  "ariel-os-log",
  "ariel-os-random",
@@ -458,6 +459,7 @@ dependencies = [
  "embassy-rp",
  "embedded-test",
  "esp-hal",
+ "esp-idf-part",
  "ld-memory",
  "linkme",
  "memsolve",
@@ -902,6 +904,21 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "ble-advertiser"
@@ -1538,6 +1555,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,6 +1823,31 @@ checksum = "c0f73a4a4a91609e977ae3b7bd831ffa292edfd42ad140a3244a61d805b0e05e"
 dependencies = [
  "critical-section",
  "defmt 1.1.1",
+]
+
+[[package]]
+name = "deku"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9711031e209dc1306d66985363b4397d4c7b911597580340b93c9729b55f6eb"
+dependencies = [
+ "bitvec",
+ "deku_derive",
+ "no_std_io2",
+ "rustversion",
+]
+
+[[package]]
+name = "deku_derive"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58cb0719583cbe4e81fb40434ace2f0d22ccc3e39a74bb3796c22b451b4f139d"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2751,6 +2814,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-idf-part"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5ebc2381d030e4e89183554c3fcd4ad44dc5ab34961ab09e09b4adbe4f94b61"
+dependencies = [
+ "bitflags 2.9.1",
+ "csv",
+ "deku",
+ "md-5",
+ "parse_int",
+ "regex",
+ "serde",
+ "serde_plain",
+ "strum",
+ "thiserror",
+]
+
+[[package]]
 name = "esp-metadata-generated"
 version = "0.3.0"
 source = "git+https://github.com/ariel-os/esp-hal?rev=531c629afdd80ea464682ce7f4db8baed97967a6#531c629afdd80ea464682ce7f4db8baed97967a6"
@@ -3252,6 +3333,12 @@ dependencies = [
  "defmt 0.3.100",
  "gcd",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -4181,6 +4268,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,6 +4290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9613770670a70499e0a10a313f0a5010a0a21b038fd07dec258e67716c3ab865"
 dependencies = [
  "conv",
+ "esp-idf-part",
  "ld-memory",
  "microlp",
  "thiserror",
@@ -4290,6 +4388,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nom"
@@ -4620,6 +4727,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
+]
+
+[[package]]
+name = "parse_int"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c464266693329dd5a8715098c7f86e6c5fd5d985018b8318f53d9c6c2b21a31"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -5041,6 +5157,12 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "ral-registers"
@@ -5558,6 +5680,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5942,6 +6073,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-triple"
@@ -6796,6 +6933,15 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xtensa-lx"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "ariel-os-embassy-common",
  "ariel-os-log",
  "ariel-os-random",
+ "ariel-os-rt",
  "ariel-os-utils",
  "bt-hci",
  "cyw43",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ dependencies = [
  "esp-hal",
  "ld-memory",
  "linkme",
+ "memsolve",
  "portable-atomic",
  "riscv",
 ]
@@ -1002,6 +1003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1413,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+dependencies = [
+ "custom_derive",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1570,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
 name = "cyw43"
@@ -3912,6 +3934,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,9 +4159,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "managed"
@@ -4138,10 +4170,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memsolve"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9613770670a70499e0a10a313f0a5010a0a21b038fd07dec258e67716c3ab865"
+dependencies = [
+ "conv",
+ "ld-memory",
+ "microlp",
+ "thiserror",
+]
+
+[[package]]
+name = "microlp"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f19803f918039a07f3c32b23716824d8f073543417bdac5b1b8619817e3674"
+dependencies = [
+ "log",
+ "sprs",
+ "web-time",
+]
 
 [[package]]
 name = "minicbor"
@@ -4203,6 +4268,21 @@ name = "nb"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
 
 [[package]]
 name = "new_debug_unreachable"
@@ -4354,6 +4434,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -5021,6 +5110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rbi"
 version = "0.1.1"
 
@@ -5668,6 +5763,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sprs"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dca58a33be2188d4edc71534f8bafa826e787cc28ca1c47f31be3423f0d6e55"
+dependencies = [
+ "ndarray",
+ "num-complex",
+ "num-traits",
+ "smallvec",
+]
+
+[[package]]
 name = "ssmarshal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5814,6 +5921,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5942,22 +6060,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6422,6 +6540,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ esp-bootloader-esp-idf = { version = "0.4.0", features = ["esp-rom-sys"] }
 esp-hal = { version = "~1.0.0", default-features = false, features = [
   "unstable",
 ] }
+esp-idf-part = { version = "0.6.0" }
 esp-metadata-generated = { version = "0.3.0", default-features = false }
 esp-println = { version = "0.16.0", default-features = false }
 esp-radio = { version = "0.17.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ heapless = { version = "0.9.1", default-features = false }
 jiff = { version = "0.2", default-features = false }
 ld-memory = { version = "0.2.9" }
 log = { version = "0.4.20", default-features = false }
+memsolve = { version = "0.2.4", default-features = false }
 once_cell = { version = "1.21.3", default-features = false, features = [
   "critical-section",
 ] }

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -54,6 +54,9 @@ contexts:
           CARGO_TARGET_DIR=${relroot}/${build-dir}/bin/${builder}/cargo
           CONFIG_EXECUTOR_STACKSIZE=${CONFIG_EXECUTOR_STACKSIZE}
           CONFIG_ISR_STACKSIZE=${CONFIG_ISR_STACKSIZE}
+          CHIP_NVM_PAGE_COUNT=${CHIP_NVM_PAGE_COUNT}
+          CHIP_NVM_START_ADDRESS=${CHIP_NVM_START_ADDRESS}
+          CHIP_NVM_PAGE_SIZE_BYTES=${CHIP_NVM_PAGE_SIZE_BYTES}
       PROFILE: release
       PROFILE_DIR: $(if("${PROFILE}"=="dev", "debug", "${PROFILE}"))
       PROBE_RS_PROTOCOL: swd
@@ -204,6 +207,11 @@ contexts:
       - has_device_identity
       - has_swi
       - sw/benchmark
+    env:
+      # Most common flash page size
+      CHIP_NVM_PAGE_SIZE_BYTES: "4096"
+      CHIP_NVM_START_ADDRESS: "0x0"
+
 
   - name: nrf51
     parent: nrf
@@ -211,6 +219,8 @@ contexts:
       - cortex-m0
     provides:
       - has_hwrng
+    env:
+      CHIP_NVM_PAGE_SIZE_BYTES: "1024"
 
   - name: nrf51822-xxaa
     parent: nrf51
@@ -218,6 +228,7 @@ contexts:
       - ram-tiny
     env:
       PROBE_RS_CHIP: nrf51822_xxAA
+      CHIP_NVM_PAGE_COUNT: "256"
 
   - name: nrf52
     parent: nrf
@@ -238,6 +249,7 @@ contexts:
       - has_ble_nrf
     env:
       PROBE_RS_CHIP: nrf52832_xxAA
+      CHIP_NVM_PAGE_COUNT: "128"
 
   - name: nrf52833
     parent: nrf52
@@ -247,6 +259,7 @@ contexts:
       - has_ble_nrf
     env:
       PROBE_RS_CHIP: nrf52833_xxAA
+      CHIP_NVM_PAGE_COUNT: "128"
 
   - name: nrf52840
     parent: nrf52
@@ -256,6 +269,7 @@ contexts:
       - has_ble_nrf
     env:
       PROBE_RS_CHIP: nrf52840_xxAA
+      CHIP_NVM_PAGE_COUNT: "256"
 
   - name: nrf53
     parent: nrf
@@ -268,6 +282,7 @@ contexts:
       - has_storage_support
     env:
       PROBE_RS_CHIP: nrf5340_xxAA
+      CHIP_NVM_PAGE_COUNT: "128"
 
   - name: nrf5340-net
     parent: nrf53
@@ -283,6 +298,9 @@ contexts:
       - usb
     env:
       PROBE_RS_CHIP: nrf5340_xxAA
+      CHIP_NVM_START_ADDRESS: "0x01000000"
+      CHIP_NVM_PAGE_COUNT: "128"
+      CHIP_NVM_PAGE_SIZE_BYTES: "2048"
     help: nRF5340 Network Core support
 
   - name: nrf91
@@ -293,6 +311,8 @@ contexts:
       # For blinky the measured consumption is ~3milliAmps without nrf91-modem to ~4 microAmps with nrf91-modem.
       # Tested using the ppk2 in ampere mode on the Thingy:91 X and nrf9160dk.
       - ?nrf91-modem
+    env:
+      CHIP_NVM_PAGE_COUNT: "256"
 
   - name: nrf9160
     parent: nrf91

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -397,6 +397,9 @@ contexts:
       RUSTFLAGS:
         # linkall first
         - -Clink-arg=-Tlinkall.x
+      CHIP_NVM_PAGE_SIZE_BYTES: "4096"
+      CHIP_NVM_START_ADDRESS: "0x9000" # skips the bootloader and partition table space.
+      CHIP_NVM_PAGE_COUNT: "1015"
 
   - name: esp32
     parent: esp

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -57,6 +57,7 @@ contexts:
           CHIP_NVM_PAGE_COUNT=${CHIP_NVM_PAGE_COUNT}
           CHIP_NVM_START_ADDRESS=${CHIP_NVM_START_ADDRESS}
           CHIP_NVM_PAGE_SIZE_BYTES=${CHIP_NVM_PAGE_SIZE_BYTES}
+          ESP_PARTITION_FILE=${ESP_PARTITION_FILE}
       PROFILE: release
       PROFILE_DIR: $(if("${PROFILE}"=="dev", "debug", "${PROFILE}"))
       PROBE_RS_PROTOCOL: swd
@@ -394,6 +395,7 @@ contexts:
       - has_hwrng
     env:
       esp_wifi_heapsize_required: $(72*1024)
+      ESP_PARTITION_FILE: ${relroot}/${build-dir}/bin/${builder}/cargo/${RUSTC_TARGET}/${PROFILE_DIR}/${app}-partitions.csv
       RUSTFLAGS:
         # linkall first
         - -Clink-arg=-Tlinkall.x
@@ -1149,12 +1151,12 @@ modules:
       - flashing-tool
     env:
       global:
-        CARGO_RUNNER: '"espflash flash --monitor"'
+        CARGO_RUNNER: '"espflash flash --monitor --partition-table ${ESP_PARTITION_FILE}"'
     tasks:
       flash:
         help: flash the target using `espflash`
         cmd:
-          - espflash flash --after hard-reset ${out} $@
+          - espflash flash --partition-table ${ESP_PARTITION_FILE} --after hard-reset ${out} $@
 
       attach:
         help: attach `espflash` to a running target

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -340,9 +340,9 @@ contexts:
       - has_swi
       - sw/benchmark
     env:
-      CHIP_ROM_START_ADDRESS: "0x10000000"
-      CHIP_ROM_PAGE_COUNT: "8192"
-      CHIP_ROM_PAGE_SIZE_BYTES: "256"
+      CHIP_NVM_START_ADDRESS: "0x10000000"
+      CHIP_NVM_PAGE_COUNT: "8192"
+      CHIP_NVM_PAGE_SIZE_BYTES: "256"
 
   - name: rp2040
     parent: rp
@@ -377,6 +377,9 @@ contexts:
         - ${SCRIPTS}/debug-openocd.sh
       OPENOCD_ARGS:
         - "-f interface/cmsis-dap.cfg -f target/rp2040.cfg"
+      RUSTFLAGS:
+        # Extra rp235xa link bits
+        - -Clink-arg=-Tmemory-rp235xa.x
     tasks:
       flash:
         cmd:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -339,6 +339,10 @@ contexts:
       - has_hwrng
       - has_swi
       - sw/benchmark
+    env:
+      CHIP_ROM_START_ADDRESS: "0x10000000"
+      CHIP_ROM_PAGE_COUNT: "8192"
+      CHIP_ROM_PAGE_SIZE_BYTES: "256"
 
   - name: rp2040
     parent: rp

--- a/src/ariel-os-buildutils/src/lib.rs
+++ b/src/ariel-os-buildutils/src/lib.rs
@@ -1,4 +1,6 @@
 //! Ariel OS build-time tools.
+use std::env;
+use std::path::PathBuf;
 
 /// Returns the first of the given contexts that is in the current `cfg` contexts.
 #[must_use]
@@ -16,4 +18,42 @@ pub fn context(context: &'static str) -> bool {
 
     // Contexts cannot include commas.
     context_var.split(',').any(|c| c == context)
+}
+
+/// Tells Cargo to re-run the build script if the file has changed.
+pub fn rerun_if_changed(file: &str) {
+    println!("cargo::rerun-if-changed={file}");
+}
+
+/// Tells Cargo to re-run the build script if the environment variable has changed.
+pub fn rerun_if_env_changed(env: &str) {
+    println!("cargo::rerun-if-env-changed={env}");
+}
+
+/// Copies over the file to the `OUT_DIR` and tells cargo to re-run the build script if this file
+/// has changed.
+///
+/// # Panics
+///
+/// Panics when `OUT_DIR` is not set, or when the supplied file name cannot be copied.
+pub fn copy_and_rerun_if_changed(file: impl AsRef<std::path::Path>) {
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let file = file.as_ref();
+    std::fs::copy(file, out.join(file.file_name().unwrap())).unwrap();
+    rerun_if_changed(file.to_str().unwrap());
+}
+
+/// Fetches the environment variable key from the current process and tells cargo to re-run the
+/// build script if this variable has changed.
+///
+/// # Errors
+///
+/// Returns ``VarError::NotPresent`` if:
+/// - The variable is not set.
+/// - The variable’s name contains an equal sign or NUL ('=' or '\0').
+///
+/// Returns ``VarError::NotUnicode`` if the variable’s value is not valid Unicode.
+pub fn env_var_and_rerun_if_changed(key: &str) -> Result<String, std::env::VarError> {
+    rerun_if_env_changed(key);
+    std::env::var(key)
 }

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 ariel-os-embassy-common = { workspace = true }
 ariel-os-log = { workspace = true }
 ariel-os-random = { workspace = true, optional = true }
-ariel-os-rt = { workspace = true, features = ["alloc"] }
+ariel-os-rt = { workspace = true, features = ["alloc", "esp-partition"] }
 ariel-os-threads = { workspace = true, optional = true }
 ariel-os-utils = { workspace = true }
 critical-section = { workspace = true }
@@ -48,6 +48,9 @@ static_cell = { workspace = true }
 
 # BLE dependencies
 bt-hci = { workspace = true, optional = true }
+
+[build-dependencies]
+ariel-os-buildutils = { workspace = true }
 
 [target.'cfg(context = "esp32")'.dependencies]
 esp-bootloader-esp-idf = { workspace = true, features = ["esp32"] }

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 ariel-os-embassy-common = { workspace = true }
 ariel-os-log = { workspace = true }
 ariel-os-random = { workspace = true, optional = true }
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 ariel-os-utils = { workspace = true }
 defmt = { workspace = true, optional = true }
 embassy-embedded-hal = { workspace = true, optional = true }

--- a/src/ariel-os-rp/build.rs
+++ b/src/ariel-os-rp/build.rs
@@ -1,8 +1,7 @@
 use std::env;
-use std::fs::copy;
 use std::path::PathBuf;
 
-use ariel_os_buildutils::context;
+use ariel_os_buildutils::{context, copy_and_rerun_if_changed};
 
 fn main() {
     if !context("ariel-os") {
@@ -10,21 +9,11 @@ fn main() {
         return;
     }
 
-    // Put the linker script somewhere the linker can find it
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    if context("rp235xa") {
+        // Put the extra linker script somewhere the linker can find it
+        copy_and_rerun_if_changed("memory-rp235xa.x");
 
-    let memory_script = if context("rp2040") {
-        "memory.x"
-    } else if context("rp235xa") {
-        "memory-rp235xa.x"
-    } else {
-        panic!("unsupported RP MCU");
-    };
-
-    copy(memory_script, out.join("memory.x")).unwrap();
-
-    println!("cargo:rustc-link-search={}", out.display());
-
-    println!("cargo:rerun-if-changed=memory.x");
-    println!("cargo:rerun-if-changed=build.rs");
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        println!("cargo:rustc-link-search={}", out.display());
+    }
 }

--- a/src/ariel-os-rp/memory-rp235xa.x
+++ b/src/ariel-os-rp/memory-rp235xa.x
@@ -1,26 +1,3 @@
-MEMORY {
-    /*
-     * The RP235x has either external or internal flash.
-     *
-     * 2 MiB is a safe default here, although an RP2354 has 4 MiB.
-     */
-    FLASH : ORIGIN = 0x10000000, LENGTH = 2048K
-    /*
-     * RAM consists of 8 banks, SRAM0-SRAM7, with a striped mapping.
-     * This is usually good for performance, as it distributes load on
-     * those banks evenly.
-     */
-    RAM : ORIGIN = 0x20000000, LENGTH = 512K
-    /*
-     * RAM banks 8 and 9 use a direct mapping. They can be used to have
-     * memory areas dedicated for some specific job, improving predictability
-     * of access times.
-     * Example: Separate stacks for core0 and core1.
-     */
-    SRAM4 : ORIGIN = 0x20080000, LENGTH = 4K
-    SRAM5 : ORIGIN = 0x20081000, LENGTH = 4K
-}
-
 SECTIONS {
     /* ### Boot ROM info
      *

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -18,6 +18,7 @@ linkme = { workspace = true }
 [build-dependencies]
 ariel-os-buildutils = { workspace = true }
 ld-memory = { workspace = true, features = ["build-rs"], optional = true }
+memsolve = { workspace = true, optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
 cortex-m = { workspace = true }
@@ -58,7 +59,7 @@ panic-printing = []
 _panic-handler = []
 single-core = ["cortex-m/critical-section-single-core"]
 multi-core = ["embassy-rp/critical-section-impl"]
-memory-x = ["dep:ld-memory"]
+memory-x = ["dep:ld-memory", "dep:memsolve"]
 nrf91-modem = []
 
 # features needed for `cargo test`

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -17,6 +17,7 @@ linkme = { workspace = true }
 
 [build-dependencies]
 ariel-os-buildutils = { workspace = true }
+esp-idf-part = { workspace = true, optional = true }
 ld-memory = { workspace = true, features = ["build-rs"], optional = true }
 memsolve = { workspace = true, optional = true }
 
@@ -60,6 +61,7 @@ _panic-handler = []
 single-core = ["cortex-m/critical-section-single-core"]
 multi-core = ["embassy-rp/critical-section-impl"]
 memory-x = ["dep:ld-memory", "dep:memsolve"]
+esp-partition = ["memory-x", "dep:esp-idf-part", "memsolve/esp"]
 nrf91-modem = []
 
 # features needed for `cargo test`

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -1,7 +1,9 @@
 use std::env;
 use std::path::PathBuf;
 
-use ariel_os_buildutils::{context, context_any};
+use ariel_os_buildutils::{
+    context, context_any, copy_and_rerun_if_changed, env_var_and_rerun_if_changed,
+};
 
 // 32 KiB recommended by [nrf-modem](https://github.com/diondokter/nrf-modem?tab=readme-ov-file#memory)
 #[allow(dead_code, reason = "only used when the feature is enabled")]
@@ -49,26 +51,21 @@ fn main() {
     }
 
     if context("xtensa") {
-        let isr_stacksize =
-            std::env::var("CONFIG_ISR_STACKSIZE").expect("CONFIG_ISR_STACKSIZE env var not set");
+        let isr_stacksize = env_var_and_rerun_if_changed("CONFIG_ISR_STACKSIZE")
+            .expect("CONFIG_ISR_STACKSIZE env var not set");
         let template = std::fs::read_to_string("isr_stack_xtensa.ld.in")
             .unwrap()
             .replace("${ISR_STACKSIZE}", &isr_stacksize);
         std::fs::write(out.join("isr_stack_xtensa.x"), &template).unwrap();
         println!("cargo:rerun-if-changed=isr_stack_xtensa.ld.in");
-        println!("cargo:rerun-if-env-changed=CONFIG_ISR_STACKSIZE");
     }
 
-    std::fs::copy("linkme.x", out.join("linkme.x")).unwrap();
-    std::fs::copy("eheap.x", out.join("eheap.x")).unwrap();
-    std::fs::copy("keep-stack-sizes.x", out.join("keep-stack-sizes.x")).unwrap();
+    copy_and_rerun_if_changed("linkme.x");
+    copy_and_rerun_if_changed("eheap.x");
+    copy_and_rerun_if_changed("keep-stack-sizes.x");
 
     #[cfg(feature = "memory-x")]
     write_memoryx();
-
-    println!("cargo:rerun-if-changed=linkme.x");
-    println!("cargo:rerun-if-changed=eheap.x");
-    println!("cargo:rerun-if-changed=keep-stack-sizes.x");
 
     println!("cargo:rustc-link-search={}", out.display());
 }

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -70,7 +70,7 @@ fn main() {
     copy_and_rerun_if_changed("keep-stack-sizes.x");
 
     #[cfg(feature = "memory-x")]
-    write_memoryx();
+    memoryx();
 
     println!("cargo:rustc-link-search={}", out.display());
 }
@@ -80,7 +80,7 @@ fn main() {
 /// # Panics
 /// Panics if called outside of a known laze context.
 #[cfg(feature = "memory-x")]
-fn write_memoryx() {
+fn memoryx() {
     let nvm_start = parse_dec_or_hex(
         &env_var_and_rerun_if_changed("CHIP_NVM_START_ADDRESS")
             .expect("CHIP_NVM_START_ADDRESS env var not set"),
@@ -101,16 +101,19 @@ fn write_memoryx() {
     let layout = memsolve::Memory::new(chip);
     let layout = if context("nrf") {
         layout_nrf(layout)
+    } else if context("rp") {
+        layout_rp(layout)
     } else {
         panic!("unknown MCU laze context");
     };
-
     let memory = layout
         .resolve_layout()
         .expect("Unable to resolve nvm layout")
         .into_memory();
     let memory = if context("nrf") {
         memory_nrf(memory)
+    } else if context("rp") {
+        memory_rp(memory)
     } else {
         panic!("unknown MCU laze context");
     };
@@ -172,6 +175,50 @@ fn memory_nrf(memory: ld_memory::Memory) -> ld_memory::Memory {
     ));
 
     memory.add_section(MemorySection::new("RAM", ram_base, ram * 1024))
+}
+
+/// Generates the rp nvm layout.
+///
+/// # Panics
+/// Panics if called outside of a known laze context.
+#[cfg(feature = "memory-x")]
+fn layout_rp(mut layout: memsolve::Memory<()>) -> memsolve::Memory<()> {
+    if context("rp2040") {
+        let boot = Section::new("BOOT2").unwrap().set_size(256).set_boot(true);
+        layout.add_section(boot);
+        layout.add_section(flash_section().set_address(0x1000_0100));
+    } else {
+        layout.add_section(flash_section().set_boot(true));
+    }
+    layout
+}
+
+/// Adds the rp memory sections to the generated layout.
+///
+/// # Panics
+/// Panics if called outside of a known laze context.
+#[cfg(feature = "memory-x")]
+fn memory_rp(memory: ld_memory::Memory) -> ld_memory::Memory {
+    let ram = if context("rp2040") {
+        256
+    } else if context("rp235xa") {
+        512
+    } else {
+        panic!("unknown rp MCU laze context");
+    };
+
+    let memory = memory.add_section(MemorySection::new("RAM", 0x2000_0000, ram * 1024));
+    if context("rp2040") {
+        memory
+            .add_section(MemorySection::new("SRAM4", 0x2004_0000, 4096))
+            .add_section(MemorySection::new("SRAM5", 0x2004_1000, 4096))
+    } else if context("rp235xa") {
+        memory
+            .add_section(MemorySection::new("SRAM4", 0x2008_0000, 4096))
+            .add_section(MemorySection::new("SRAM5", 0x2008_1000, 4096))
+    } else {
+        panic!("unknown rp MCU laze context");
+    }
 }
 
 /// Parses a number, supporting hexadecimal and decimal format.

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -5,6 +5,11 @@ use ariel_os_buildutils::{
     context, context_any, copy_and_rerun_if_changed, env_var_and_rerun_if_changed,
 };
 
+#[cfg(feature = "memory-x")]
+use ld_memory::MemorySection;
+#[cfg(feature = "memory-x")]
+use memsolve::section::Section;
+
 // 32 KiB recommended by [nrf-modem](https://github.com/diondokter/nrf-modem?tab=readme-ov-file#memory)
 #[allow(dead_code, reason = "only used when the feature is enabled")]
 const NRF91_MODEM_IPC_KB: u64 = 32;
@@ -76,47 +81,88 @@ fn main() {
 /// Panics if called outside of a known laze context.
 #[cfg(feature = "memory-x")]
 fn write_memoryx() {
-    use ld_memory::{Memory, MemorySection};
-    let (ram, flash) = if context("nrf51822-xxaa") {
-        (16, 256)
+    let nvm_start = parse_dec_or_hex(
+        &env_var_and_rerun_if_changed("CHIP_NVM_START_ADDRESS")
+            .expect("CHIP_NVM_START_ADDRESS env var not set"),
+    )
+    .expect("CHIP_NVM_START_ADDRESS is not a decimal or hex value");
+    let nvm_page_size = parse_dec_or_hex(
+        &env_var_and_rerun_if_changed("CHIP_NVM_PAGE_SIZE_BYTES")
+            .expect("CHIP_NVM_PAGE_SIZE_BYTES env var not set"),
+    )
+    .expect("CHIP_NVM_PAGE_SIZE_BYTES is not a decimal or hex value");
+    let nvm_page_count = env_var_and_rerun_if_changed("CHIP_NVM_PAGE_COUNT")
+        .expect("CHIP_NVM_PAGE_COUNT env var not set")
+        .parse::<u64>()
+        .expect("CHIP_NVM_PAGE_COUNT is not a decimal number");
+
+    let chip = memsolve::chip::Chip::new(nvm_page_size, nvm_start, nvm_page_size * nvm_page_count)
+        .unwrap();
+    let layout = memsolve::Memory::new(chip);
+    let layout = if context("nrf") {
+        layout_nrf(layout)
+    } else {
+        panic!("unknown MCU laze context");
+    };
+
+    let memory = layout
+        .resolve_layout()
+        .expect("Unable to resolve nvm layout")
+        .into_memory();
+    let memory = if context("nrf") {
+        memory_nrf(memory)
+    } else {
+        panic!("unknown MCU laze context");
+    };
+    memory.to_cargo_outdir("memory.x").expect("wrote memory.x");
+}
+
+/// Generates the nrf nvm layout.
+///
+/// # Panics
+/// Panics if called outside of a known laze context.
+#[cfg(feature = "memory-x")]
+fn layout_nrf(mut layout: memsolve::Memory<()>) -> memsolve::Memory<()> {
+    layout.add_section(flash_section().set_boot(true));
+    layout
+}
+
+/// Adds the nrf memory sections to the generated layout.
+///
+/// # Panics
+/// Panics if called outside of a known laze context.
+#[cfg(feature = "memory-x")]
+fn memory_nrf(memory: ld_memory::Memory) -> ld_memory::Memory {
+    let ram = if context("nrf51822-xxaa") {
+        16
     } else if context("nrf52832") {
-        (64, 256)
+        64
     } else if context("nrf52833") {
-        (128, 512)
+        128
     } else if context("nrf52840") {
-        (256, 1024)
+        256
     } else if context("nrf5340-app") {
-        (512, 1024)
+        512
     } else if context("nrf5340-net") {
-        (64, 256)
+        64
     } else if context_any(&["nrf9151", "nrf9160"]).is_some() {
         let ram = 256;
-        let flash = 1024;
         if cfg!(feature = "nrf91-modem") {
-            (ram - NRF91_MODEM_IPC_KB, flash)
+            ram - NRF91_MODEM_IPC_KB
         } else {
-            (ram, flash)
+            ram
         }
     } else {
         panic!("please set the MCU laze context");
     };
 
-    let (pagesize, ram_base, flash_base) = if context("nrf5340-net") {
-        (2048, 0x2100_0000, 0x0100_0000)
+    let ram_base = if context("nrf5340-net") {
+        0x2100_0000
     } else if cfg!(feature = "nrf91-modem") {
-        (4096, 0x2000_0000 + NRF91_MODEM_IPC_KB * 1024, 0)
+        0x2000_0000 + NRF91_MODEM_IPC_KB * 1024
     } else {
-        (4096, 0x2000_0000, 0)
+        0x2000_0000
     };
-
-    // generate linker script
-    let memory = Memory::new()
-        .add_section(MemorySection::new("RAM", ram_base, ram * 1024))
-        .add_section(
-            MemorySection::new("FLASH", flash_base, flash * 1024)
-                .pagesize(pagesize)
-                .from_env(),
-        );
 
     #[cfg(feature = "nrf91-modem")]
     let memory = memory.add_section(MemorySection::new(
@@ -125,5 +171,29 @@ fn write_memoryx() {
         NRF91_MODEM_IPC_KB * 1024,
     ));
 
-    memory.to_cargo_outdir("memory.x").expect("wrote memory.x");
+    memory.add_section(MemorySection::new("RAM", ram_base, ram * 1024))
+}
+
+/// Parses a number, supporting hexadecimal and decimal format.
+///
+/// # Errors
+///
+/// Returns ``std::num::ParseIntError`` when the number is neither decimal, nor hexadecimal.
+#[cfg(feature = "memory-x")]
+fn parse_dec_or_hex(input: &str) -> Result<u64, std::num::ParseIntError> {
+    if let Some(hex) = input.strip_prefix("0x") {
+        u64::from_str_radix(hex, 16)
+    } else {
+        input.parse::<u64>()
+    }
+}
+
+/// Creates the flash section for memsolve.
+#[cfg(feature = "memory-x")]
+#[allow(
+    clippy::missing_panics_doc,
+    reason = "Panic only happens with incorrect section names"
+)]
+fn flash_section() -> Section<()> {
+    Section::new("FLASH").unwrap().set_maximize(true)
 }

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -99,6 +99,12 @@ fn memoryx() {
     let chip = memsolve::chip::Chip::new(nvm_page_size, nvm_start, nvm_page_size * nvm_page_count)
         .unwrap();
     let layout = memsolve::Memory::new(chip);
+    if context("esp") {
+        #[cfg(feature = "esp-partition")]
+        gen_esp_partition_table(layout.with_esp_metadata());
+        return;
+    }
+
     let layout = if context("nrf") {
         layout_nrf(layout)
     } else if context("rp") {
@@ -219,6 +225,42 @@ fn memory_rp(memory: ld_memory::Memory) -> ld_memory::Memory {
     } else {
         panic!("unknown rp MCU laze context");
     }
+}
+
+/// Generate the esp32 partition table.
+///
+/// # Panics
+/// Panics if called outside of a known laze context.
+#[cfg(feature = "esp-partition")]
+fn gen_esp_partition_table(mut memory: memsolve::esp::EspMemory) {
+    use ariel_os_buildutils::rerun_if_changed;
+    use esp_idf_part::{AppType, DataType, Type};
+    memory.add_section(
+        Section::new("nvs")
+            .unwrap()
+            .set_size(0x6000)
+            .set_address(0x9000)
+            .add_esp_metadata(Type::Data, DataType::Nvs),
+    );
+    memory.add_section(
+        Section::new("phy_init")
+            .unwrap()
+            .set_size(0x1000)
+            .set_address(0xf000)
+            .add_esp_metadata(Type::Data, DataType::Phy),
+    );
+    memory.add_section(
+        Section::new("factory")
+            .unwrap()
+            .set_maximize(true)
+            .set_address_align(0x10000)
+            .add_esp_metadata(Type::App, AppType::Factory),
+    );
+    let layout = memory.resolve_layout().unwrap();
+    let partition_table = layout.into_esp_partition().to_csv().unwrap();
+    let path = &PathBuf::from(env::var_os("ESP_PARTITION_FILE").unwrap());
+    std::fs::write(path, partition_table).unwrap();
+    rerun_if_changed(path.to_str().unwrap());
 }
 
 /// Parses a number, supporting hexadecimal and decimal format.

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -372,6 +372,17 @@ who = "chrysn <chrysn@fsfe.org>"
 criteria = "safe-to-deploy"
 delta = "0.4.27 -> 0.4.28"
 
+[[audits.log]]
+who = "Koen Zandberg <koen@bergzand.net>"
+criteria = "safe-to-deploy"
+delta = "0.4.29 -> 0.4.34"
+notes = "No changes to unsafe code. Newly added code looks reasonable."
+
+[[audits.memsolve]]
+who = "Koen Zandberg <koen@bergzand.net>"
+criteria = "safe-to-deploy"
+version = "0.2.4"
+
 [[audits.minicbor-adapters]]
 who = "chrysn <chrysn@fsfe.org>"
 criteria = "safe-to-deploy"
@@ -393,6 +404,17 @@ who = "chrysn <chrysn@fsfe.org>"
 criteria = "safe-to-deploy"
 delta = "3.0.3+3.0.2 -> 3.1.0+3.3.0"
 notes = "Review extends to the source of nrfxlib-sys only. The library ships also proprietary C components, which were not (and, due to being closed source, can not) be reviewed."
+
+[[audits.num-complex]]
+who = "Koen Zandberg <koen@bergzand.net>"
+criteria = "safe-to-deploy"
+delta = "0.4.2 -> 0.4.6"
+notes = """
+Minor update of the crate:
+- Bumps the rust  edition to 2021
+- Adds support for rkyv and bytecheck as optional dependencies
+- Rest of the changes are all safe code
+"""
 
 [[audits.num-conv]]
 who = "Nils Ponsard <nils.ponsard@inria.fr>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -340,6 +340,10 @@ criteria = "safe-to-deploy"
 version = "0.2.15"
 criteria = "safe-to-deploy"
 
+[[exemptions.conv]]
+version = "0.3.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.convert_case]]
 version = "0.8.0"
 criteria = "safe-to-deploy"
@@ -394,6 +398,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.curve25519-dalek-derive]]
 version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.custom_derive]]
+version = "0.1.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.cyw43]]
@@ -1004,6 +1012,14 @@ criteria = "safe-to-deploy"
 version = "0.1.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.matrixmultiply]]
+version = "0.3.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.microlp]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.minicbor]]
 version = "2.1.3"
 criteria = "safe-to-deploy"
@@ -1018,6 +1034,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.minimal-lexical]]
 version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ndarray]]
+version = "0.17.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.nourl]]
@@ -1204,6 +1224,10 @@ criteria = "safe-to-deploy"
 version = "0.3.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.rawpointer]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.rbi]]
 version = "0.1.1"
 criteria = "safe-to-deploy"
@@ -1356,6 +1380,10 @@ criteria = "safe-to-deploy"
 version = "0.7.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.sprs]]
+version = "0.11.4"
+criteria = "safe-to-deploy"
+
 [[exemptions.ssmarshal]]
 version = "1.0.0"
 criteria = "safe-to-deploy"
@@ -1446,6 +1474,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.volatile-register]]
 version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.web-time]]
+version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.xtensa-lx]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -14,6 +14,13 @@ when = "2026-01-22"
 user-id = 55123
 user-login = "rust-lang-owner"
 
+[[publisher.bumpalo]]
+version = "3.20.3"
+when = "2026-05-22"
+user-id = 696
+user-login = "fitzgen"
+user-name = "Nick Fitzgerald"
+
 [[publisher.cc]]
 version = "1.0.89"
 when = "2024-03-04"
@@ -89,6 +96,13 @@ when = "2025-03-03"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
+
+[[publisher.js-sys]]
+version = "0.3.76"
+when = "2024-12-07"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
 
 [[publisher.libc]]
 version = "0.2.172"
@@ -305,6 +319,13 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.syn]]
+version = "3.0.4"
+when = "2026-08-24"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.target-triple]]
 version = "1.0.0"
 when = "2025-10-27"
@@ -320,15 +341,15 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.thiserror]]
-version = "2.0.18"
-when = "2026-01-18"
+version = "2.0.20"
+when = "2026-08-08"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.thiserror-impl]]
-version = "2.0.18"
-when = "2026-01-18"
+version = "2.0.20"
+when = "2026-08-08"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -441,6 +462,41 @@ user-name = "Alex Crichton"
 [[publisher.wasi]]
 version = "0.14.2+wasi-0.2.4"
 when = "2025-02-28"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-bindgen]]
+version = "0.2.99"
+when = "2024-12-07"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-bindgen-backend]]
+version = "0.2.100"
+when = "2025-01-12"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-bindgen-macro]]
+version = "0.2.99"
+when = "2024-12-07"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-bindgen-macro-support]]
+version = "0.2.100"
+when = "2025-01-12"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-bindgen-shared]]
+version = "0.2.100"
+when = "2025-01-12"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -597,6 +653,13 @@ version = "0.39.0"
 when = "2025-02-05"
 user-id = 73222
 user-login = "wasmtime-publish"
+
+[[audits.bytecode-alliance.wildcard-audits.bumpalo]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 696 # Nick Fitzgerald (fitzgen)
+start = "2019-03-16"
+end = "2026-08-21"
 
 [[audits.bytecode-alliance.wildcard-audits.wit-bindgen-rt]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -793,12 +856,6 @@ who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
 version = "0.1.3"
 notes = "A part of RustCrypto/utils, this crate is designed to handle unsafe buffers and carefully documents the safety concerns throughout. Older versions of this tally up to ~130k daily downloads."
-
-[[audits.bytecode-alliance.audits.log]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.4.22 -> 0.4.27"
-notes = "Lots of minor updates to macros and such, nothing touching `unsafe`"
 
 [[audits.bytecode-alliance.audits.managed]]
 who = "Chris Fallin <chris@cfallin.org>"
@@ -1220,6 +1277,20 @@ Unsafe review in https://docs.google.com/document/d/1IXQbD1GhTRqNHIGxq6yy7qHqxeO
 Unsafety is generally very well-documented, with one exception, which we
 describe in the review doc.
 """
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.log]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.22 -> 0.4.25"
+notes = "No impact on `unsafe` usage in `lib.rs`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.log]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.25 -> 0.4.26"
+notes = "Only trivial code and documentation changes."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.nb]]
@@ -2515,10 +2586,29 @@ criteria = "safe-to-deploy"
 delta = "1.2.0 -> 1.2.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.js-sys]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.76 -> 0.3.77"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.litemap]]
 who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
 criteria = "safe-to-deploy"
 delta = "0.7.5 -> 0.8.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.log]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.26 -> 0.4.29"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-complex]]
+who = "Josh Stone <jistone@redhat.com>"
+criteria = "safe-to-deploy"
+version = "0.4.2"
+notes = "All code written or reviewed by Josh Stone."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.num-conv]]
@@ -2864,6 +2954,18 @@ who = "Valentin Gosu <valentin.gosu@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "2.5.1 -> 2.5.4"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.wasm-bindgen]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.99 -> 0.2.100"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.wasm-bindgen-macro]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.99 -> 0.2.100"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.windows-link]]
 who = "Mark Hammond <mhammond@skippinet.com.au>"


### PR DESCRIPTION
# Description

This migrates the memory section generation as used by the esp to use [memsolve](https://codeberg.org/bergzand/memsolve) to allow for dynamic generation of the <del>memory sections</del> partition table. This paves the way for OTA, configuration sections etc.

## Testing

I've tested this so far only on my esp32c3 devkit board. Further testing is required, but so far I can't get the binaries to remain identical. Investigation is needed to check if this is expected or whether I missed something that changed the binaries.

## Issues/PRs References

depends on #2244 

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
