### PR TITLE
feat(log): add custom logging transport driver option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,6 +3138,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-usb-serial-logger"
+version = "0.0.0"
+dependencies = [
+ "ariel-os",
+ "ariel-os-boards",
+ "embassy-futures",
+ "embassy-sync 0.7.2",
+ "embedded-io-async 0.7.0",
+]
+
+[[package]]
 name = "extra-embedded-io-adapters"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/book/src/logging.md
+++ b/book/src/logging.md
@@ -106,6 +106,26 @@ When `espflash` is selected at the time of compilation, `logging-over-debug-chan
 > - Other logging transports will later be supported, including UART and USB CDC-ACM on non-ESP32 devices.
 > - Using multiple transports at the same time may be supported in the future.
 
+### Custom Logging Transports
+
+An application can connect a custom logging transport to send the logs through.
+
+This is enabled using the `custom-logging-transport` [laze module][laze-modules-book]. This will 
+disable all other logging transports and gives access to [`register_custom_transport()`][register_custom_transport_fn].
+This functions takes two arguments: 
+ - `write_bytes`: this function should take a reference to a slice of bytes (`&[u8]`) as input and
+ send it through the transport.
+ - `flush`: this function should flush the data through the transport when available for
+the transport.
+
+> [!IMPORTANT]
+> The functions given to `register_custom_transport` must not wait on interrupts they may be called
+> in the context of a critical section and should not make calls to the logging facade.
+
+> [!NOTE]
+> The logs triggered before setting the logging transport functions using `register_custom_transport` 
+> may be lost.
+
 ## Fetching and Displaying the Logging Output on the Host
 
 When the [flashing][flashing-board-book] transport allows it, the `run` laze task not only flashes the board but also fetches and displays the logging output on the host.
@@ -145,3 +165,4 @@ When multiple tasks of the same name exist, which variant is used depends on whi
 [semihosting-book]: ./flashing-debugging.md#semihosting
 [laze-tasks-book]: ./build-system.md#laze-tasks
 [rtt-book]: ./flashing-debugging.md#real-time-transfer-rtt
+[register_custom_transport_fn]: https://ariel-os.github.io/ariel-os/dev/docs/api/ariel_os/log/transport/fn.register_custom_transport.html

--- a/examples/laze.yml
+++ b/examples/laze.yml
@@ -38,3 +38,4 @@ subdirs:
   - udp-echo
   - usb-keyboard
   - usb-serial
+  - usb-serial-logger

--- a/examples/usb-serial-logger/Cargo.toml
+++ b/examples/usb-serial-logger/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "example-usb-serial-logger"
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+ariel-os = { path = "../../src/ariel-os", features = ["time"] }
+ariel-os-boards = { path = "../../src/ariel-os-boards" }
+embassy-futures = { workspace = true }
+embassy-sync = { workspace = true }
+embedded-io-async = { version = "0.7" }
+
+[lints]
+workspace = true

--- a/examples/usb-serial-logger/README.md
+++ b/examples/usb-serial-logger/README.md
@@ -1,0 +1,14 @@
+# usb-serial-logger
+
+## About
+
+This application is showing basic logging over _USB serial_ with Ariel OS.
+
+## How to run
+
+In this directory, run
+
+    laze build -b nrf52840dk run
+
+With the device USB cable connected, a USB serial port should show up on your computer.
+It will print logs at regular intervals.

--- a/examples/usb-serial-logger/laze.yml
+++ b/examples/usb-serial-logger/laze.yml
@@ -1,0 +1,6 @@
+apps:
+  - name: example-usb-serial-logger
+    selects:
+      - custom-logging-transport # Has to be selected before `usb` is selected
+      - log
+      - usb

--- a/examples/usb-serial-logger/src/main.rs
+++ b/examples/usb-serial-logger/src/main.rs
@@ -1,0 +1,106 @@
+#![no_std]
+#![no_main]
+
+use ariel_os::{
+    cell::StaticCell,
+    log::{debug, error, info, println, trace, transport::register_custom_transport, warn},
+    reexports::embassy_usb::{self, class::cdc_acm::CdcAcmError},
+    time::Timer,
+};
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, pipe::Pipe};
+use embassy_usb::{
+    class::cdc_acm::{CdcAcmClass, State},
+    driver::EndpointError,
+};
+use embedded_io_async::Write;
+
+const MAX_FULL_SPEED_PACKET_SIZE: u8 = 64;
+
+const LOG_BUFFER_SIZE: usize = 1024;
+static LOG_BUFFER: Pipe<CriticalSectionRawMutex, LOG_BUFFER_SIZE> = Pipe::new();
+
+#[ariel_os::task(autostart)]
+async fn logging() {
+    loop {
+        Timer::after_secs(1).await;
+        info!("Testing USB CDC ACM logging");
+        println!("-- this is printed via `println!()`");
+        trace!("-- trace log level enabled");
+        debug!("-- debug log level enabled");
+        info!("-- info log level enabled");
+        warn!("-- warn log level enabled");
+        error!("-- error log level enabled (just testing)");
+    }
+}
+
+#[ariel_os::task(autostart, usb_builder_hook)]
+async fn main() {
+    register_custom_transport(write_bytes, flush);
+
+    info!("Hello World!");
+
+    static STATE: StaticCell<State<'_>> = StaticCell::new();
+
+    // Create and inject the USB class on the system USB builder.
+    let class = USB_BUILDER_HOOK
+        .with(|builder| {
+            CdcAcmClass::new(
+                builder,
+                STATE.init_with(State::new),
+                MAX_FULL_SPEED_PACKET_SIZE.into(),
+            )
+        })
+        .await;
+
+    let (mut sender, mut receiver) = class.split();
+    loop {
+        let sender_fut = async {
+            sender.wait_connection().await;
+            let mut buffer = [0; LOG_BUFFER_SIZE as usize];
+            loop {
+                let len = LOG_BUFFER.read(&mut buffer).await;
+
+                if matches!(
+                    sender.write_all(&buffer[..len]).await,
+                    Err(CdcAcmError::NotConnected)
+                ) {
+                    // If the USB connection is disconnected, wait until it's reconnected.
+                    sender.wait_connection().await;
+                };
+            }
+        };
+
+        // The serial has to be read otherwise the USB device hangs on some MCUs.
+        let receiver_fut = async {
+            receiver.wait_connection().await;
+            let mut buffer = [0; MAX_FULL_SPEED_PACKET_SIZE as usize];
+            loop {
+                if matches!(
+                    receiver.read_packet(&mut buffer).await,
+                    Err(EndpointError::Disabled)
+                ) {
+                    receiver.wait_connection().await;
+                }
+            }
+        };
+
+        embassy_futures::join::join(sender_fut, receiver_fut).await;
+    }
+}
+
+pub fn write_bytes(bytes: &[u8]) {
+    let end = bytes.len();
+
+    let mut total = 0;
+    while total < end {
+        let n = match LOG_BUFFER.try_write(&bytes[total..end]) {
+            Ok(n) => n,
+            // Pipe full, drop the data.
+            Err(_) => return,
+        };
+        total += n;
+    }
+}
+
+// No-op, flushing isn't possible with this setup.
+pub fn flush() {}

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1859,6 +1859,18 @@ modules:
       # Optional as we want to be able to disable it in applications.
       - ?panic-printing
 
+  - name: custom-logging-transport
+    help: Connect a custom logging transport to pass the logs through.
+    provides_unique:
+      - logging-transport
+    # Conflicts with defmt until a logger is implemented.
+    conflicts:
+      - defmt
+    env:
+      global:
+        FEATURES:
+          - ariel-os/custom-logging-transport
+
   # Ordered by priority.
   # Currently the logging transports are mutually exclusive.
   - name: logging-transport-default

--- a/src/ariel-os/Cargo.toml
+++ b/src/ariel-os/Cargo.toml
@@ -229,6 +229,8 @@ rtt-target = ["ariel-os-debug/rtt-target"]
 defmt-rtt = ["ariel-os-log/defmt-rtt"]
 esp-println = ["ariel-os-log/esp-println"]
 semihosting = ["ariel-os-debug/semihosting"]
+# Log transport defined by the application.
+custom-logging-transport = ["ariel-os-log/custom-transport-driver"]
 
 net = ["ariel-os-embassy/net"]
 


### PR DESCRIPTION
# Description

This adds the ability to send logs through a custom transport that can be defined in the application.

## Testing

```sh 
laze -C examples/usb-serial-logger build -b nrf52840dk run 
```

Read the logs through the usb serial device.


## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

- Depends on #2272 

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
A custom logging transport can now be defined from the application, see the [logging book page](https://ariel-os.github.io/ariel-os/dev/docs/book/logging.html#custom-logging-transports).
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
