### PR TITLE
fix(st-nucleo-wba55): add config rcc for wba55

### DIFF
--- a/src/ariel-os-stm32/src/rcc.rs
+++ b/src/ariel-os-stm32/src/rcc.rs
@@ -296,6 +296,29 @@ fn default() -> embassy_stm32::rcc::Config {
         rcc.sys = Sysclk::PLL1_R;
     }
 
+    #[cfg(context = "st-nucleo-wba55")]
+    {
+        use embassy_stm32::rcc::*;
+
+        rcc.hse = Some(Hse {
+            prescaler: HsePrescaler::DIV1,
+        });
+
+        rcc.pll1 = Some(Pll {
+            source: PllSource::HSE,
+            prediv: PllPreDiv::DIV2, // 32 / 2 = 16 MHz
+            mul: PllMul::MUL25,      // 16 * 25 = 400 MHz VCO (128..=544)
+            divp: None,
+            divq: None,
+            divr: Some(PllDiv::DIV4), // 400 / 4 = 100 MHz (sysclk, max)
+            frac: None,
+        });
+        rcc.sys = Sysclk::PLL1_R;
+        // The PLL is unavailable in voltage range 2
+        rcc.voltage_scale = VoltageScale::RANGE1;
+        rcc.mux.sai1sel = mux::Sai1sel::HSI;
+    }
+
     #[cfg(context = "st-nucleo-wba65ri")]
     {
         use embassy_stm32::rcc::*;


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->

This PR fix error running `examples/hello-world` on `STM32WBA55CG`. It fails because SAI1 is not configured, but this PR also set sysclock to 100MHz (max value)

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

During the 1AD hackathon, I was trying to run arielOS on a `STM32WBA55CG`, but got an weird error during the `examples/hello-world`. 

```console
> laze -C examples/hello-world build -b st-nucleo-wba55 run
laze: project root: /home/william/projects/rust/ariel-os relpath: examples/hello-world project_file: laze-project.yml
laze: building all for st-nucleo-wba55
laze: reading cache: local paths don't match
laze: parsing 81 files took 10.8558ms
laze: stat'ing 81 files took 107.072µs
configuring hello-world for st-nucleo-wba55
configured 1 builds (took 1.608118ms).
laze: writing cache took 262.916µs.
   Compiling ariel-os-stm32 v0.5.0 (/home/william/projects/rust/ariel-os/src/ariel-os-stm32)
   Compiling ariel-os-hal v0.5.0 (/home/william/projects/rust/ariel-os/src/ariel-os-hal)
   Compiling ariel-os-identity v0.5.0 (/home/william/projects/rust/ariel-os/src/ariel-os-identity)
   Compiling ariel-os-boards v0.0.0 (/home/william/projects/rust/ariel-os/src/ariel-os-boards)
   Compiling ariel-os-embassy v0.5.0 (/home/william/projects/rust/ariel-os/src/ariel-os-embassy)
   Compiling ariel-os v0.5.0 (/home/william/projects/rust/ariel-os/src/ariel-os)
   Compiling hello-world v0.0.0 (/home/william/projects/rust/ariel-os/examples/hello-world)
    Finished [`release` profile [optimized + debuginfo]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 1.23s
     Running `probe-rs run --protocol=swd --chip STM32WBA55CG --preverify ../../build/bin/st-nucleo-wba55/cargo/thumbv8m.main-none-eabihf/release/hello-world`
      Erasing ✔ 100% [####################]  16.00 KiB @ 229.16 KiB/s (took 0s)
  Programming ✔ 100% [####################]  11.00 KiB @  42.40 KiB/s (took 0s)                                                                                                                     Finished in 0.54s
panicked at /home/william/.cargo/git/checkouts/embassy-0012190963c274d8/1b75c3d/embassy-stm32/src/rcc/wba.rs:261:40:
PLL1.P not configured
Firmware exited with: Application exit (Unknown exit code 1)
Core 0
    Frame 0: syscall_readonly @ 0x08001906 inline
       /home/william/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semihosting-0.1.24/src/sys/arm_compat/syscall/arm.rs:93:9
    Frame 1: sys_exit_extended @ 0x0000000008001904 inline
       /home/william/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semihosting-0.1.24/src/sys/arm_compat/mod.rs:287:9
    Frame 2: exit @ 0x00000000080018f4
       /home/william/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semihosting-0.1.24/src/sys/arm_compat/mod.rs:257:9
    Frame 3: exit @ 0x080018e8
       /home/william/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semihosting-0.1.24/src/process.rs:73:5
    Frame 4: exit @ 0x08000278
       /home/william/projects/rust/ariel-os/src/ariel-os-debug/src/exit.rs:39:5
    Frame 5: panic @ 0x08000920
       /home/william/projects/rust/ariel-os/src/ariel-os-rt/src/lib.rs:144:5
    Frame 6: panic_fmt @ 0x08000ac2
       /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/panicking.rs:80:14
    Frame 7: panic_display<&str> @ 0x08001170 inline
       /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/panicking.rs:259:5
    Frame 8: expect_failed @ 0x0000000008001156
       /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/option.rs:2257:5
    Frame 9: <unknown function @ 0x080004a8> @ 0x080004a8 inline
       /home/william/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs:968:21
    Frame 10: init @ 0x000000000800048e inline
       /home/william/.cargo/git/checkouts/embassy-0012190963c274d8/1b75c3d/embassy-stm32/src/rcc/wba.rs:261:40
    Frame 11: init_rcc @ 0x0000000008000364 inline
       /home/william/.cargo/git/checkouts/embassy-0012190963c274d8/1b75c3d/embassy-stm32/src/rcc/mod.rs:399:9
    Frame 12: {closure#0} @ 0x0000000008000364 inline
       /home/william/.cargo/git/checkouts/embassy-0012190963c274d8/1b75c3d/embassy-stm32/src/lib.rs:626:13
    Frame 13: with<embassy_stm32::_generated::Peripherals, embassy_stm32::init_hw::{closure_env#0}> @ 0x0000000008000288 inline
       /home/william/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/critical-section-1.2.0/src/lib.rs:248:14
    Frame 14: init_hw @ 0x0000000008000282 inline
       /home/william/.cargo/git/checkouts/embassy-0012190963c274d8/1b75c3d/embassy-stm32/src/lib.rs:497:5
    Frame 15: init @ 0x0000000008000282 inline
       /home/william/.cargo/git/checkouts/embassy-0012190963c274d8/1b75c3d/embassy-stm32/src/lib.rs:325:5
    Frame 16: init @ 0x0000000008000282 inline
       /home/william/projects/rust/ariel-os/src/ariel-os-stm32/src/lib.rs:98:23
    Frame 17: init @ 0x0000000008000282
       /home/william/projects/rust/ariel-os/src/ariel-os-embassy/src/lib.rs:160:13
    Frame 18: startup @ 0x080009d4
       /home/william/projects/rust/ariel-os/src/ariel-os-rt/src/lib.rs:181:9
    Frame 19: __cortex_m_rt_main @ 0x08000930
       /home/william/projects/rust/ariel-os/src/ariel-os-rt/src/cortexm.rs:194:5
    Frame 20: __cortex_m_rt_main_trampoline @ 0x08000928
       /home/william/projects/rust/ariel-os/src/ariel-os-rt/src/cortexm.rs:192:1
    Frame 21: Reset @ 0x0800019a> @ 0x000000000800019a

    Frame 22: Reset @ 0x0800019a> @ 0x000000000800019a

Error: Application exit
laze: error: command ` OPENOCD_ARGS="foo" SCRIPTS=../../scripts CONFIG_BOARD=st-nucleo-wba55 CARGO_BUILD_TARGET=thumbv8m.main-none-eabihf CARGO_TARGET_THUMBV8M_MAIN_NONE_EABIHF_RUNNER='probe-rs run --protocol=swd --chip STM32WBA55CG --preverify' CARGO_TARGET_THUMBV8M_MAIN_NONE_EABIHF_RUSTFLAGS="--cfg context=\"st-nucleo-wba55\" --cfg context=\"stm32wba55cg\" --cfg context=\"stm32\" --cfg context=\"ariel-os\" --cfg context=\"default\" --cfg capability=\"hw/stm32-rng\" --cfg stable -Cembed-bitcode=yes -Clto=fat -Ccodegen-units=1 --cfg capability=\"hw/device-identity\" -Clink-arg=-Tdefmt.x --cfg armv8m --cfg armv8m_eabihf -Clink-arg=--nmagic -Clink-arg=--no-eh-frame-hdr -Clink-arg=-Tlinkme.x -Clink-arg=-Tlink.x -Clink-arg=-Teheap.x -Clink-arg=-Tdevice.x -Clink-arg=-Tisr_stack.x --cfg context=\"cortex-m\" --cfg context=\"cortex-m33f\"" CARGO_TARGET_DIR=../../build/bin/st-nucleo-wba55/cargo CONFIG_EXECUTOR_STACKSIZE=8192 CONFIG_ISR_STACKSIZE=2048 CONFIG_SWI=USART2 DEFMT_LOG=info,  cargo   run --profile=release --features=ariel-os/panic-printing,ariel-os/defmt-rtt,ariel-os/defmt,ariel-os/logging-over-debug-channel,ariel-os/single-core,ariel-os/executor-interrupt,ariel-os/semihosting --bin hello-world $@`: task command had non-zero exit code
```

Seems like `None` is configured as default, and it fails at `Sai1sel::PLL1_P => Some(pll1.p.expect("PLL1.P not configured")),`

So we are adding some config on `rcc.rs`

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

I don't know how can I test if I didn't break other boards, any help would be appreciated! :))

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
(ST NUCLEO-WBA55CG) A default clock configuration suited for that board is now provided.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
