### PR TITLE
fix(threads): reduce overhead of multi-core scheduling with core-affinities

### DIFF
--- a/src/ariel-os-runqueue/src/lib.rs
+++ b/src/ariel-os-runqueue/src/lib.rs
@@ -128,33 +128,6 @@ mod tests {
     }
 
     #[test]
-    fn iter() {
-        let mut runqueue: RunQueue<8, 32> = RunQueue::new();
-
-        runqueue.add(ThreadId::new(0), RunqueueId::new(0));
-        runqueue.add(ThreadId::new(1), RunqueueId::new(2));
-        runqueue.add(ThreadId::new(2), RunqueueId::new(2));
-        runqueue.add(ThreadId::new(3), RunqueueId::new(3));
-
-        let (head, rq) = runqueue.get_next_with_rq().unwrap();
-        assert_eq!(head, ThreadId::new(3));
-        assert_eq!(rq, RunqueueId::new(3));
-        let mut iter = runqueue.iter_from(head, rq);
-
-        assert_eq!(iter.next(), Some(ThreadId::new(1)));
-        assert_eq!(iter.next(), Some(ThreadId::new(2)));
-        assert_eq!(iter.next(), Some(ThreadId::new(0)));
-
-        assert!(iter.next().is_none());
-        assert!(iter.next().is_none());
-
-        let mut iter2 = runqueue.iter_from(ThreadId::new(1), RunqueueId::new(2));
-        assert_eq!(iter2.next(), Some(ThreadId::new(2)));
-        assert_eq!(iter2.next(), Some(ThreadId::new(0)));
-        assert!(iter2.next().is_none());
-    }
-
-    #[test]
     fn filter() {
         let mut runqueue: RunQueue<8, 32> = RunQueue::new();
 
@@ -163,23 +136,26 @@ mod tests {
         runqueue.add(ThreadId::new(2), RunqueueId::new(2));
         runqueue.add(ThreadId::new(3), RunqueueId::new(3));
 
-        assert_eq!(runqueue.get_next_filter(|_| true), Some(ThreadId::new(3)));
+        assert_eq!(
+            runqueue.get_next_filter(|_| true),
+            Some((ThreadId::new(3), ThreadId::new(3), RunqueueId::new(3)))
+        );
         assert_eq!(runqueue.get_next_filter(|_| false), None);
         assert_eq!(
             runqueue.get_next_filter(|t| *t == ThreadId::new(0)),
-            Some(ThreadId::new(0))
+            Some((ThreadId::new(0), ThreadId::new(0), RunqueueId::new(0)))
         );
         assert_eq!(
             runqueue.get_next_filter(|t| *t != ThreadId::new(0)),
-            Some(ThreadId::new(3))
+            Some((ThreadId::new(3), ThreadId::new(3), RunqueueId::new(3)))
         );
         assert_eq!(
             runqueue.get_next_filter(|t| usize::from(*t) % 2 == 0),
-            Some(ThreadId::new(2))
+            Some((ThreadId::new(2), ThreadId::new(1), RunqueueId::new(2)))
         );
         assert_eq!(
             runqueue.get_next_filter(|t| usize::from(*t) < 2),
-            Some(ThreadId::new(1))
+            Some((ThreadId::new(1), ThreadId::new(2), RunqueueId::new(2)))
         );
     }
 }

--- a/src/ariel-os-runqueue/src/runqueue.rs
+++ b/src/ariel-os-runqueue/src/runqueue.rs
@@ -115,6 +115,16 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
         }
     }
 
+    /// Removes thread with tid `n`.
+    ///
+    /// The function is an optimized version of [`del`] with O(1) for when
+    /// the thread's predecessor in the runqueue and its runqueue ID is known.
+    pub fn del_opt(&mut self, n: ThreadId, prev: ThreadId, rq: RunqueueId) {
+        if self.queues.del_opt(n.0, prev.0, rq.0) {
+            self.bitcache &= !(1 << rq.0);
+        }
+    }
+
     /// Returns the tid that should run next.
     ///
     /// Returns the next runnable thread of
