### PR TITLE
refactor(wifi): unify WiFi configuration and connection

### DIFF
--- a/src/ariel-os-embassy-common/Cargo.toml
+++ b/src/ariel-os-embassy-common/Cargo.toml
@@ -42,5 +42,7 @@ ble = ["dep:static_cell", "dep:trouble-host"]
 
 cellular-networking = []
 
+wifi = []
+
 [lints]
 workspace = true

--- a/src/ariel-os-embassy-common/src/lib.rs
+++ b/src/ariel-os-embassy-common/src/lib.rs
@@ -30,6 +30,9 @@ pub mod spi;
 #[cfg(feature = "uart")]
 pub mod uart;
 
+#[cfg(feature = "wifi")]
+pub mod wifi;
+
 pub mod reexports {
     //! Crate re-exports.
 

--- a/src/ariel-os-embassy-common/src/wifi.rs
+++ b/src/ariel-os-embassy-common/src/wifi.rs
@@ -1,10 +1,10 @@
-//! Common WiFi configuration for Ariel OS.
+//! Common Wi-Fi configuration for Ariel OS.
 //!
 //! This module contains the types and [`WIFI_CONFIG`] constant containing the build-time configuration.
 
 use ariel_os_utils::str_from_env;
 
-/// Current wifi configuration.
+/// Current Wi-Fi configuration.
 // TODO: Feature-gate this when AP mode is implemented.
 pub const WIFI_CONFIG: StationConfig = {
     const WIFI_NETWORK: &str = str_from_env!("CONFIG_WIFI_NETWORK", "Wi-Fi SSID (network name)");
@@ -15,10 +15,10 @@ pub const WIFI_CONFIG: StationConfig = {
     }
 };
 
-/// WiFi configuration in station mode.
+/// Wi-Fi configuration in station mode.
 pub struct StationConfig {
-    /// WiFi access point SSID.
+    /// Wi-Fi access point SSID.
     pub ssid: &'static str,
-    /// WiFi access point password.
+    /// Wi-Fi access point password.
     pub password: &'static str,
 }

--- a/src/ariel-os-embassy-common/src/wifi.rs
+++ b/src/ariel-os-embassy-common/src/wifi.rs
@@ -1,0 +1,24 @@
+//! Common WiFi configuration for Ariel OS.
+//!
+//! This module contains the types and [`WIFI_CONFIG`] constant containing the build-time configuration.
+
+use ariel_os_utils::str_from_env;
+
+/// Current wifi configuration.
+// TODO: Feature-gate this when AP mode is implemented.
+pub const WIFI_CONFIG: StationConfig = {
+    const WIFI_NETWORK: &str = str_from_env!("CONFIG_WIFI_NETWORK", "Wi-Fi SSID (network name)");
+    const WIFI_PASSWORD: &str = str_from_env!("CONFIG_WIFI_PASSWORD", "Wi-Fi password");
+    StationConfig {
+        ssid: WIFI_NETWORK,
+        password: WIFI_PASSWORD,
+    }
+};
+
+/// WiFi configuration in station mode.
+pub struct StationConfig {
+    /// WiFi access point SSID.
+    pub ssid: &'static str,
+    /// WiFi access point password.
+    pub password: &'static str,
+}

--- a/src/ariel-os-embassy/Cargo.toml
+++ b/src/ariel-os-embassy/Cargo.toml
@@ -140,7 +140,7 @@ cellular-networking = [
   "ariel-os-embassy-common/cellular-networking",
 ]
 
-wifi = []
+wifi = ["ariel-os-embassy-common/wifi"]
 wifi-cyw43 = ["ariel-os-hal/wifi-cyw43", "net", "wifi"]
 wifi-esp = ["ariel-os-hal/wifi-esp", "net", "wifi"]
 

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -348,7 +348,7 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
     ble::init_stack(ble_controller, spawner);
 
     #[cfg(feature = "wifi-esp")]
-    let device = hal::wifi::esp_wifi::init(&mut peripherals, spawner);
+    let (device, control) = hal::wifi::esp_wifi::init(&mut peripherals);
 
     #[cfg(feature = "tuntap")]
     let device = crate::hal::tuntap::create();
@@ -427,9 +427,21 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
         }
     }
 
