### PR TITLE
docs(usb): correct how to enable USB device support

### DIFF
--- a/book/src/usb.md
+++ b/book/src/usb.md
@@ -32,7 +32,7 @@ The others may still be integrated by Ariel OS to implement specific functional
 ## Software Integration
 
 Ariel OS provides support for the USB peripheral role through [`embassy-usb`][embassy-usb-docsrs], which provides a consistent API across the supported hardware.
-It can be enabled with the `usb` Cargo feature.
+It can be enabled with the `usb` [laze module][laze-modules-book], which is only made available when the board features a USB device port.
 
 An instance of [`embassy_usb::Builder`][ariel-os-usbbuilder-rustdoc] is created by Ariel OS, on which support for well-known USB device classes can be added using a dedicated [Ariel OS task hook][task-attr-docs]:
 
@@ -103,3 +103,4 @@ Otherwise, an appropriate clock configuration must be [provided in the applicati
 [external-crystal-oscillator]: ./clocks.md#external-clock-signals
 [clock-tree-configuration-book]: ./clocks.md#configuring-the-clock-tree
 [usb-2.0-spec]: https://www.usb.org/document-library/usb-20-specification
+[laze-modules-book]: ./build-system.md#laze-modules


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This clarifies how to properly enable USB device support, as #2150 mistakenly documented it as requiring the activation of the `usb` *Cargo feature* instead of the laze module of the same name. It also explains when the laze module is (not) available.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Example: Depends on #9876.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->
No need for an entry as the USB page was only added in #2150.

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
