### PR TITLE
feat(rp): allow enabling internal pull-ups for the I2C controller

### DIFF
--- a/src/ariel-os-rp/src/i2c/controller/mod.rs
+++ b/src/ariel-os-rp/src/i2c/controller/mod.rs
@@ -21,12 +21,18 @@ const KHZ_TO_HZ: u32 = 1000;
 pub struct Config {
     /// The frequency at which the bus should operate.
     pub frequency: Frequency,
+    /// Whether to enable the internal pull-up resistor on the SDA pin.
+    pub sda_pullup: bool,
+    /// Whether to enable the internal pull-up resistor on the SCL pin.
+    pub scl_pullup: bool,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             frequency: Frequency::UpTo100k(Kilohertz::kHz(100)),
+            sda_pullup: false,
+            scl_pullup: false,
         }
     }
 }
@@ -142,6 +148,8 @@ macro_rules! define_i2c_drivers {
 
                     let mut i2c_config = embassy_rp::i2c::Config::default();
                     i2c_config.frequency = config.frequency.khz() * KHZ_TO_HZ;
+                    i2c_config.sda_pullup = config.sda_pullup;
+                    i2c_config.scl_pullup = config.scl_pullup;
 
                     bind_interrupts!(
                         struct Irqs {


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This adds the couple of I2C configuration settings that allow enabling the internal pull-ups. That wasn't done initially because they were not exposed by `embassy-rp` (only [added in `embassy-rp@0.8.0`](https://docs.embassy.dev/embassy-rp/0.8.0/rp2040/i2c/struct.Config.html)).

As mentioned in #2223, internal pull-ups are rarely enough for I2C (especially as those on RP are pretty weak; between ~30 kΩ and ~80 kΩ on the RP2040 and RP235x at 3.3 V), but this makes the API consistent with that of `ariel-os-nrf` and `ariel-os-stm32`.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
I've only tested that enabling these still allowed I2C to work (by writing a quick example for a sensor); I didn't check that these pull-ups were enough as I don't have a sensor board *without* onboard pull-ups handy.

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->
- Follow-up to #1328

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(RP) It is now possible to enable the internal pull-ups on I2C pins if necessary.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