+    #[cfg(feature = "wifi")]
+    let wifi_config = ariel_os_embassy_common::wifi::WIFI_CONFIG;
+
     #[cfg(feature = "wifi-cyw43")]
     {
-        hal::cyw43::join(control).await;
+        spawner
+            .spawn(hal::cyw43::join(control, wifi_config))
+            .expect("start wifi join task");
+    };
+
+    #[cfg(feature = "wifi-esp")]
+    {
+        spawner
+            .spawn(hal::wifi::esp_wifi::join(control, wifi_config))
+            .expect("start wifi join task");
     };
 
     // mark used

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -432,9 +432,8 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
 
     #[cfg(feature = "wifi-cyw43")]
     {
-        spawner
-            .spawn(hal::cyw43::join(control, wifi_config))
-            .expect("start wifi join task");
+        // Using an embassy task would cost us a lot of storage and RAM.
+        hal::cyw43::join(control, wifi_config).await;
     };
 
     #[cfg(feature = "wifi-esp")]

--- a/src/ariel-os-embassy/src/lib.rs
+++ b/src/ariel-os-embassy/src/lib.rs
@@ -10,6 +10,9 @@ pub use ariel_os_hal::hal;
 #[cfg(feature = "executor-thread")]
 use ariel_os_embassy_common::executor_thread;
 
+#[cfg(feature = "wifi")]
+use ariel_os_embassy_common::wifi::WIFI_CONFIG;
+
 #[cfg(feature = "debug-uart")]
 pub mod debug_uart;
 
@@ -427,20 +430,17 @@ async fn init_task(mut peripherals: hal::OptionalPeripherals) {
         }
     }
 
-    #[cfg(feature = "wifi")]
-    let wifi_config = ariel_os_embassy_common::wifi::WIFI_CONFIG;
-
     #[cfg(feature = "wifi-cyw43")]
     {
         // Using an embassy task would cost us a lot of storage and RAM.
-        hal::cyw43::join(control, wifi_config).await;
+        hal::cyw43::join(control, WIFI_CONFIG).await;
     };
 
     #[cfg(feature = "wifi-esp")]
     {
         spawner
-            .spawn(hal::wifi::esp_wifi::join(control, wifi_config))
-            .expect("start wifi join task");
+            .spawn(hal::wifi::esp_wifi::join(control, WIFI_CONFIG))
+            .unwrap();
     };
 
     // mark used

--- a/src/ariel-os-esp/Cargo.toml
+++ b/src/ariel-os-esp/Cargo.toml
@@ -150,7 +150,7 @@ ble-central = ["ble-esp"]
 ble-peripheral = ["ble-esp"]
 
 ## Enables Wi-Fi support.
