### PR TITLE
fix(esp): pass xtensa sysroot to liboscore bindgen

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -922,6 +922,9 @@ modules:
           # and the second $ escapes for laze's internal ninja, resulting in
           # the shell to see just ${ESPUP_...
           - . $\\${ESPUP_EXPORT_FILE:-~/export-esp.sh}
+        CARGO_ENV:
+          # liboscore's bindgen needs the Xtensa sysroot to find relevant headers
+          - BINDGEN_EXTRA_CLANG_ARGS=--sysroot=$$(${CC} -print-sysroot)
 
   - name: riscv
     selects:


### PR DESCRIPTION
# Description

This PR fixes the [`liboscore` bindgen issue](https://github.com/ariel-os/ariel-os/issues/1564) for Xtensa targets by passing the cross-compiler sysroot via `BINDGEN_EXTRA_CLANG_ARGS`. 

## Testing

I've tested the examples on an actual Seeed Studio Xiao ESP32-S3 (see related PR: #2257)

## Issues/PRs References

Fixes #1564, fixes #1495

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!-- changelog:begin -->
- The `liboscore` bindgen now uses cross-compiler sysroot when building for Xtensa target. This fixes the build issue with CoAP examples on chips like ESP32-S3.
<!-- changelog:end -->

## Change Checklist


- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
