### PR TITLE
feat: generate stm32 memory layout using memsolve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,7 @@ dependencies = [
 name = "ariel-os-esp"
 version = "0.5.0"
 dependencies = [
+ "ariel-os-buildutils",
  "ariel-os-embassy-common",
  "ariel-os-log",
  "ariel-os-random",
@@ -458,6 +459,7 @@ dependencies = [
  "embassy-rp",
  "embedded-test",
  "esp-hal",
+ "esp-idf-part",
  "ld-memory",
  "linkme",
  "memsolve",
@@ -902,6 +904,21 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "ble-advertiser"
@@ -1538,6 +1555,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,6 +1823,31 @@ checksum = "c0f73a4a4a91609e977ae3b7bd831ffa292edfd42ad140a3244a61d805b0e05e"
 dependencies = [
  "critical-section",
  "defmt 1.1.1",
+]
+
+[[package]]
+name = "deku"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9711031e209dc1306d66985363b4397d4c7b911597580340b93c9729b55f6eb"
+dependencies = [
+ "bitvec",
+ "deku_derive",
+ "no_std_io2",
+ "rustversion",
+]
+
+[[package]]
+name = "deku_derive"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58cb0719583cbe4e81fb40434ace2f0d22ccc3e39a74bb3796c22b451b4f139d"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2751,6 +2814,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-idf-part"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5ebc2381d030e4e89183554c3fcd4ad44dc5ab34961ab09e09b4adbe4f94b61"
+dependencies = [
+ "bitflags 2.9.1",
+ "csv",
+ "deku",
+ "md-5",
+ "parse_int",
+ "regex",
+ "serde",
+ "serde_plain",
+ "strum",
+ "thiserror",
+]
+
+[[package]]
 name = "esp-metadata-generated"
 version = "0.3.0"
 source = "git+https://github.com/ariel-os/esp-hal?rev=531c629afdd80ea464682ce7f4db8baed97967a6#531c629afdd80ea464682ce7f4db8baed97967a6"
@@ -3252,6 +3333,12 @@ dependencies = [
  "defmt 0.3.100",
  "gcd",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -4181,6 +4268,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,6 +4290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9613770670a70499e0a10a313f0a5010a0a21b038fd07dec258e67716c3ab865"
 dependencies = [
  "conv",
+ "esp-idf-part",
  "ld-memory",
  "microlp",
  "thiserror",
@@ -4290,6 +4388,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nom"
@@ -4620,6 +4727,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
+]
+
+[[package]]
+name = "parse_int"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c464266693329dd5a8715098c7f86e6c5fd5d985018b8318f53d9c6c2b21a31"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -5041,6 +5157,12 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "ral-registers"
@@ -5558,6 +5680,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5942,6 +6073,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-triple"
@@ -6796,6 +6933,15 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xtensa-lx"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "ariel-os-embassy-common",
  "ariel-os-log",
  "ariel-os-random",
+ "ariel-os-rt",
  "ariel-os-utils",
  "bt-hci",
  "cyw43",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ dependencies = [
  "esp-hal",
  "ld-memory",
  "linkme",
+ "memsolve",
  "portable-atomic",
  "riscv",
 ]
@@ -1002,6 +1003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1413,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+dependencies = [
+ "custom_derive",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1570,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
 name = "cyw43"
@@ -3912,6 +3934,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,9 +4159,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "managed"
@@ -4138,10 +4170,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memsolve"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9613770670a70499e0a10a313f0a5010a0a21b038fd07dec258e67716c3ab865"
+dependencies = [
+ "conv",
+ "ld-memory",
+ "microlp",
+ "thiserror",
+]
+
+[[package]]
+name = "microlp"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f19803f918039a07f3c32b23716824d8f073543417bdac5b1b8619817e3674"
+dependencies = [
+ "log",
+ "sprs",
+ "web-time",
+]
 
 [[package]]
 name = "minicbor"
@@ -4203,6 +4268,21 @@ name = "nb"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
 
 [[package]]
 name = "new_debug_unreachable"
@@ -4354,6 +4434,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -5021,6 +5110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rbi"
 version = "0.1.1"
 
@@ -5668,6 +5763,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sprs"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dca58a33be2188d4edc71534f8bafa826e787cc28ca1c47f31be3423f0d6e55"
+dependencies = [
+ "ndarray",
+ "num-complex",
+ "num-traits",
+ "smallvec",
+]
+
+[[package]]
 name = "ssmarshal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5814,6 +5921,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5942,22 +6060,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6422,6 +6540,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,7 @@ dependencies = [
 name = "ariel-os-stm32-mapping"
 version = "0.5.0"
 dependencies = [
+ "ariel-os-rt",
  "embassy-stm32",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ esp-bootloader-esp-idf = { version = "0.4.0", features = ["esp-rom-sys"] }
 esp-hal = { version = "~1.0.0", default-features = false, features = [
   "unstable",
 ] }
+esp-idf-part = { version = "0.6.0" }
 esp-metadata-generated = { version = "0.3.0", default-features = false }
 esp-println = { version = "0.16.0", default-features = false }
 esp-radio = { version = "0.17.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ heapless = { version = "0.9.1", default-features = false }
 jiff = { version = "0.2", default-features = false }
 ld-memory = { version = "0.2.9" }
 log = { version = "0.4.20", default-features = false }
+memsolve = { version = "0.2.4", default-features = false }
 once_cell = { version = "1.21.3", default-features = false, features = [
   "critical-section",
 ] }

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -54,6 +54,9 @@ contexts:
           CARGO_TARGET_DIR=${relroot}/${build-dir}/bin/${builder}/cargo
           CONFIG_EXECUTOR_STACKSIZE=${CONFIG_EXECUTOR_STACKSIZE}
           CONFIG_ISR_STACKSIZE=${CONFIG_ISR_STACKSIZE}
+          CHIP_NVM_PAGE_COUNT=${CHIP_NVM_PAGE_COUNT}
+          CHIP_NVM_START_ADDRESS=${CHIP_NVM_START_ADDRESS}
+          CHIP_NVM_PAGE_SIZE_BYTES=${CHIP_NVM_PAGE_SIZE_BYTES}
       PROFILE: release
       PROFILE_DIR: $(if("${PROFILE}"=="dev", "debug", "${PROFILE}"))
       PROBE_RS_PROTOCOL: swd
@@ -204,6 +207,11 @@ contexts:
       - has_device_identity
       - has_swi
       - sw/benchmark
+    env:
+      # Most common flash page size
+      CHIP_NVM_PAGE_SIZE_BYTES: "4096"
+      CHIP_NVM_START_ADDRESS: "0x0"
+
 
   - name: nrf51
     parent: nrf
@@ -211,6 +219,8 @@ contexts:
       - cortex-m0
     provides:
       - has_hwrng
+    env:
+      CHIP_NVM_PAGE_SIZE_BYTES: "1024"
 
   - name: nrf51822-xxaa
     parent: nrf51
@@ -218,6 +228,7 @@ contexts:
       - ram-tiny
     env:
       PROBE_RS_CHIP: nrf51822_xxAA
+      CHIP_NVM_PAGE_COUNT: "256"
 
   - name: nrf52
     parent: nrf
@@ -238,6 +249,7 @@ contexts:
       - has_ble_nrf
     env:
       PROBE_RS_CHIP: nrf52832_xxAA
+      CHIP_NVM_PAGE_COUNT: "128"
 
   - name: nrf52833
     parent: nrf52
@@ -247,6 +259,7 @@ contexts:
       - has_ble_nrf
     env:
       PROBE_RS_CHIP: nrf52833_xxAA
+      CHIP_NVM_PAGE_COUNT: "128"
 
   - name: nrf52840
     parent: nrf52
@@ -256,6 +269,7 @@ contexts:
       - has_ble_nrf
     env:
       PROBE_RS_CHIP: nrf52840_xxAA
+      CHIP_NVM_PAGE_COUNT: "256"
 
   - name: nrf53
     parent: nrf
@@ -268,6 +282,7 @@ contexts:
       - has_storage_support
     env:
       PROBE_RS_CHIP: nrf5340_xxAA
+      CHIP_NVM_PAGE_COUNT: "128"
 
   - name: nrf5340-net
     parent: nrf53
@@ -283,6 +298,9 @@ contexts:
       - usb
     env:
       PROBE_RS_CHIP: nrf5340_xxAA
+      CHIP_NVM_START_ADDRESS: "0x01000000"
+      CHIP_NVM_PAGE_COUNT: "128"
+      CHIP_NVM_PAGE_SIZE_BYTES: "2048"
     help: nRF5340 Network Core support
 
   - name: nrf91
@@ -293,6 +311,8 @@ contexts:
       # For blinky the measured consumption is ~3milliAmps without nrf91-modem to ~4 microAmps with nrf91-modem.
       # Tested using the ppk2 in ampere mode on the Thingy:91 X and nrf9160dk.
       - ?nrf91-modem
+    env:
+      CHIP_NVM_PAGE_COUNT: "256"
 
   - name: nrf9160
     parent: nrf91

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -397,6 +397,9 @@ contexts:
       RUSTFLAGS:
         # linkall first
         - -Clink-arg=-Tlinkall.x
+      CHIP_NVM_PAGE_SIZE_BYTES: "4096"
+      CHIP_NVM_START_ADDRESS: "0x9000" # skips the bootloader and partition table space.
+      CHIP_NVM_PAGE_COUNT: "1015"
 
   - name: esp32
     parent: esp

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -571,6 +571,7 @@ contexts:
       - sw/benchmark
     env:
       OPENOCD_ARGS: foo
+      CHIP_NVM_START_ADDRESS: "0x08000000"
     tasks:
       flash-dfuse:
         cmd:
@@ -586,6 +587,8 @@ contexts:
       isr_stacksize_required_default: "1024"
       executor_stacksize_required_default: "3072"
       PROBE_RS_CHIP: STM32C031C6
+      CHIP_NVM_PAGE_SIZE_BYTES: "2048"
+      CHIP_NVM_PAGE_COUNT: "16"
 
   - name: stm32f042k6
     parent: stm32
@@ -608,6 +611,8 @@ contexts:
       PROBE_RS_CHIP: STM32F303CB
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-usb-lp-can-rx0\"
+      CHIP_NVM_PAGE_SIZE_BYTES: "2048"
+      CHIP_NVM_PAGE_COUNT: "128"
 
   - name: stm32f303re
     parent: stm32
@@ -619,6 +624,8 @@ contexts:
       PROBE_RS_CHIP: STM32F303RE
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-usb-lp-can-rx0\"
+      CHIP_NVM_PAGE_SIZE_BYTES: "2048"
+      CHIP_NVM_PAGE_COUNT: "256"
 
   - name: stm32f401re
     parent: stm32
@@ -648,6 +655,8 @@ contexts:
       PROBE_RS_CHIP: STM32G431RB
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
+      CHIP_NVM_PAGE_SIZE_BYTES: "2048"
+      CHIP_NVM_PAGE_COUNT: "64"
 
   - name: stm32f767zi
     parent: stm32
@@ -675,6 +684,8 @@ contexts:
         - --cfg capability=\"hw/stm32-dual-core\"
         - --cfg capability=\"hw/stm32-hash-rng\"
         - --cfg capability=\"hw/stm32-usb-synopsys\"
+      CHIP_NVM_PAGE_SIZE_BYTES: "0x20000" # 128 KiB
+      CHIP_NVM_PAGE_COUNT: "16"
 
   - name: stm32h753zi
     parent: stm32
@@ -688,6 +699,8 @@ contexts:
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-hash-rng\"
         - --cfg capability=\"hw/stm32-usb-synopsys\"
+      CHIP_NVM_PAGE_SIZE_BYTES: "0x20000" # 128 KiB
+      CHIP_NVM_PAGE_COUNT: "16"
 
   - name: stm32l475vg
     parent: stm32
@@ -701,6 +714,8 @@ contexts:
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
         - --cfg capability=\"hw/stm32-usb-synopsys\" # Needs an external 32.768 kHz crystal to have a stable clock
+      CHIP_NVM_PAGE_SIZE_BYTES: "2048"
+      CHIP_NVM_PAGE_COUNT: "512"
 
   - name: stm32u073kc
     parent: stm32
@@ -715,6 +730,8 @@ contexts:
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng-cryp\"
         - --cfg capability=\"hw/stm32-usb-drd-fs\"
+      CHIP_NVM_PAGE_SIZE_BYTES: "2048"
+      CHIP_NVM_PAGE_COUNT: "128"
 
   - name: stm32u083mc
     parent: stm32
@@ -729,6 +746,8 @@ contexts:
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng-cryp\"
         - --cfg capability=\"hw/stm32-usb-drd-fs\"
+      CHIP_NVM_PAGE_SIZE_BYTES: "2048"
+      CHIP_NVM_PAGE_COUNT: "128"
 
   - name: stm32u585ai
     parent: stm32
@@ -742,6 +761,9 @@ contexts:
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
         - --cfg capability=\"hw/stm32-usb-synopsys\"
+      CHIP_NVM_PAGE_SIZE_BYTES: "8192"
+      CHIP_NVM_PAGE_COUNT: "256"
+      # 768KB RAM
 
   - name: stm32wb55rg
     parent: stm32
@@ -755,6 +777,9 @@ contexts:
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
         - --cfg capability=\"hw/stm32-usb-lp\"
+      CHIP_NVM_PAGE_SIZE_BYTES: "4096"
+      CHIP_NVM_PAGE_COUNT: "256"
+      # 192 KB
 
   - name: stm32wba55cg
     parent: stm32
@@ -766,6 +791,8 @@ contexts:
       PROBE_RS_CHIP: STM32WBA55CG
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
+      CHIP_NVM_PAGE_SIZE_BYTES: "8192"
+      CHIP_NVM_PAGE_COUNT: "128"
 
   - name: stm32wba65ri
     parent: stm32
@@ -779,6 +806,8 @@ contexts:
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
         - --cfg capability=\"hw/stm32-usb-synopsys-hs\"
+      CHIP_NVM_PAGE_SIZE_BYTES: "8192"
+      CHIP_NVM_PAGE_COUNT: "256"
 
   - name: stm32wle5jc
     parent: stm32
@@ -791,6 +820,9 @@ contexts:
       PROBE_RS_CHIP: STM32WLE5JC
       RUSTFLAGS:
         - --cfg capability=\"hw/stm32-rng\"
+      CHIP_NVM_PAGE_SIZE_BYTES: "2048"
+      CHIP_NVM_PAGE_COUNT: "128"
+      # 64KB RAM
 
 modules:
   - name: thumbv6m-none-eabi

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -57,6 +57,7 @@ contexts:
           CHIP_NVM_PAGE_COUNT=${CHIP_NVM_PAGE_COUNT}
           CHIP_NVM_START_ADDRESS=${CHIP_NVM_START_ADDRESS}
           CHIP_NVM_PAGE_SIZE_BYTES=${CHIP_NVM_PAGE_SIZE_BYTES}
+          ESP_PARTITION_FILE=${ESP_PARTITION_FILE}
       PROFILE: release
       PROFILE_DIR: $(if("${PROFILE}"=="dev", "debug", "${PROFILE}"))
       PROBE_RS_PROTOCOL: swd
@@ -394,6 +395,7 @@ contexts:
       - has_hwrng
     env:
       esp_wifi_heapsize_required: $(72*1024)
+      ESP_PARTITION_FILE: ${relroot}/${build-dir}/bin/${builder}/cargo/${RUSTC_TARGET}/${PROFILE_DIR}/${app}-partitions.csv
       RUSTFLAGS:
         # linkall first
         - -Clink-arg=-Tlinkall.x
@@ -1149,12 +1151,12 @@ modules:
       - flashing-tool
     env:
       global:
-        CARGO_RUNNER: '"espflash flash --monitor"'
+        CARGO_RUNNER: '"espflash flash --monitor --partition-table ${ESP_PARTITION_FILE}"'
     tasks:
       flash:
         help: flash the target using `espflash`
         cmd:
-          - espflash flash --after hard-reset ${out} $@
+          - espflash flash --partition-table ${ESP_PARTITION_FILE} --after hard-reset ${out} $@
 
       attach:
         help: attach `espflash` to a running target

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -340,9 +340,9 @@ contexts:
       - has_swi
       - sw/benchmark
     env:
-      CHIP_ROM_START_ADDRESS: "0x10000000"
-      CHIP_ROM_PAGE_COUNT: "8192"
-      CHIP_ROM_PAGE_SIZE_BYTES: "256"
+      CHIP_NVM_START_ADDRESS: "0x10000000"
+      CHIP_NVM_PAGE_COUNT: "8192"
+      CHIP_NVM_PAGE_SIZE_BYTES: "256"
 
   - name: rp2040
     parent: rp
@@ -377,6 +377,9 @@ contexts:
         - ${SCRIPTS}/debug-openocd.sh
       OPENOCD_ARGS:
         - "-f interface/cmsis-dap.cfg -f target/rp2040.cfg"
+      RUSTFLAGS:
+        # Extra rp235xa link bits
+        - -Clink-arg=-Tmemory-rp235xa.x
     tasks:
       flash:
         cmd:

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -339,6 +339,10 @@ contexts:
       - has_hwrng
       - has_swi
       - sw/benchmark
+    env:
+      CHIP_ROM_START_ADDRESS: "0x10000000"
+      CHIP_ROM_PAGE_COUNT: "8192"
+      CHIP_ROM_PAGE_SIZE_BYTES: "256"
 
   - name: rp2040
     parent: rp

--- a/src/ariel-os-buildutils/src/lib.rs
+++ b/src/ariel-os-buildutils/src/lib.rs
@@ -1,4 +1,6 @@
 //! Ariel OS build-time tools.
+use std::env;
+use std::path::PathBuf;
 
 /// Returns the first of the given contexts that is in the current `cfg` contexts.
 #[must_use]
@@ -16,4 +18,42 @@ pub fn context(context: &'static str) -> bool {
 
     // Contexts cannot include commas.
     context_var.split(',').any(|c| c == context)
+}
+
+/// Tells Cargo to re-run the build script if the file has changed.
+pub fn rerun_if_changed(file: &str) {
+    println!("cargo::rerun-if-changed={file}");
+}
+
+/// Tells Cargo to re-run the build script if the environment variable has changed.
+pub fn rerun_if_env_changed(env: &str) {
+    println!("cargo::rerun-if-env-changed={env}");
+}
+
+/// Copies over the file to the `OUT_DIR` and tells cargo to re-run the build script if this file
+/// has changed.
+///
+/// # Panics
+///
+/// Panics when `OUT_DIR` is not set, or when the supplied file name cannot be copied.
+pub fn copy_and_rerun_if_changed(file: impl AsRef<std::path::Path>) {
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let file = file.as_ref();
+    std::fs::copy(file, out.join(file.file_name().unwrap())).unwrap();
+    rerun_if_changed(file.to_str().unwrap());
+}
+
+/// Fetches the environment variable key from the current process and tells cargo to re-run the
+/// build script if this variable has changed.
+///
+/// # Errors
+///
+/// Returns ``VarError::NotPresent`` if:
+/// - The variable is not set.
+/// - The variable’s name contains an equal sign or NUL ('=' or '\0').
+///
+/// Returns ``VarError::NotUnicode`` if the variable’s value is not valid Unicode.
+pub fn env_var_and_rerun_if_changed(key: &str) -> Result<String, std::env::VarError> {
+    rerun_if_env_changed(key);
+    std::env::var(key)
 }

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 ariel-os-embassy-common = { workspace = true }
 ariel-os-log = { workspace = true }
 ariel-os-random = { workspace = true, optional = true }
-ariel-os-rt = { workspace = true, features = ["alloc"] }
+ariel-os-rt = { workspace = true, features = ["alloc", "esp-partition"] }
 ariel-os-threads = { workspace = true, optional = true }
 ariel-os-utils = { workspace = true }
 critical-section = { workspace = true }
@@ -48,6 +48,9 @@ static_cell = { workspace = true }
 
 # BLE dependencies
 bt-hci = { workspace = true, optional = true }
+
+[build-dependencies]
+ariel-os-buildutils = { workspace = true }
 
 [target.'cfg(context = "esp32")'.dependencies]
 esp-bootloader-esp-idf = { workspace = true, features = ["esp32"] }

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 ariel-os-embassy-common = { workspace = true }
 ariel-os-log = { workspace = true }
 ariel-os-random = { workspace = true, optional = true }
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 ariel-os-utils = { workspace = true }
 defmt = { workspace = true, optional = true }
 embassy-embedded-hal = { workspace = true, optional = true }

--- a/src/ariel-os-rp/build.rs
+++ b/src/ariel-os-rp/build.rs
@@ -1,8 +1,7 @@
 use std::env;
-use std::fs::copy;
 use std::path::PathBuf;
 
-use ariel_os_buildutils::context;
+use ariel_os_buildutils::{context, copy_and_rerun_if_changed};
 
 fn main() {
     if !context("ariel-os") {
@@ -10,21 +9,11 @@ fn main() {
         return;
     }
 
-    // Put the linker script somewhere the linker can find it
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    if context("rp235xa") {
+        // Put the extra linker script somewhere the linker can find it
+        copy_and_rerun_if_changed("memory-rp235xa.x");
 
-    let memory_script = if context("rp2040") {
-        "memory.x"
-    } else if context("rp235xa") {
-        "memory-rp235xa.x"
-    } else {
-        panic!("unsupported RP MCU");
-    };
-
-    copy(memory_script, out.join("memory.x")).unwrap();
-
-    println!("cargo:rustc-link-search={}", out.display());
-
-    println!("cargo:rerun-if-changed=memory.x");
-    println!("cargo:rerun-if-changed=build.rs");
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        println!("cargo:rustc-link-search={}", out.display());
+    }
 }

--- a/src/ariel-os-rp/memory-rp235xa.x
+++ b/src/ariel-os-rp/memory-rp235xa.x
@@ -1,26 +1,3 @@
-MEMORY {
-    /*
-     * The RP235x has either external or internal flash.
-     *
-     * 2 MiB is a safe default here, although an RP2354 has 4 MiB.
-     */
-    FLASH : ORIGIN = 0x10000000, LENGTH = 2048K
-    /*
-     * RAM consists of 8 banks, SRAM0-SRAM7, with a striped mapping.
-     * This is usually good for performance, as it distributes load on
-     * those banks evenly.
-     */
-    RAM : ORIGIN = 0x20000000, LENGTH = 512K
-    /*
-     * RAM banks 8 and 9 use a direct mapping. They can be used to have
-     * memory areas dedicated for some specific job, improving predictability
-     * of access times.
-     * Example: Separate stacks for core0 and core1.
-     */
-    SRAM4 : ORIGIN = 0x20080000, LENGTH = 4K
-    SRAM5 : ORIGIN = 0x20081000, LENGTH = 4K
-}
-
 SECTIONS {
     /* ### Boot ROM info
      *

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -18,6 +18,7 @@ linkme = { workspace = true }
 [build-dependencies]
 ariel-os-buildutils = { workspace = true }
 ld-memory = { workspace = true, features = ["build-rs"], optional = true }
+memsolve = { workspace = true, optional = true }
 
 [target.'cfg(context = "cortex-m")'.dependencies]
 cortex-m = { workspace = true }
@@ -58,7 +59,7 @@ panic-printing = []
 _panic-handler = []
 single-core = ["cortex-m/critical-section-single-core"]
 multi-core = ["embassy-rp/critical-section-impl"]
-memory-x = ["dep:ld-memory"]
+memory-x = ["dep:ld-memory", "dep:memsolve"]
 nrf91-modem = []
 
 # features needed for `cargo test`

--- a/src/ariel-os-rt/Cargo.toml
+++ b/src/ariel-os-rt/Cargo.toml
@@ -17,6 +17,7 @@ linkme = { workspace = true }
 
 [build-dependencies]
 ariel-os-buildutils = { workspace = true }
+esp-idf-part = { workspace = true, optional = true }
 ld-memory = { workspace = true, features = ["build-rs"], optional = true }
 memsolve = { workspace = true, optional = true }
 
@@ -60,6 +61,7 @@ _panic-handler = []
 single-core = ["cortex-m/critical-section-single-core"]
 multi-core = ["embassy-rp/critical-section-impl"]
 memory-x = ["dep:ld-memory", "dep:memsolve"]
+esp-partition = ["memory-x", "dep:esp-idf-part", "memsolve/esp"]
 nrf91-modem = []
 
 # features needed for `cargo test`

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -1,7 +1,9 @@
 use std::env;
 use std::path::PathBuf;
 
-use ariel_os_buildutils::{context, context_any};
+use ariel_os_buildutils::{
+    context, context_any, copy_and_rerun_if_changed, env_var_and_rerun_if_changed,
+};
 
 // 32 KiB recommended by [nrf-modem](https://github.com/diondokter/nrf-modem?tab=readme-ov-file#memory)
 #[allow(dead_code, reason = "only used when the feature is enabled")]
@@ -49,26 +51,21 @@ fn main() {
     }
 
     if context("xtensa") {
-        let isr_stacksize =
-            std::env::var("CONFIG_ISR_STACKSIZE").expect("CONFIG_ISR_STACKSIZE env var not set");
+        let isr_stacksize = env_var_and_rerun_if_changed("CONFIG_ISR_STACKSIZE")
+            .expect("CONFIG_ISR_STACKSIZE env var not set");
         let template = std::fs::read_to_string("isr_stack_xtensa.ld.in")
             .unwrap()
             .replace("${ISR_STACKSIZE}", &isr_stacksize);
         std::fs::write(out.join("isr_stack_xtensa.x"), &template).unwrap();
         println!("cargo:rerun-if-changed=isr_stack_xtensa.ld.in");
-        println!("cargo:rerun-if-env-changed=CONFIG_ISR_STACKSIZE");
     }
 
-    std::fs::copy("linkme.x", out.join("linkme.x")).unwrap();
-    std::fs::copy("eheap.x", out.join("eheap.x")).unwrap();
-    std::fs::copy("keep-stack-sizes.x", out.join("keep-stack-sizes.x")).unwrap();
+    copy_and_rerun_if_changed("linkme.x");
+    copy_and_rerun_if_changed("eheap.x");
+    copy_and_rerun_if_changed("keep-stack-sizes.x");
 
     #[cfg(feature = "memory-x")]
     write_memoryx();
-
-    println!("cargo:rerun-if-changed=linkme.x");
-    println!("cargo:rerun-if-changed=eheap.x");
-    println!("cargo:rerun-if-changed=keep-stack-sizes.x");
 
     println!("cargo:rustc-link-search={}", out.display());
 }

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -70,7 +70,7 @@ fn main() {
     copy_and_rerun_if_changed("keep-stack-sizes.x");
 
     #[cfg(feature = "memory-x")]
-    write_memoryx();
+    memoryx();
 
     println!("cargo:rustc-link-search={}", out.display());
 }
@@ -80,7 +80,7 @@ fn main() {
 /// # Panics
 /// Panics if called outside of a known laze context.
 #[cfg(feature = "memory-x")]
-fn write_memoryx() {
+fn memoryx() {
     let nvm_start = parse_dec_or_hex(
         &env_var_and_rerun_if_changed("CHIP_NVM_START_ADDRESS")
             .expect("CHIP_NVM_START_ADDRESS env var not set"),
@@ -101,16 +101,19 @@ fn write_memoryx() {
     let layout = memsolve::Memory::new(chip);
     let layout = if context("nrf") {
         layout_nrf(layout)
+    } else if context("rp") {
+        layout_rp(layout)
     } else {
         panic!("unknown MCU laze context");
     };
-
     let memory = layout
         .resolve_layout()
         .expect("Unable to resolve nvm layout")
         .into_memory();
     let memory = if context("nrf") {
         memory_nrf(memory)
+    } else if context("rp") {
+        memory_rp(memory)
     } else {
         panic!("unknown MCU laze context");
     };
@@ -172,6 +175,50 @@ fn memory_nrf(memory: ld_memory::Memory) -> ld_memory::Memory {
     ));
 
     memory.add_section(MemorySection::new("RAM", ram_base, ram * 1024))
+}
+
+/// Generates the rp nvm layout.
+///
+/// # Panics
+/// Panics if called outside of a known laze context.
+#[cfg(feature = "memory-x")]
+fn layout_rp(mut layout: memsolve::Memory<()>) -> memsolve::Memory<()> {
+    if context("rp2040") {
+        let boot = Section::new("BOOT2").unwrap().set_size(256).set_boot(true);
+        layout.add_section(boot);
+        layout.add_section(flash_section().set_address(0x1000_0100));
+    } else {
+        layout.add_section(flash_section().set_boot(true));
+    }
+    layout
+}
+
+/// Adds the rp memory sections to the generated layout.
+///
+/// # Panics
+/// Panics if called outside of a known laze context.
+#[cfg(feature = "memory-x")]
+fn memory_rp(memory: ld_memory::Memory) -> ld_memory::Memory {
+    let ram = if context("rp2040") {
+        256
+    } else if context("rp235xa") {
+        512
+    } else {
+        panic!("unknown rp MCU laze context");
+    };
+
+    let memory = memory.add_section(MemorySection::new("RAM", 0x2000_0000, ram * 1024));
+    if context("rp2040") {
+        memory
+            .add_section(MemorySection::new("SRAM4", 0x2004_0000, 4096))
+            .add_section(MemorySection::new("SRAM5", 0x2004_1000, 4096))
+    } else if context("rp235xa") {
+        memory
+            .add_section(MemorySection::new("SRAM4", 0x2008_0000, 4096))
+            .add_section(MemorySection::new("SRAM5", 0x2008_1000, 4096))
+    } else {
+        panic!("unknown rp MCU laze context");
+    }
 }
 
 /// Parses a number, supporting hexadecimal and decimal format.

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -5,6 +5,11 @@ use ariel_os_buildutils::{
     context, context_any, copy_and_rerun_if_changed, env_var_and_rerun_if_changed,
 };
 
+#[cfg(feature = "memory-x")]
+use ld_memory::MemorySection;
+#[cfg(feature = "memory-x")]
+use memsolve::section::Section;
+
 // 32 KiB recommended by [nrf-modem](https://github.com/diondokter/nrf-modem?tab=readme-ov-file#memory)
 #[allow(dead_code, reason = "only used when the feature is enabled")]
 const NRF91_MODEM_IPC_KB: u64 = 32;
@@ -76,47 +81,88 @@ fn main() {
 /// Panics if called outside of a known laze context.
 #[cfg(feature = "memory-x")]
 fn write_memoryx() {
-    use ld_memory::{Memory, MemorySection};
-    let (ram, flash) = if context("nrf51822-xxaa") {
-        (16, 256)
+    let nvm_start = parse_dec_or_hex(
+        &env_var_and_rerun_if_changed("CHIP_NVM_START_ADDRESS")
+            .expect("CHIP_NVM_START_ADDRESS env var not set"),
+    )
+    .expect("CHIP_NVM_START_ADDRESS is not a decimal or hex value");
+    let nvm_page_size = parse_dec_or_hex(
+        &env_var_and_rerun_if_changed("CHIP_NVM_PAGE_SIZE_BYTES")
+            .expect("CHIP_NVM_PAGE_SIZE_BYTES env var not set"),
+    )
+    .expect("CHIP_NVM_PAGE_SIZE_BYTES is not a decimal or hex value");
+    let nvm_page_count = env_var_and_rerun_if_changed("CHIP_NVM_PAGE_COUNT")
+        .expect("CHIP_NVM_PAGE_COUNT env var not set")
+        .parse::<u64>()
+        .expect("CHIP_NVM_PAGE_COUNT is not a decimal number");
+
+    let chip = memsolve::chip::Chip::new(nvm_page_size, nvm_start, nvm_page_size * nvm_page_count)
+        .unwrap();
+    let layout = memsolve::Memory::new(chip);
+    let layout = if context("nrf") {
+        layout_nrf(layout)
+    } else {
+        panic!("unknown MCU laze context");
+    };
+
+    let memory = layout
+        .resolve_layout()
+        .expect("Unable to resolve nvm layout")
+        .into_memory();
+    let memory = if context("nrf") {
+        memory_nrf(memory)
+    } else {
+        panic!("unknown MCU laze context");
+    };
+    memory.to_cargo_outdir("memory.x").expect("wrote memory.x");
+}
+
+/// Generates the nrf nvm layout.
+///
+/// # Panics
+/// Panics if called outside of a known laze context.
+#[cfg(feature = "memory-x")]
+fn layout_nrf(mut layout: memsolve::Memory<()>) -> memsolve::Memory<()> {
+    layout.add_section(flash_section().set_boot(true));
+    layout
+}
+
+/// Adds the nrf memory sections to the generated layout.
+///
+/// # Panics
+/// Panics if called outside of a known laze context.
+#[cfg(feature = "memory-x")]
+fn memory_nrf(memory: ld_memory::Memory) -> ld_memory::Memory {
+    let ram = if context("nrf51822-xxaa") {
+        16
     } else if context("nrf52832") {
-        (64, 256)
+        64
     } else if context("nrf52833") {
-        (128, 512)
+        128
     } else if context("nrf52840") {
-        (256, 1024)
+        256
     } else if context("nrf5340-app") {
-        (512, 1024)
+        512
     } else if context("nrf5340-net") {
-        (64, 256)
+        64
     } else if context_any(&["nrf9151", "nrf9160"]).is_some() {
         let ram = 256;
-        let flash = 1024;
         if cfg!(feature = "nrf91-modem") {
-            (ram - NRF91_MODEM_IPC_KB, flash)
+            ram - NRF91_MODEM_IPC_KB
         } else {
-            (ram, flash)
+            ram
         }
     } else {
         panic!("please set the MCU laze context");
     };
 
-    let (pagesize, ram_base, flash_base) = if context("nrf5340-net") {
-        (2048, 0x2100_0000, 0x0100_0000)
+    let ram_base = if context("nrf5340-net") {
+        0x2100_0000
     } else if cfg!(feature = "nrf91-modem") {
-        (4096, 0x2000_0000 + NRF91_MODEM_IPC_KB * 1024, 0)
+        0x2000_0000 + NRF91_MODEM_IPC_KB * 1024
     } else {
-        (4096, 0x2000_0000, 0)
+        0x2000_0000
     };
-
-    // generate linker script
-    let memory = Memory::new()
-        .add_section(MemorySection::new("RAM", ram_base, ram * 1024))
-        .add_section(
-            MemorySection::new("FLASH", flash_base, flash * 1024)
-                .pagesize(pagesize)
-                .from_env(),
-        );
 
     #[cfg(feature = "nrf91-modem")]
     let memory = memory.add_section(MemorySection::new(
@@ -125,5 +171,29 @@ fn write_memoryx() {
         NRF91_MODEM_IPC_KB * 1024,
     ));
 
-    memory.to_cargo_outdir("memory.x").expect("wrote memory.x");
+    memory.add_section(MemorySection::new("RAM", ram_base, ram * 1024))
+}
+
+/// Parses a number, supporting hexadecimal and decimal format.
+///
+/// # Errors
+///
+/// Returns ``std::num::ParseIntError`` when the number is neither decimal, nor hexadecimal.
+#[cfg(feature = "memory-x")]
+fn parse_dec_or_hex(input: &str) -> Result<u64, std::num::ParseIntError> {
+    if let Some(hex) = input.strip_prefix("0x") {
+        u64::from_str_radix(hex, 16)
+    } else {
+        input.parse::<u64>()
+    }
+}
+
+/// Creates the flash section for memsolve.
+#[cfg(feature = "memory-x")]
+#[allow(
+    clippy::missing_panics_doc,
+    reason = "Panic only happens with incorrect section names"
+)]
+fn flash_section() -> Section<()> {
+    Section::new("FLASH").unwrap().set_maximize(true)
 }

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -109,6 +109,8 @@ fn memoryx() {
         layout_nrf(layout)
     } else if context("rp") {
         layout_rp(layout)
+    } else if context("stm32") {
+        layout_stm32(layout)
     } else {
         panic!("unknown MCU laze context");
     };
@@ -120,6 +122,8 @@ fn memoryx() {
         memory_nrf(memory)
     } else if context("rp") {
         memory_rp(memory)
+    } else if context("stm32") {
+        memory_stm32(memory)
     } else {
         panic!("unknown MCU laze context");
     };
@@ -225,6 +229,49 @@ fn memory_rp(memory: ld_memory::Memory) -> ld_memory::Memory {
     } else {
         panic!("unknown rp MCU laze context");
     }
+}
+
+/// Generates the stm32 nvm layout.
+///
+/// # Panics
+/// Panics if called outside of a known laze context.
+#[cfg(feature = "memory-x")]
+fn layout_stm32(mut layout: memsolve::Memory<()>) -> memsolve::Memory<()> {
+    layout.add_section(flash_section().set_boot(true));
+    layout
+}
+
+/// Adds the stm32 memory sections to the generated layout.
+///
+/// # Panics
+/// Panics if called outside of a known laze context.
+#[cfg(feature = "memory-x")]
+fn memory_stm32(memory: ld_memory::Memory) -> ld_memory::Memory {
+    // Sorted by ram size
+    let (ram, ram_base) = if context("stm32c031c6") {
+        (12, 0x2000_0000)
+    } else if context("stm32g431rb") {
+        (32, 0x2000_0000)
+    } else if context_any(&["stm32u073kc", "stm32u083mc", "stm32f303cb"]).is_some() {
+        (40, 0x2000_0000)
+    } else if context_any(&["stm32f303re", "stm32wle5jc"]).is_some() {
+        (64, 0x2000_0000)
+    } else if context("stm32l475vg") {
+        (96, 0x2000_0000)
+    } else if context("stm32wba55cg") {
+        (128, 0x2000_0000)
+    } else if context("stm32wb55rg") {
+        (192, 0x2000_0000)
+    } else if context_any(&["stm32h755zi", "stm32h753zi"]).is_some() {
+        (512, 0x2400_0000)
+    } else if context("stm32wba65ri") {
+        (512, 0x2000_0000)
+    } else if context("stm32u585ai") {
+        (768, 0x2000_0000)
+    } else {
+        panic!("please set the MCU laze context");
+    };
+    memory.add_section(MemorySection::new("RAM", ram_base, ram * 1024))
 }
 
 /// Generate the esp32 partition table.

--- a/src/ariel-os-rt/build.rs
+++ b/src/ariel-os-rt/build.rs
@@ -99,6 +99,12 @@ fn memoryx() {
     let chip = memsolve::chip::Chip::new(nvm_page_size, nvm_start, nvm_page_size * nvm_page_count)
         .unwrap();
     let layout = memsolve::Memory::new(chip);
+    if context("esp") {
+        #[cfg(feature = "esp-partition")]
+        gen_esp_partition_table(layout.with_esp_metadata());
+        return;
+    }
+
     let layout = if context("nrf") {
         layout_nrf(layout)
     } else if context("rp") {
@@ -219,6 +225,42 @@ fn memory_rp(memory: ld_memory::Memory) -> ld_memory::Memory {
     } else {
         panic!("unknown rp MCU laze context");
     }
+}
+
+/// Generate the esp32 partition table.
+///
+/// # Panics
+/// Panics if called outside of a known laze context.
+#[cfg(feature = "esp-partition")]
+fn gen_esp_partition_table(mut memory: memsolve::esp::EspMemory) {
+    use ariel_os_buildutils::rerun_if_changed;
+    use esp_idf_part::{AppType, DataType, Type};
+    memory.add_section(
+        Section::new("nvs")
+            .unwrap()
+            .set_size(0x6000)
+            .set_address(0x9000)
+            .add_esp_metadata(Type::Data, DataType::Nvs),
+    );
+    memory.add_section(
+        Section::new("phy_init")
+            .unwrap()
+            .set_size(0x1000)
+            .set_address(0xf000)
+            .add_esp_metadata(Type::Data, DataType::Phy),
+    );
+    memory.add_section(
+        Section::new("factory")
+            .unwrap()
+            .set_maximize(true)
+            .set_address_align(0x10000)
+            .add_esp_metadata(Type::App, AppType::Factory),
+    );
+    let layout = memory.resolve_layout().unwrap();
+    let partition_table = layout.into_esp_partition().to_csv().unwrap();
+    let path = &PathBuf::from(env::var_os("ESP_PARTITION_FILE").unwrap());
+    std::fs::write(path, partition_table).unwrap();
+    rerun_if_changed(path.to_str().unwrap());
 }
 
 /// Parses a number, supporting hexadecimal and decimal format.

--- a/src/ariel-os-stm32-mapping/Cargo.toml
+++ b/src/ariel-os-stm32-mapping/Cargo.toml
@@ -9,43 +9,43 @@ license.workspace = true
 # BEGIN AUTO-GENERATED STM32 MAPPING
 [target.'cfg(context = "stm32c011d6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c011d6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32c011f4")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c011f4"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32c011f6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c011f6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32c011j4")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c011j4"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32c011j6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c011j6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32c031c4")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c031c4"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32c031c6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c031c6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32c031f4")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c031f4"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32c031f6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c031f6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32c031g4")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c031g4"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32c031g6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c031g6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32c031k4")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c031k4"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32c031k6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c031k6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f030c6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f030c6"] }
 
@@ -666,211 +666,211 @@ embassy-stm32 = { workspace = true, features = ["stm32f217zg"] }
 
 [target.'cfg(context = "stm32f301c6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f301c6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f301c8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f301c8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f301k6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f301k6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f301k8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f301k8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f301r6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f301r6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f301r8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f301r8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302c6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302c6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302c8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302c8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302k6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302k6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302k8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302k8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302r6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302r6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302r8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302r8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302rb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302rb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302rd")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302rd"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302vb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302vb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302vd")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302vd"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302zd")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302zd"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f302ze")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f302ze"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303c6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303c6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303c8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303c8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303k6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303k6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303k8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303k8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303r6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303r6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303r8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303r8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303rb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303rb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303rd")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303rd"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303vb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303vb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303vd")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303vd"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303zd")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303zd"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f303ze")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f303ze"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f318c8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f318c8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f318k8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f318k8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f328c8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f328c8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f334c4")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f334c4"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f334c6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f334c6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f334c8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f334c8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f334k4")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f334k4"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f334k6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f334k6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f334k8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f334k8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f334r6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f334r6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f334r8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f334r8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f358cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f358cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f358rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f358rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f358vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f358vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f373c8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f373c8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f373cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f373cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f373cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f373cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f373r8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f373r8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f373rb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f373rb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f373rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f373rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f373v8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f373v8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f373vb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f373vb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f373vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f373vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f378cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f378cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f378rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f378rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f378vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f378vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f398ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f398ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32f401cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32f401cb"] }
 
@@ -1896,283 +1896,283 @@ embassy-stm32 = { workspace = true, features = ["stm32g0c1ve"] }
 
 [target.'cfg(context = "stm32g431c6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431c6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g431c8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431c8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g431cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g431k6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431k6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g431k8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431k8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g431kb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431kb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g431m6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431m6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g431m8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431m8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g431mb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431mb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g431r6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431r6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g431r8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431r8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g431rb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431rb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g431v6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431v6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g431v8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431v8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g431vb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g431vb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g441cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g441cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g441kb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g441kb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g441mb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g441mb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g441rb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g441rb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g441vb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g441vb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g471cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g471cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g471ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g471ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g471mc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g471mc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g471me")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g471me"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g471qc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g471qc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g471qe")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g471qe"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g471rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g471rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g471re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g471re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g471vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g471vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g471ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g471ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473mb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473mb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473mc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473mc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473me")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473me"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473pb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473pb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473pc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473pc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473pe")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473pe"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473qb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473qb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473qc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473qc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473qe")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473qe"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473rb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473rb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473vb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473vb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g473ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g473ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474mb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474mb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474mc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474mc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474me")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474me"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474pb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474pb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474pc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474pc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474pe")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474pe"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474qb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474qb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474qc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474qc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474qe")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474qe"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474rb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474rb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474vb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474vb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g474ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g474ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g483ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g483ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g483me")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g483me"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g483pe")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g483pe"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g483qe")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g483qe"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g483re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g483re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g483ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g483ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g484ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g484ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g484me")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g484me"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g484pe")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g484pe"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g484qe")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g484qe"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g484re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g484re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g484ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g484ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g491cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g491cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g491ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g491ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g491kc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g491kc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g491ke")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g491ke"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g491mc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g491mc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g491me")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g491me"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g491rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g491rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g491re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g491re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g491vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g491vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g491ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g491ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g4a1ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g4a1ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g4a1ke")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g4a1ke"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g4a1me")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g4a1me"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g4a1re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g4a1re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32g4a1ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32g4a1ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h503cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h503cb"] }
 
@@ -2310,403 +2310,403 @@ embassy-stm32 = { workspace = true, features = ["stm32h573zi"] }
 
 [target.'cfg(context = "stm32h723ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h723ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h723vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h723vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h723ze")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h723ze"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h723zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h723zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h725ae")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h725ae"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h725ag")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h725ag"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h725ie")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h725ie"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h725ig")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h725ig"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h725re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h725re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h725rg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h725rg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h725ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h725ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h725vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h725vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h725ze")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h725ze"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h725zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h725zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h730ab")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h730ab"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h730ib")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h730ib"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h730vb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h730vb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h730zb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h730zb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h733vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h733vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h733zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h733zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h735ag")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h735ag"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h735ig")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h735ig"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h735rg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h735rg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h735vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h735vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h735zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h735zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h742ag")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h742ag"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h742ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h742ai"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h742bg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h742bg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h742bi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h742bi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h742ig")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h742ig"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h742ii")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h742ii"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h742vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h742vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h742vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h742vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h742xg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h742xg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h742xi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h742xi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h742zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h742zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h742zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h742zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h743ag")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h743ag"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h743ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h743ai"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h743bg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h743bg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h743bi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h743bi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h743ig")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h743ig"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h743ii")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h743ii"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h743vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h743vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h743vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h743vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h743xg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h743xg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h743xi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h743xi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h743zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h743zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h743zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h743zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h745bg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h745bg-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h745bi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h745bi-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h745ig")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h745ig-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h745ii")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h745ii-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h745xg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h745xg-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h745xi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h745xi-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h745zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h745zg-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h745zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h745zi-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h747ag")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h747ag-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h747ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h747ai-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h747bg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h747bg-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h747bi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h747bi-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h747ig")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h747ig-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h747ii")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h747ii-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h747xg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h747xg-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h747xi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h747xi-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h747zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h747zi-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h750ib")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h750ib"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h750vb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h750vb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h750xb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h750xb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h750zb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h750zb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h753ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h753ai"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h753bi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h753bi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h753ii")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h753ii"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h753vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h753vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h753xi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h753xi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h753zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h753zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h755bi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h755bi-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h755ii")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h755ii-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h755xi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h755xi-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h755zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h755zi-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h757ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h757ai-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h757bi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h757bi-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h757ii")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h757ii-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h757xi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h757xi-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h757zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h757zi-cm7"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3ag")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3ag"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3ai"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3ig")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3ig"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3ii")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3ii"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3lg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3lg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3li")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3li"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3ng")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3ng"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3ni")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3ni"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3qi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3qi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3rg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3rg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3ri")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3ri"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7a3zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7a3zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7b0ab")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7b0ab"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7b0ib")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7b0ib"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7b0rb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7b0rb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7b0vb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7b0vb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7b0zb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7b0zb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7b3ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7b3ai"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7b3ii")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7b3ii"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7b3li")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7b3li"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7b3ni")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7b3ni"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7b3qi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7b3qi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7b3ri")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7b3ri"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7b3vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7b3vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7b3zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7b3zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7r3a8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7r3a8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7r3i8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7r3i8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7r3l8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7r3l8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7r3r8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7r3r8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7r3v8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7r3v8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7r3z8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7r3z8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7r7a8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7r7a8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7r7i8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7r7i8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7r7l8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7r7l8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7r7z8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7r7z8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7s3a8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7s3a8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7s3i8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7s3i8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7s3l8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7s3l8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7s3r8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7s3r8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7s3v8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7s3v8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7s3z8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7s3z8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7s7a8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7s7a8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7s7i8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7s7i8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7s7l8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7s7l8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32h7s7z8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32h7s7z8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l010c6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l010c6"] }
 
@@ -3270,421 +3270,421 @@ embassy-stm32 = { workspace = true, features = ["stm32l162ze"] }
 
 [target.'cfg(context = "stm32l412c8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l412c8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l412cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l412cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l412k8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l412k8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l412kb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l412kb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l412r8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l412r8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l412rb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l412rb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l412t8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l412t8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l412tb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l412tb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l422cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l422cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l422kb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l422kb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l422rb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l422rb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l422tb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l422tb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l431cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l431cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l431cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l431cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l431kb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l431kb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l431kc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l431kc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l431rb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l431rb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l431rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l431rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l431vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l431vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l432kb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l432kb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l432kc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l432kc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l433cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l433cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l433cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l433cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l433rb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l433rb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l433rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l433rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l433vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l433vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l442kc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l442kc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l443cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l443cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l443rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l443rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l443vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l443vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l451cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l451cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l451ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l451ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l451rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l451rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l451re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l451re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l451vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l451vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l451ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l451ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l452cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l452cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l452ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l452ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l452rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l452rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l452re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l452re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l452vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l452vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l452ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l452ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l462ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l462ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l462re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l462re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l462ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l462ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l471qe")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l471qe"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l471qg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l471qg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l471re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l471re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l471rg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l471rg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l471ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l471ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l471vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l471vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l471ze")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l471ze"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l471zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l471zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l475rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l475rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l475re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l475re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l475rg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l475rg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l475vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l475vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l475ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l475ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l475vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l475vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l476je")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l476je"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l476jg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l476jg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l476me")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l476me"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l476mg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l476mg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l476qe")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l476qe"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l476qg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l476qg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l476rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l476rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l476re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l476re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l476rg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l476rg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l476vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l476vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l476ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l476ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l476vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l476vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l476ze")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l476ze"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l476zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l476zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l486jg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l486jg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l486qg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l486qg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l486rg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l486rg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l486vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l486vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l486zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l486zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l496ae")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l496ae"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l496ag")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l496ag"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l496qe")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l496qe"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l496qg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l496qg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l496re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l496re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l496rg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l496rg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l496ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l496ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l496vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l496vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l496wg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l496wg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l496ze")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l496ze"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l496zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l496zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4a6ag")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4a6ag"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4a6qg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4a6qg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4a6rg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4a6rg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4a6vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4a6vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4a6zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4a6zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4p5ae")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4p5ae"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4p5ag")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4p5ag"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4p5ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4p5ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4p5cg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4p5cg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4p5qe")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4p5qe"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4p5qg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4p5qg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4p5re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4p5re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4p5rg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4p5rg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4p5ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4p5ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4p5vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4p5vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4p5ze")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4p5ze"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4p5zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4p5zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4q5ag")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4q5ag"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4q5cg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4q5cg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4q5qg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4q5qg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4q5rg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4q5rg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4q5vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4q5vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4q5zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4q5zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r5ag")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r5ag"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r5ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r5ai"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r5qg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r5qg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r5qi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r5qi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r5vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r5vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r5vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r5vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r5zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r5zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r5zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r5zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r7ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r7ai"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r7vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r7vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r7zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r7zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r9ag")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r9ag"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r9ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r9ai"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r9vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r9vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r9vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r9vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r9zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r9zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4r9zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4r9zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4s5ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4s5ai"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4s5qi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4s5qi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4s5vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4s5vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4s5zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4s5zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4s7ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4s7ai"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4s7vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4s7vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4s7zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4s7zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4s9ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4s9ai"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4s9vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4s9vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l4s9zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l4s9zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32l552cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32l552cc"] }
 
@@ -3738,528 +3738,528 @@ embassy-stm32 = { workspace = true, features = ["stm32l562ze"] }
 
 [target.'cfg(context = "stm32u031c6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u031c6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u031c8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u031c8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u031f4")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u031f4"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u031f6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u031f6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u031f8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u031f8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u031g6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u031g6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u031g8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u031g8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u031k4")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u031k4"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u031k6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u031k6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u031k8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u031k8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u031r6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u031r6"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u031r8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u031r8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073c8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073c8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073h8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073h8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073hb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073hb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073hc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073hc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073k8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073k8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073kb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073kb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073kc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073kc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073m8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073m8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073mb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073mb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073mc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073mc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073r8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073r8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073rb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073rb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u073rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u073rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u083cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u083cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u083hc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u083hc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u083kc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u083kc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u083mc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u083mc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u083rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u083rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u535cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u535cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u535cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u535cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u535ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u535ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u535je")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u535je"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u535nc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u535nc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u535ne")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u535ne"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u535rb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u535rb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u535rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u535rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u535re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u535re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u535vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u535vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u535ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u535ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u545ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u545ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u545je")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u545je"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u545ne")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u545ne"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u545re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u545re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u545ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u545ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u575ag")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u575ag"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u575ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u575ai"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u575cg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u575cg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u575ci")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u575ci"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u575og")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u575og"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u575oi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u575oi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u575qg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u575qg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u575qi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u575qi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u575rg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u575rg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u575ri")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u575ri"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u575vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u575vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u575vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u575vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u575zg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u575zg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u575zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u575zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u585ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u585ai"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u585ci")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u585ci"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u585oi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u585oi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u585qi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u585qi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u585ri")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u585ri"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u585vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u585vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u585zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u585zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u595ai")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u595ai"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u595aj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u595aj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u595qi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u595qi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u595qj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u595qj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u595ri")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u595ri"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u595rj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u595rj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u595vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u595vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u595vj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u595vj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u595zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u595zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u595zj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u595zj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u599bj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u599bj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u599ni")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u599ni"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u599nj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u599nj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u599vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u599vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u599vj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u599vj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u599zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u599zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u599zj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u599zj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5a5aj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5a5aj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5a5qi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5a5qi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5a5qj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5a5qj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5a5rj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5a5rj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5a5vj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5a5vj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5a5zj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5a5zj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5a9bj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5a9bj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5a9nj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5a9nj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5a9vj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5a9vj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5a9zj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5a9zj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5f7vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5f7vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5f7vj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5f7vj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5f9bj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5f9bj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5f9nj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5f9nj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5f9vi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5f9vi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5f9vj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5f9vj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5f9zi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5f9zi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5f9zj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5f9zj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5g7vj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5g7vj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5g9bj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5g9bj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5g9nj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5g9nj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5g9vj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5g9vj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32u5g9zj")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32u5g9zj"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb10cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb10cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb15cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb15cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb30ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb30ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb35cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb35cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb35ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb35ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb50cg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb50cg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb55cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb55cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb55ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb55ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb55cg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb55cg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb55rc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb55rc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb55re")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb55re"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb55rg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb55rg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb55vc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb55vc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb55ve")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb55ve"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb55vg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb55vg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wb55vy")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wb55vy"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba50ke")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba50ke"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba50kg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba50kg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba52ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba52ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba52cg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba52cg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba52ke")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba52ke"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba52kg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba52kg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba54ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba54ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba54cg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba54cg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba54ke")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba54ke"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba54kg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba54kg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba55ce")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba55ce"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba55cg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba55cg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba55he")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba55he"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba55hg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba55hg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba55ue")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba55ue"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba55ug")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba55ug"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba62cg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba62cg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba62ci")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba62ci"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba62mg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba62mg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba62mi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba62mi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba62pg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba62pg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba62pi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba62pi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba63cg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba63cg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba63ci")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba63ci"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba64cg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba64cg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba64ci")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba64ci"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba65cg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba65cg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba65ci")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba65ci"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba65mg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba65mg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba65mi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba65mi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba65pg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba65pg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba65pi")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba65pi"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba65rg")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba65rg"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wba65ri")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wba65ri"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wl54cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wl54cc-cm4"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wl54jc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wl54jc-cm4"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wl55cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wl55cc-cm4"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wl55jc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wl55jc-cm4"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wle4c8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wle4c8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wle4cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wle4cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wle4cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wle4cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wle4j8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wle4j8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wle4jb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wle4jb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wle4jc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wle4jc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wle5c8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wle5c8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wle5cb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wle5cb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wle5cc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wle5cc"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wle5j8")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wle5j8"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wle5jb")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wle5jb"] }
-
+ariel-os-rt = { workspace = true, features = ["memory-x"] }
 [target.'cfg(context = "stm32wle5jc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wle5jc"] }
-# END AUTO-GENERATED STM32 MAPPING
+ariel-os-rt = { workspace = true, features = ["memory-x"] }# END AUTO-GENERATED STM32 MAPPING
 
 [lints]

--- a/src/ariel-os-stm32-mapping/build.rs
+++ b/src/ariel-os-stm32-mapping/build.rs
@@ -41,32 +41,28 @@ fn generate_target_table(row: &str) -> String {
     let mut cols = row.split(',');
 
     let mcu = cols.next().unwrap();
+    let mcu = &mcu[1..mcu.len() - 1];
     let cargo_feature = {
-        let mut mcu_base = mcu.to_owned();
-        let skip_leading_quotation_mark = &mcu_base[1..];
         if CM4_CM7_MCU_PREFIXES
             .iter()
-            .any(|prefix| skip_leading_quotation_mark.starts_with(prefix))
+            .any(|prefix| mcu.starts_with(prefix))
         {
             // Remove the trailing quotation mark.
-            mcu_base.pop();
-            format!("{mcu_base}-cm7\"")
+            format!("\"{mcu}-cm7\"")
         } else if CM0P_CM4_MCU_PREFIXES
             .iter()
-            .any(|prefix| skip_leading_quotation_mark.starts_with(prefix))
+            .any(|prefix| mcu.starts_with(prefix))
         {
             // Remove the trailing quotation mark.
-            mcu_base.pop();
-            format!("{mcu_base}-cm4\"")
+            format!("\"{mcu}-cm4\"")
         } else {
-            mcu_base
+            format!("\"{mcu}\"")
         }
     };
 
-    // The TOML quotation marks come from the already-quoted CSV strings.
     format!(
         r#"
-[target.'cfg(context = {mcu})'.dependencies]
+[target.'cfg(context = "{mcu}")'.dependencies]
 embassy-stm32 = {{ workspace = true, features = [{cargo_feature}] }}
 "#,
     )

--- a/src/ariel-os-stm32-mapping/build.rs
+++ b/src/ariel-os-stm32-mapping/build.rs
@@ -17,6 +17,12 @@ const END_PATTERN: &str = "END AUTO-GENERATED STM32 MAPPING";
 const CM4_CM7_MCU_PREFIXES: &[&str] = &["stm32h745", "stm32h747", "stm32h755", "stm32h757"];
 const CM0P_CM4_MCU_PREFIXES: &[&str] = &["stm32wl54", "stm32wl55"];
 
+// These MCUs support memory-x generation
+const SUPPORT_MEMORYX: &[&str] = &[
+    "stm32c0", "stm32f3", "stm32wl", "stm32g4", "stm32h7", "stm32l4", "stm32u0", "stm32u5",
+    "stm32wb",
+];
+
 fn main() {
     let cargo_manifest_path = std::env::var("CARGO_MANIFEST_PATH").unwrap();
     let mut cargo_manifest = std::fs::read_to_string(&cargo_manifest_path).unwrap();
@@ -60,10 +66,17 @@ fn generate_target_table(row: &str) -> String {
         }
     };
 
-    format!(
+    // The TOML quotation marks come from the already-quoted CSV strings.
+    let mut target = format!(
         r#"
 [target.'cfg(context = "{mcu}")'.dependencies]
 embassy-stm32 = {{ workspace = true, features = [{cargo_feature}] }}
 "#,
-    )
+    );
+
+    if SUPPORT_MEMORYX.iter().any(|prefix| mcu.starts_with(prefix)) {
+        target.push_str(r#"ariel-os-rt = { workspace = true, features = ["memory-x"] }"#);
+    }
+
+    target
 }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -372,6 +372,17 @@ who = "chrysn <chrysn@fsfe.org>"
 criteria = "safe-to-deploy"
 delta = "0.4.27 -> 0.4.28"
 
+[[audits.log]]
+who = "Koen Zandberg <koen@bergzand.net>"
+criteria = "safe-to-deploy"
+delta = "0.4.29 -> 0.4.34"
+notes = "No changes to unsafe code. Newly added code looks reasonable."
+
+[[audits.memsolve]]
+who = "Koen Zandberg <koen@bergzand.net>"
+criteria = "safe-to-deploy"
+version = "0.2.4"
+
 [[audits.minicbor-adapters]]
 who = "chrysn <chrysn@fsfe.org>"
 criteria = "safe-to-deploy"
@@ -393,6 +404,17 @@ who = "chrysn <chrysn@fsfe.org>"
 criteria = "safe-to-deploy"
 delta = "3.0.3+3.0.2 -> 3.1.0+3.3.0"
 notes = "Review extends to the source of nrfxlib-sys only. The library ships also proprietary C components, which were not (and, due to being closed source, can not) be reviewed."
+
+[[audits.num-complex]]
+who = "Koen Zandberg <koen@bergzand.net>"
+criteria = "safe-to-deploy"
+delta = "0.4.2 -> 0.4.6"
+notes = """
+Minor update of the crate:
+- Bumps the rust  edition to 2021
+- Adds support for rkyv and bytecheck as optional dependencies
+- Rest of the changes are all safe code
+"""
 
 [[audits.num-conv]]
 who = "Nils Ponsard <nils.ponsard@inria.fr>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -340,6 +340,10 @@ criteria = "safe-to-deploy"
 version = "0.2.15"
 criteria = "safe-to-deploy"
 
+[[exemptions.conv]]
+version = "0.3.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.convert_case]]
 version = "0.8.0"
 criteria = "safe-to-deploy"
@@ -394,6 +398,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.curve25519-dalek-derive]]
 version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.custom_derive]]
+version = "0.1.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.cyw43]]
@@ -1004,6 +1012,14 @@ criteria = "safe-to-deploy"
 version = "0.1.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.matrixmultiply]]
+version = "0.3.11"
+criteria = "safe-to-deploy"
+
+[[exemptions.microlp]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.minicbor]]
 version = "2.1.3"
 criteria = "safe-to-deploy"
@@ -1018,6 +1034,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.minimal-lexical]]
 version = "0.2.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.ndarray]]
+version = "0.17.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.nourl]]
@@ -1204,6 +1224,10 @@ criteria = "safe-to-deploy"
 version = "0.3.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.rawpointer]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.rbi]]
 version = "0.1.1"
 criteria = "safe-to-deploy"
@@ -1356,6 +1380,10 @@ criteria = "safe-to-deploy"
 version = "0.7.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.sprs]]
+version = "0.11.4"
+criteria = "safe-to-deploy"
+
 [[exemptions.ssmarshal]]
 version = "1.0.0"
 criteria = "safe-to-deploy"
@@ -1446,6 +1474,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.volatile-register]]
 version = "0.2.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.web-time]]
+version = "1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.xtensa-lx]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -14,6 +14,13 @@ when = "2026-01-22"
 user-id = 55123
 user-login = "rust-lang-owner"
 
+[[publisher.bumpalo]]
+version = "3.20.3"
+when = "2026-05-22"
+user-id = 696
+user-login = "fitzgen"
+user-name = "Nick Fitzgerald"
+
 [[publisher.cc]]
 version = "1.0.89"
 when = "2024-03-04"
@@ -89,6 +96,13 @@ when = "2025-03-03"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
+
+[[publisher.js-sys]]
+version = "0.3.76"
+when = "2024-12-07"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
 
 [[publisher.libc]]
 version = "0.2.172"
@@ -305,6 +319,13 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.syn]]
+version = "3.0.4"
+when = "2026-08-24"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.target-triple]]
 version = "1.0.0"
 when = "2025-10-27"
@@ -320,15 +341,15 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.thiserror]]
-version = "2.0.18"
-when = "2026-01-18"
+version = "2.0.20"
+when = "2026-08-08"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.thiserror-impl]]
-version = "2.0.18"
-when = "2026-01-18"
+version = "2.0.20"
+when = "2026-08-08"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -441,6 +462,41 @@ user-name = "Alex Crichton"
 [[publisher.wasi]]
 version = "0.14.2+wasi-0.2.4"
 when = "2025-02-28"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-bindgen]]
+version = "0.2.99"
+when = "2024-12-07"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-bindgen-backend]]
+version = "0.2.100"
+when = "2025-01-12"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-bindgen-macro]]
+version = "0.2.99"
+when = "2024-12-07"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-bindgen-macro-support]]
+version = "0.2.100"
+when = "2025-01-12"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-bindgen-shared]]
+version = "0.2.100"
+when = "2025-01-12"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -597,6 +653,13 @@ version = "0.39.0"
 when = "2025-02-05"
 user-id = 73222
 user-login = "wasmtime-publish"
+
+[[audits.bytecode-alliance.wildcard-audits.bumpalo]]
+who = "Nick Fitzgerald <fitzgen@gmail.com>"
+criteria = "safe-to-deploy"
+user-id = 696 # Nick Fitzgerald (fitzgen)
+start = "2019-03-16"
+end = "2026-08-21"
 
 [[audits.bytecode-alliance.wildcard-audits.wit-bindgen-rt]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -793,12 +856,6 @@ who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
 version = "0.1.3"
 notes = "A part of RustCrypto/utils, this crate is designed to handle unsafe buffers and carefully documents the safety concerns throughout. Older versions of this tally up to ~130k daily downloads."
-
-[[audits.bytecode-alliance.audits.log]]
-who = "Alex Crichton <alex@alexcrichton.com>"
-criteria = "safe-to-deploy"
-delta = "0.4.22 -> 0.4.27"
-notes = "Lots of minor updates to macros and such, nothing touching `unsafe`"
 
 [[audits.bytecode-alliance.audits.managed]]
 who = "Chris Fallin <chris@cfallin.org>"
@@ -1220,6 +1277,20 @@ Unsafe review in https://docs.google.com/document/d/1IXQbD1GhTRqNHIGxq6yy7qHqxeO
 Unsafety is generally very well-documented, with one exception, which we
 describe in the review doc.
 """
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.log]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.22 -> 0.4.25"
+notes = "No impact on `unsafe` usage in `lib.rs`."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.log]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.25 -> 0.4.26"
+notes = "Only trivial code and documentation changes."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.nb]]
@@ -2515,10 +2586,29 @@ criteria = "safe-to-deploy"
 delta = "1.2.0 -> 1.2.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.js-sys]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.76 -> 0.3.77"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.litemap]]
 who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
 criteria = "safe-to-deploy"
 delta = "0.7.5 -> 0.8.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.log]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.26 -> 0.4.29"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-complex]]
+who = "Josh Stone <jistone@redhat.com>"
+criteria = "safe-to-deploy"
+version = "0.4.2"
+notes = "All code written or reviewed by Josh Stone."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.num-conv]]
@@ -2864,6 +2954,18 @@ who = "Valentin Gosu <valentin.gosu@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "2.5.1 -> 2.5.4"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.wasm-bindgen]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.99 -> 0.2.100"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.wasm-bindgen-macro]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.99 -> 0.2.100"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.windows-link]]
 who = "Mark Hammond <mhammond@skippinet.com.au>"


### PR DESCRIPTION
# Description

This migrates the memory section generation as used by the stm32 to use [memsolve](https://codeberg.org/bergzand/memsolve) to allow for dynamic generation of the memory sections. This paves the way for bootloaders, configuration sections etc.

Only stm32 families where one of the boards already supports storage are migrated, the rest can be done later. The families where the flash pages are heterogeneous in size (the f2, f4 and f7) are more complex and require support in memsolve for this. But these families do not support storage anyway currently.

## Testing


Binaries should be identical before and after this PR. I've tested this by building the `examples/hello-world` for all affected boards and compare the digest of the resulting binary
```shellsession
laze build -r context::stm32 -C examples/hello-world
for f in build/bin/*/cargo/*/release/hello-world; do objcopy -O binary $f ${f}.bin; done
shasum build/bin/*/cargo/*/release/hello-world.bin
```

<details><summary> <h3> Before </h3> </summary>

```
729a8e3ba005343bf148f5db8c01c7fbff152b54  build/bin/arduino-uno-q/cargo/thumbv8m.main-none-eabihf/release/hello-world.bin
c07eb9f5dd3a35f4c74a1fd40174de5770474123  build/bin/seeedstudio-lora-e5-mini/cargo/thumbv7em-none-eabi/release/hello-world.bin
dcf0643172bad03d3b3759131632932ee04023a6  build/bin/st-b-l475e-iot01a/cargo/thumbv7em-none-eabihf/release/hello-world.bin
f612a0f5216e93f9b47807eb2838fa52d453fb75  build/bin/stm32u083c-dk/cargo/thumbv6m-none-eabi/release/hello-world.bin
3cbcbd3fa054d1b9554ddfd6feb44c80b9ee74ae  build/bin/st-nucleo-c031c6/cargo/thumbv6m-none-eabi/release/hello-world.bin
6198c75f8c8fb9b5f067f90a0e623a97142a9aea  build/bin/st-nucleo-f042k6/cargo/thumbv6m-none-eabi/release/hello-world.bin
318b5fdaf9b9a20f85154ab025e34af64a13cc81  build/bin/st-nucleo-f303re/cargo/thumbv7em-none-eabihf/release/hello-world.bin
5f305098caa32a21c3dfc6100af170cd5e158c10  build/bin/st-nucleo-f401re/cargo/thumbv7em-none-eabihf/release/hello-world.bin
83cb48b37bd2be424c7f4cacef2001de7a6d80e1  build/bin/st-nucleo-f411re/cargo/thumbv7em-none-eabihf/release/hello-world.bin
f05e2109469713c73501885fe2cab44b84bd14a8  build/bin/st-nucleo-f767zi/cargo/thumbv7em-none-eabihf/release/hello-world.bin
40f9c819e729ee1ae250e924c834db373a25cdbe  build/bin/st-nucleo-g431rb/cargo/thumbv7em-none-eabihf/release/hello-world.bin
9aa77a86dddef802f37563dc73e4f20bbb12f976  build/bin/st-nucleo-h753zi/cargo/thumbv7em-none-eabihf/release/hello-world.bin
b32688a47fd43e5813c85c313692bfd8cfd3cde0  build/bin/st-nucleo-h755zi-q/cargo/thumbv7em-none-eabihf/release/hello-world.bin
96be28fa4282cd5d11fff7ebc855b3d9979d39c9  build/bin/st-nucleo-wb55/cargo/thumbv7em-none-eabihf/release/hello-world.bin
22fb9354f3ebca1599dc6ae1e762ddfbc29efd9c  build/bin/st-nucleo-wba55/cargo/thumbv8m.main-none-eabihf/release/hello-world.bin
9d25dead843bb6d509cd4e2c2408e433fcf43d6c  build/bin/st-nucleo-wba65ri/cargo/thumbv8m.main-none-eabihf/release/hello-world.bin
1998b75db28a1b5c67aae0d787d1f45a9c4eb830  build/bin/st-steval-mkboxpro/cargo/thumbv8m.main-none-eabihf/release/hello-world.bin

```

</details>

<details><summary> <h3> After </h3> </summary>

```
729a8e3ba005343bf148f5db8c01c7fbff152b54  build/bin/arduino-uno-q/cargo/thumbv8m.main-none-eabihf/release/hello-world.bin
c07eb9f5dd3a35f4c74a1fd40174de5770474123  build/bin/seeedstudio-lora-e5-mini/cargo/thumbv7em-none-eabi/release/hello-world.bin
dcf0643172bad03d3b3759131632932ee04023a6  build/bin/st-b-l475e-iot01a/cargo/thumbv7em-none-eabihf/release/hello-world.bin
f612a0f5216e93f9b47807eb2838fa52d453fb75  build/bin/stm32u083c-dk/cargo/thumbv6m-none-eabi/release/hello-world.bin
3cbcbd3fa054d1b9554ddfd6feb44c80b9ee74ae  build/bin/st-nucleo-c031c6/cargo/thumbv6m-none-eabi/release/hello-world.bin
6198c75f8c8fb9b5f067f90a0e623a97142a9aea  build/bin/st-nucleo-f042k6/cargo/thumbv6m-none-eabi/release/hello-world.bin
318b5fdaf9b9a20f85154ab025e34af64a13cc81  build/bin/st-nucleo-f303re/cargo/thumbv7em-none-eabihf/release/hello-world.bin
5f305098caa32a21c3dfc6100af170cd5e158c10  build/bin/st-nucleo-f401re/cargo/thumbv7em-none-eabihf/release/hello-world.bin
83cb48b37bd2be424c7f4cacef2001de7a6d80e1  build/bin/st-nucleo-f411re/cargo/thumbv7em-none-eabihf/release/hello-world.bin
f05e2109469713c73501885fe2cab44b84bd14a8  build/bin/st-nucleo-f767zi/cargo/thumbv7em-none-eabihf/release/hello-world.bin
40f9c819e729ee1ae250e924c834db373a25cdbe  build/bin/st-nucleo-g431rb/cargo/thumbv7em-none-eabihf/release/hello-world.bin
9aa77a86dddef802f37563dc73e4f20bbb12f976  build/bin/st-nucleo-h753zi/cargo/thumbv7em-none-eabihf/release/hello-world.bin
b32688a47fd43e5813c85c313692bfd8cfd3cde0  build/bin/st-nucleo-h755zi-q/cargo/thumbv7em-none-eabihf/release/hello-world.bin
96be28fa4282cd5d11fff7ebc855b3d9979d39c9  build/bin/st-nucleo-wb55/cargo/thumbv7em-none-eabihf/release/hello-world.bin
22fb9354f3ebca1599dc6ae1e762ddfbc29efd9c  build/bin/st-nucleo-wba55/cargo/thumbv8m.main-none-eabihf/release/hello-world.bin
9d25dead843bb6d509cd4e2c2408e433fcf43d6c  build/bin/st-nucleo-wba65ri/cargo/thumbv8m.main-none-eabihf/release/hello-world.bin
1998b75db28a1b5c67aae0d787d1f45a9c4eb830  build/bin/st-steval-mkboxpro/cargo/thumbv8m.main-none-eabihf/release/hello-world.bin

```

</details>

## Issues/PRs References

depends on #2246 

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