-wifi = []
+wifi = ["ariel-os-embassy-common/wifi"]
 
 ## Enables built-in Wi-Fi hardware.
 wifi-esp = [

--- a/src/ariel-os-esp/src/wifi.rs
+++ b/src/ariel-os-esp/src/wifi.rs
@@ -1,9 +1,2 @@
-use ariel_os_utils::str_from_env;
-
 #[cfg(feature = "wifi-esp")]
 pub mod esp_wifi;
-
-// TODO: this should be factored out in ariel-os-embassy again
-pub(crate) const WIFI_NETWORK: &str =
-    str_from_env!("CONFIG_WIFI_NETWORK", "Wi-Fi SSID (network name)");
-pub(crate) const WIFI_PASSWORD: &str = str_from_env!("CONFIG_WIFI_PASSWORD", "Wi-Fi password");

--- a/src/ariel-os-esp/src/wifi/esp_wifi.rs
+++ b/src/ariel-os-esp/src/wifi/esp_wifi.rs
@@ -5,21 +5,23 @@ use esp_radio::wifi::{
     Config, ModeConfig, WifiController, WifiDevice, WifiEvent, WifiStationState, sta::StationConfig,
 };
 
+use ariel_os_embassy_common::wifi::StationConfig as ArielStationConfig;
+
 pub type NetworkDevice = WifiDevice<'static>;
 
-pub fn init(peripherals: &mut crate::OptionalPeripherals, spawner: Spawner) -> NetworkDevice {
+pub fn init(
+    peripherals: &mut crate::OptionalPeripherals,
+) -> (NetworkDevice, WifiController<'static>) {
     let config = Config::default();
     let wifi = peripherals.WIFI.take().unwrap();
 
     let (controller, interfaces) = esp_radio::wifi::new(wifi, config).unwrap();
 
-    spawner.spawn(connection(controller)).ok();
-
-    interfaces.station
+    (interfaces.station, controller)
 }
 
 #[embassy_executor::task]
-async fn connection(mut controller: WifiController<'static>) {
+pub async fn join(mut controller: WifiController<'static>, config: ArielStationConfig) {
     debug!("start connection task");
 
     #[cfg(not(feature = "defmt"))]
@@ -40,8 +42,8 @@ async fn connection(mut controller: WifiController<'static>) {
             debug!("Configuring Wi-Fi");
             let client_config = ModeConfig::Station(
                 StationConfig::default()
-                    .with_ssid(crate::wifi::WIFI_NETWORK.try_into().unwrap())
-                    .with_password(crate::wifi::WIFI_PASSWORD.try_into().unwrap()),
+                    .with_ssid(config.ssid.try_into().unwrap())
+                    .with_password(config.password.try_into().unwrap()),
             );
             controller.set_config(&client_config).unwrap();
             debug!("Starting Wi-Fi");

--- a/src/ariel-os-rp/Cargo.toml
+++ b/src/ariel-os-rp/Cargo.toml
@@ -98,7 +98,7 @@ ble-central = ["ble-cyw43"]
 defmt = ["dep:defmt", "cyw43?/defmt", "embassy-rp/defmt"]
 
 ## Enables Wi-Fi support.
-wifi = []
+wifi = ["ariel-os-embassy-common/wifi"]
 
 ## Enables support for the CYW43 Wi-Fi chip.
 wifi-cyw43 = ["_cyw43", "cyw43-firmware?/wifi", "wifi"]

--- a/src/ariel-os-rp/src/cyw43.rs
+++ b/src/ariel-os-rp/src/cyw43.rs
@@ -15,6 +15,9 @@ use static_cell::StaticCell;
 
 #[cfg(feature = "ble-cyw43")]
 use bt_hci::controller::ExternalController;
+
+#[cfg(feature = "wifi")]
+use ariel_os_embassy_common::wifi::StationConfig;
 #[cfg(feature = "wifi")]
 use cyw43::JoinOptions;
 
@@ -23,15 +26,13 @@ pub type NetworkDevice = cyw43::NetDriver<'static>;
 static STATE: StaticCell<cyw43::State> = StaticCell::new();
 
 #[cfg(feature = "wifi")]
-pub async fn join(mut control: cyw43::Control<'static>) {
+#[embassy_executor::task]
+pub async fn join(mut control: cyw43::Control<'static>, config: StationConfig) {
     use ariel_os_log::info;
     loop {
         //control.join_open(WIFI_NETWORK).await;
         match control
-            .join(
-                crate::wifi::WIFI_NETWORK,
-                JoinOptions::new(crate::wifi::WIFI_PASSWORD.as_bytes()),
-            )
+            .join(config.ssid, JoinOptions::new(config.password.as_bytes()))
             .await
         {
             Ok(_) => {

--- a/src/ariel-os-rp/src/cyw43.rs
+++ b/src/ariel-os-rp/src/cyw43.rs
@@ -26,7 +26,6 @@ pub type NetworkDevice = cyw43::NetDriver<'static>;
 static STATE: StaticCell<cyw43::State> = StaticCell::new();
 
 #[cfg(feature = "wifi")]
-#[embassy_executor::task]
 pub async fn join(mut control: cyw43::Control<'static>, config: StationConfig) {
     use ariel_os_log::info;
     loop {

--- a/src/ariel-os-rp/src/lib.rs
+++ b/src/ariel-os-rp/src/lib.rs
@@ -13,9 +13,6 @@ pub mod peripheral {
 #[cfg(context = "rp235xa")]
 mod picotool;
 
-#[cfg(feature = "wifi")]
-mod wifi;
-
 #[cfg(feature = "ble")]
 #[doc(hidden)]
 pub mod ble;

--- a/src/ariel-os-rp/src/wifi.rs
+++ b/src/ariel-os-rp/src/wifi.rs
@@ -1,6 +1,0 @@
-use ariel_os_utils::str_from_env;
-
-// TODO: this should be factored out in ariel-os-embassy again
-pub(crate) const WIFI_NETWORK: &str =
-    str_from_env!("CONFIG_WIFI_NETWORK", "Wi-Fi SSID (network name)");
-pub(crate) const WIFI_PASSWORD: &str = str_from_env!("CONFIG_WIFI_PASSWORD", "Wi-Fi password");


### PR DESCRIPTION
# Description

This refactors the WiFi configuration and join mechanic to be unified between ESP and RP.
This work is the first step towards having WiFi AP in Ariel. 

## Testing

```
laze -C examples/tcp-client/ build -b espressif-esp32-s3-devkitc-1 run
laze -C examples/tcp-client/ build -b rpi-pico-w run
```


## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
