### PR TITLE
fix: `missing_lints_inheritance` and subsequent clippy lints

### DIFF
--- a/src/ariel-os-buildutils/Cargo.toml
+++ b/src/ariel-os-buildutils/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+
+[lints]
+workspace = true

--- a/src/ariel-os-buildutils/src/lib.rs
+++ b/src/ariel-os-buildutils/src/lib.rs
@@ -1,12 +1,14 @@
 //! Ariel OS build-time tools.
 
 /// Returns the first of the given contexts that is in the current `cfg` contexts.
+#[must_use]
 pub fn context_any(contexts: &[&'static str]) -> Option<&'static str> {
     // Contexts cannot include commas.
     contexts.iter().find(|c| context(c)).copied()
 }
 
 /// Returns whether the given context is in the current 'cfg' contexts.
+#[must_use]
 pub fn context(context: &'static str) -> bool {
     let Ok(context_var) = std::env::var("CARGO_CFG_CONTEXT") else {
         return false;

--- a/src/ariel-os-stm32-mapping/Cargo.toml
+++ b/src/ariel-os-stm32-mapping/Cargo.toml
@@ -6,6 +6,8 @@ rust-version.workspace = true
 repository.workspace = true
 license.workspace = true
 
+[lints]
+
 # BEGIN AUTO-GENERATED STM32 MAPPING
 [target.'cfg(context = "stm32c011d6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c011d6"] }

--- a/src/ariel-os-stm32-mapping/Cargo.toml
+++ b/src/ariel-os-stm32-mapping/Cargo.toml
@@ -6,8 +6,6 @@ rust-version.workspace = true
 repository.workspace = true
 license.workspace = true
 
-[lints]
-
 # BEGIN AUTO-GENERATED STM32 MAPPING
 [target.'cfg(context = "stm32c011d6")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32c011d6"] }
@@ -4263,3 +4261,5 @@ embassy-stm32 = { workspace = true, features = ["stm32wle5jb"] }
 [target.'cfg(context = "stm32wle5jc")'.dependencies]
 embassy-stm32 = { workspace = true, features = ["stm32wle5jc"] }
 # END AUTO-GENERATED STM32 MAPPING
+
+[lints]

--- a/src/ariel-os-stm32/Cargo.toml
+++ b/src/ariel-os-stm32/Cargo.toml
@@ -28,6 +28,11 @@ paste = { workspace = true }
 portable-atomic = { workspace = true }
 static_cell = { workspace = true }
 
+[build-dependencies]
+stm32-metapac = { version = "18.0.0", default-features = false, features = [
+  "metadata",
+] }
+
 [target.'cfg(use_stm32_single_bank)'.dependencies]
 embassy-stm32 = { workspace = true, default-features = false, features = [
   "single-bank",
@@ -36,11 +41,6 @@ embassy-stm32 = { workspace = true, default-features = false, features = [
 [target.'cfg(use_stm32_dual_bank)'.dependencies]
 embassy-stm32 = { workspace = true, default-features = false, features = [
   "dual-bank",
-] }
-
-[build-dependencies]
-stm32-metapac = { version = "18.0.0", default-features = false, features = [
-  "metadata",
 ] }
 
 [features]

--- a/tests/threading-fpu/Cargo.toml
+++ b/tests/threading-fpu/Cargo.toml
@@ -7,3 +7,6 @@ publish = false
 [dependencies]
 ariel-os = { path = "../../src/ariel-os" }
 ariel-os-boards = { path = "../../src/ariel-os-boards" }
+
+[lints]
+workspace = true


### PR DESCRIPTION
# Description

Fixes most of the warning coming from [`missing_lints_inheritance`](https://doc.rust-lang.org/cargo/reference/lints.html#missing_lints_inheritance)
<!-- A summary of your changes and why you made them. -->

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->
This does not fix the warning on ariel-os-boards which is auto-generated so to properly silence this warning we would probably need to do that in sbd-gen.
## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
