### PR TITLE
docs(log): make transport module visible

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -70,12 +70,12 @@ jobs:
               -p coapcore \
               --features "
                   ariel-os-sensors/max-sample-min-count-12,
+                  ariel-os-log/custom-transport-driver,
                   bench,
                   ble,
                   coap,
                   core-affinity,
                   csprng,
-                  defmt,
                   dns,
                   executor-thread,
                   external-interrupts,

--- a/src/ariel-os-log/Cargo.toml
+++ b/src/ariel-os-log/Cargo.toml
@@ -18,7 +18,11 @@ logging-transport.xor = { features = [
 
 # Temporary, refuse to have defmt as a frontend when we use a pluggable transport.
 # Remove this when a defmt logger is implemented for pluggable transports.
-transport-defmt-conflict.xor = { features = ["defmt", "_pluggable-transport"] }
+transport-defmt-conflict.xor = { features = [
+  "defmt",
+  "internal-transport-driver",
+  "custom-transport-driver",
+] }
 
 [package.metadata.feature-groups.features]
 defmt-rtt.requires = { features = ["logging-over-debug-channel"] }
@@ -64,9 +68,6 @@ log = ["dep:ariel-os-utils", "dep:const-str", "dep:critical-section", "dep:log"]
 # Enables the `esp-println` crate.
 esp-println = ["dep:esp-println"]
 
-# Pluggable transport, has to be enabled by other features like "internal-transport-driver".
-_pluggable-transport = ["dep:embassy-sync"]
-
 # Logging transports.
 debug-uart = ["dep:embassy-sync", "logging-over-uart"]
 # `defmt-rtt` uses the debug channel as the logging transport, so it has to go
@@ -77,9 +78,9 @@ logging-over-debug-channel = ["dep:ariel-os-debug"]
 logging-over-uart = ["esp-println?/uart"]
 logging-over-usb = ["esp-println?/jtag-serial"]
 # Connect log transports that are implemented inside Ariel OS' repo.
-internal-transport-driver = ["_pluggable-transport"]
+internal-transport-driver = ["dep:embassy-sync"]
 # Connect log transports implemented in an application.
-custom-transport-driver = ["_pluggable-transport"]
+custom-transport-driver = ["dep:embassy-sync"]
 
 std = []
 

--- a/src/ariel-os-log/src/lib.rs
+++ b/src/ariel-os-log/src/lib.rs
@@ -22,7 +22,10 @@
 mod _featurecomb {}
 
 #[doc(hidden)]
-#[cfg(feature = "_pluggable-transport")]
+#[cfg(feature = "internal-transport-driver")]
+pub mod transport;
+
+#[cfg(feature = "custom-transport-driver")]
 pub mod transport;
 
 #[allow(unused, reason = "conditional compilation")]

--- a/src/ariel-os-log/src/lib.rs
+++ b/src/ariel-os-log/src/lib.rs
@@ -99,7 +99,7 @@ pub mod log {
         feature = "std" => {
             pub use std::println;
         }
-        feature = "custom-transport" => {
+        any(feature = "internal-transport-driver", feature = "custom-transport-driver") => {
             pub use crate::transport_println as println;
         }
         not(context = "ariel-os") => {

--- a/src/ariel-os-log/src/transport.rs
+++ b/src/ariel-os-log/src/transport.rs
@@ -69,6 +69,6 @@ pub fn _print(args: core::fmt::Arguments<'_>) {
 macro_rules! transport_println {
     ($($arg:tt)*) => {{
         #[expect(clippy::used_underscore_items, reason = "consistency with std::println")]
-        $crate::custom_transport::_print(format_args!("{}\n", format_args!($($arg)*)));
+        $crate::transport::_print(format_args!("{}\n", format_args!($($arg)*)));
     }};
 }

--- a/src/ariel-os-log/src/transport.rs
+++ b/src/ariel-os-log/src/transport.rs
@@ -1,15 +1,10 @@
-//! Connector to logging transports.
-//!
-//! ## For implementors
-//!
-//! Log transport implementations outside of this crate have to register their `write_bytes` and `flush`
-//! functions using [`register_transport_functions`].
-//!
-//! Those functions should not wait for interrupts when called as they may be ran in a
-//! critical section context. The execution of those functions should not trigger calls to the
-//! logging facade as that would create an infinite logging cycle (or a crash in the case of defmt).
+//! This module provides facilities for registering a custom logging transport from within
+//! an application.
 
-// Custom logging transport implementations end up depending on the HAL, that then depends on
+// Internal logging transport implementations use the same [`register_custom_transport`] function
+// but uses the `internal-transport-driver` feature to access this module.
+//
+// Logging transport implementations end up depending on the HAL, that then depends on
 // `ariel-os-log`, creating a circular dependency. Connecting log transports like this helps break
 // the cycle.
 
@@ -18,18 +13,19 @@ use embassy_sync::once_lock::OnceLock;
 static TRANSPORT_WRITE_BYTES_FN: OnceLock<fn(&[u8])> = OnceLock::new();
 static TRANSPORT_FLUSH_FN: OnceLock<fn()> = OnceLock::new();
 
-/// Register custom transport functions.
+/// Registers a custom transport.
+///
+/// Registering a custom transport requires providing two functions:
 ///
 /// - `write_bytes_fn` is used to write bytes to the transport. Depending on the logging facade it
 ///   may be UTF-8 encoded text or raw binary data.
-/// - `flush_fn` is used to flush the data in the transport. Currently it is only used when defmt is
-///   the logging facade.
+/// - `flush_fn` is used to flush the data in the transport.
 ///
-/// ## Critical section
+/// ## Important note
 ///
 /// `write_bytes_fn` and `flush_fn` may be executed inside a critical section, disabling interrupts.
-/// They should not wait for interrupts and should not trigger calls to the logging facade.
-pub fn register_transport_functions(write_bytes_fn: fn(&[u8]), flush_fn: fn()) {
+/// They should therefore not wait for interrupts and should not trigger calls to the logging facade.
+pub fn register_custom_transport(write_bytes_fn: fn(&[u8]), flush_fn: fn()) {
     let _ = TRANSPORT_WRITE_BYTES_FN.init(write_bytes_fn);
     let _ = TRANSPORT_FLUSH_FN.init(flush_fn);
 }


### PR DESCRIPTION
# Description

This makes the transport documentation visible from the rendered documentation.

## Testing

Look at the published documentation and check if the `transport` module is shown in `ariel-os-log` 

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
Skipping changelog, the real feature will be added with #2250.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