@@ -127,26 +137,51 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
     /// Returns the tid that should run next and the runqueue it is in.
     #[must_use]
     pub fn get_next_with_rq(&self) -> Option<(ThreadId, RunqueueId)> {
-        let rq_ffs = ffs(self.bitcache);
-        if rq_ffs == 0 {
-            return None;
-        }
-        let rq = rq_ffs as u8 - 1;
+        let rq = self.get_next_rq()?.0;
         self.queues
             .peek_head(rq)
             .map(|id| (ThreadId::new(id), RunqueueId::new(rq)))
     }
 
     /// Returns the next thread from the runqueue that fulfills the predicate.
+    ///
+    /// Returns the next thread, it's predecessor in the same runqueue (for optimized
+    /// deletion), and its runqueue id.
     pub fn get_next_filter<F: FnMut(&ThreadId) -> bool>(
         &self,
         mut predicate: F,
-    ) -> Option<ThreadId> {
-        let (next, prio) = self.get_next_with_rq()?;
-        if predicate(&next) {
-            return Some(next);
+    ) -> Option<(ThreadId, ThreadId, RunqueueId)> {
+        // Bitcache of the queues that we need to iterate over.
+        let mut bitcache = self.bitcache;
+        let mut rq = self.get_next_rq()?.0;
+        let mut rq_head = self.queues.peek_head(rq)?;
+        let mut next = rq_head;
+        let mut prev = self.queues.peek_tail(rq)?;
+
+        loop {
+            if predicate(&ThreadId(next)) {
+                return Some((ThreadId(next), ThreadId(prev), RunqueueId(rq)));
+            }
+
+            prev = next;
+            next = self.queues.peek_next(prev);
+
+            // Check if we are done iteration over the current runaueue.
+            if next == rq_head {
+                // Clear runqueue from bitcache.
+                bitcache &= !(1 << rq);
+
+                // Get head from remaining highest priority runqueue.
+                if bitcache == 0 {
+                    return None;
+                }
+                rq = ffs(bitcache) as u8 - 1;
+
+                prev = self.queues.peek_tail(rq)?;
+                rq_head = self.queues.peek_next(prev);
+                next = rq_head;
+            }
         }
-        self.iter_from(next, prio).find(predicate)
     }
 
     /// Pop the thread that should run next.
@@ -154,11 +189,7 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
     /// Pops the next runnable thread of
     /// the runqueue with the highest index.
     pub fn pop_next(&mut self) -> Option<ThreadId> {
-        let rq_ffs = ffs(self.bitcache);
-        if rq_ffs == 0 {
-            return None;
-        }
-        let rq = (rq_ffs - 1) as u8;
+        let rq = self.get_next_rq()?.0;
         let head = self.queues.pop_head(rq).map(ThreadId::new);
         if self.queues.is_empty(rq) {
             self.bitcache &= !(1 << rq);
@@ -183,67 +214,19 @@ impl<const N_QUEUES: usize, const N_THREADS: usize> RunQueue<{ N_QUEUES }, { N_T
         self.queues.is_empty(rq.0)
     }
 
-    /// Returns an iterator over the [`RunQueue`], starting after thread `start` in runqueue `rq`.
-    ///
-    /// The `start` is not included in the iterator.
-    #[must_use]
-    pub fn iter_from(
-        &self,
-        start: ThreadId,
-        rq: RunqueueId,
-    ) -> RunQueueIter<'_, N_QUEUES, N_THREADS> {
-        RunQueueIter {
-            prev: start.0,
-            rq_head: self.queues.peek_head(rq.0),
-            // Clear higher priority runqueues.
-            bitcache: self.bitcache % (1 << (rq.0 + 1)),
-            queues: &self.queues,
+    fn get_next_rq(&self) -> Option<RunqueueId> {
+        let rq_ffs = ffs(self.bitcache);
+        if rq_ffs == 0 {
+            return None;
         }
+        let rq = (rq_ffs - 1) as u8;
+        Some(RunqueueId(rq))
     }
 }
 
 #[inline]
 fn ffs(val: usize) -> u32 {
     USIZE_BITS as u32 - val.leading_zeros()
-}
-
-/// Iterator over threads in a [`RunQueue`].
-///
-/// It starts from the highest priority queue and continues switching to lower
-/// priority queues after circling through a queue once, until all queues
-/// that are included in this iterator have been iterated.
-pub struct RunQueueIter<'a, const N_QUEUES: usize, const N_THREADS: usize> {
-    queues: &'a clist::CList<N_QUEUES, N_THREADS>,
-    // Predecessor in the circular runqueue list.
-    prev: u8,
-    // Head of the currently iterated runqueue.
-    rq_head: Option<u8>,
-    // Bitcache with the remaining queues that have to be iterated.
-    bitcache: usize,
-}
-
-impl<const N_QUEUES: usize, const N_THREADS: usize> Iterator
-    for RunQueueIter<'_, { N_QUEUES }, { N_THREADS }>
-{
-    type Item = ThreadId;
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut next = self.queues.peek_next(self.prev);
-        if next == self.rq_head? {
-            // Circled through whole queue, so switch to next one.
-            let rq = ffs(self.bitcache) as u8 - 1;
-            // Clear current runqueue from bitcache.
-            self.bitcache &= !(1 << rq);
-            // Get head from remaining highest priority runqueue.
-            self.rq_head = if self.bitcache > 0 {
-                self.queues.peek_head(ffs(self.bitcache) as u8 - 1)
-            } else {
-                None
-            };
-            next = self.rq_head?;
-        }
-        self.prev = next;
-        Some(ThreadId(next))
-    }
 }
 
 mod clist {
@@ -327,9 +310,33 @@ mod clist {
                     self.tail[rq] = prev as u8;
                 }
             }
+            // Update link from the previous thread.
             self.next_idxs[prev] = self.next_idxs[n as usize];
             self.next_idxs[n as usize] = Self::sentinel();
             empty_runqueue
+        }
+
+        /// Optimized variant of [`del`] if the runqueue and previous thread in runqueue
+        /// is known.
+        pub fn del_opt(&mut self, n: u8, prev_in_rq: u8, rq: u8) -> bool {
+            // Thread bytes itself.
+            let is_only_in_rq = prev_in_rq == n;
+
+            if is_only_in_rq {
+                self.tail[rq as usize] = Self::sentinel();
+            } else {
+                // Update link from the previous thread.
+                self.next_idxs[prev_in_rq as usize] = self.next_idxs[n as usize];
+
+                // Update tail.
+                if self.tail[rq as usize] == n {
+                    self.tail[rq as usize] = prev_in_rq;
+                }
+            }
+
+            self.next_idxs[n as usize] = Self::sentinel();
+
+            is_only_in_rq
         }
 
         pub fn pop_head(&mut self, rq: u8) -> Option<u8> {
@@ -353,10 +360,15 @@ mod clist {
 
         #[inline]
         pub fn peek_head(&self, rq: u8) -> Option<u8> {
+            self.peek_tail(rq).map(|tail| self.next_idxs[tail as usize])
+        }
+
+        #[inline]
+        pub fn peek_tail(&self, rq: u8) -> Option<u8> {
             if self.is_empty(rq) {
                 None
             } else {
-                Some(self.next_idxs[self.tail[rq as usize] as usize])
+                Some(self.tail[rq as usize])
             }
         }
 

--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -458,13 +458,10 @@ impl Scheduler {
         // On multi-core with core-affinities, get next thread with matching affinity.
         #[cfg(all(feature = "multi-core", feature = "core-affinity"))]
         {
-            // TODO: this would benefit from a `del_one_with_filter` to avoid
-            // iterating twice.
-            let next = self
+            let (next, prev, rq) = self
                 .runqueue
                 .get_next_filter(|&t| self.is_affine_to_curr_core(t))?;
-            // Delete thread from runqueue to match the `pop_next`.
-            self.runqueue.del(next);
+            self.runqueue.del_opt(next, prev, rq);
             Some(next)
         }
     }

--- a/src/ariel-os-threads/src/lib.rs
+++ b/src/ariel-os-threads/src/lib.rs
@@ -767,14 +767,24 @@ pub fn yield_same() {
         if !scheduler.runqueue.is_empty(prio) {
             schedule();
 
-            // Check if the yielding thread can continue their execution on another
-            // core that currently runs a lower priority thread.
-            // This is only necessary when core-affinities are enabled, because only
-            // then it is possible that a lower prio thread runs while a higher prio
-            // runqueue isn't empty.
+            // Check edge case when core-affinities are enabled.
+            // With core-affinities, it might be that we are yielding to a same-prio
+            // thread that is pinned to our core. Due to this pinning, it is possible that
+            // another, lower prio thread is running on the second core.
+            // If that's the case, we should preempt the lower-prio thread.
             #[cfg(feature = "core-affinity")]
             if _affinity == CoreAffinity::no_affinity() {
-                scheduler.schedule_if_higher_prio(_tid, prio);
+                let pid = scheduler
+                    .runqueue
+                    .get_next()
+                    .expect("Runqueue isn't empty.");
+                let thread = scheduler.get_unchecked(pid);
+
+                // Check if the next thread is pinned to our core.
+                if thread.core_affinity == CoreAffinity::one(core_id()) {
+                    // Check if we can run on the second core.
+                    scheduler.schedule_if_higher_prio(_tid, prio);
+                }
             }
         }
     });


### PR DESCRIPTION
# Description

Enabling the `core-affinity` feature for multi-core is currently quite expensive. 
This is due to two parts;
1. The selection of the next runnable thread is more complex
2. The `yield_now` function needs to check for more edge cases

## Regarding 1.

Instead of just popping[^1] the head of the runqueue, with core-affinities we first need to iterate over the runqueue to find the first thread with matching core affinity, and then delete the thread from the runqueue [^2]. 
Deleting a thread from the runqueue is quite expensive because we need to again find the thread's position in the runqueue to update the links from it's predecessor and potentially also the runqueue tail.  
This PR optimizes the deletion process by using the already present info from the first iteration for deleting with `O(1)` instead of `O(n)`.

## Regarding 2.

With core affinities, we have the unique case that it is possible that a lower priority thread is running, even though a higher prio thread is waiting in the runqueue. This is because the higher prio thread might be pinned to another core. 
When a thread yields, we therefore not only need to check if there is a another thread waiting, but also if the yielding thread can migrate to another core.
The PR optimizes this case a bit. We only check if a thread can migrate (the check is quite expensive) if the next waiting thread is actually pinned.

[^1]: the currently running thread is not in the runqueue on multicore
[^2]: This needs to happen in two steps because we otherwise run into conflicting mutable/immutable accesses.

## Testing

Benchmarked with the `bench_sched_yield` benchmark with 3 and 4 threads. Tested 4 cases:
1. `core-affinity` feature disabled
2. `core-affinity` feature enabled but not used
4. `core-affinity` feature enabled and the benchmark thread is pinned to `Core 0`
5. `core-affinity` feature enabled and the benchmark thread is pinned to `Core 1`

|Test | disabled | enabled | Pinned on Core 0 | Pinned on Core 1
|- | -| - | - | -
main (t=3) | 1397 | 2998 | 3585 | 3583 
this PR (t=3) |1397 | 1905 | 2716 | 2715
main (t=4) | 1845  | 4028 | 3773 | 3770 
this PR (t=4) | 1845 | 2537 |  2447 | 2699 

The numbers are still not ideal, but at least better. Also, I noticed that **2.** (handling the edge-case when yielding) is more expensive that **1.**. I'd assume that this function is used rather rarely, so generally the overhead of the `core-affinity` feature is acceptable once this PR lands. 

## Issues/PRs References

Core-affinities are needed for a quick-fix to re-enable multi-core for the esp32-s3, #1716.

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
Improve scheduler performance under multi-core with the `core-affinity` feature enabled.

<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [ ] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [ ] I have followed the [Coding Conventions][coding-conventions].
- [ ] I have tested and performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
