### PR TITLE
refactor(ethernet): factor out how the MAC address is obtained

### DIFF
--- a/laze-project.yml
+++ b/laze-project.yml
@@ -1365,10 +1365,17 @@ modules:
     selects:
       - doc-only
 
+  - name: ethernet
+    help: private
+    selects:
+      # Needed for MAC address generation.
+      - hw/device-identity
+      - network
+
   - name: ethernet-stm32
     selects:
+      - ethernet
       - has_ethernet_stm32
-      - network
     provides_unique:
       - network_device
     env:
@@ -1384,8 +1391,8 @@ modules:
 
   - name: ethernet-wiznet-w5500
     selects:
+      - ethernet
       - has_ethernet_w5500
-      - network
     provides_unique:
       - network_device
       - wiznet_chip
@@ -1400,8 +1407,8 @@ modules:
 
   - name: ethernet-wiznet-w5100s
     selects:
+      - ethernet
       - has_ethernet_w5100s
-      - network
     provides_unique:
       - network_device
       - wiznet_chip
@@ -1416,8 +1423,8 @@ modules:
 
   - name: ethernet-wiznet-w6100
     selects:
+      - ethernet
       - has_ethernet_w6100
-      - network
     provides_unique:
       - network_device
       - wiznet_chip
@@ -1432,8 +1439,8 @@ modules:
 
   - name: ethernet-wiznet-w6300
     selects:
+      - ethernet
       - has_ethernet_w6300
-      - network
     provides_unique:
       - network_device
       - wiznet_chip

--- a/src/ariel-os-embassy-common/src/ethernet.rs
+++ b/src/ariel-os-embassy-common/src/ethernet.rs
@@ -1,0 +1,4 @@
+//! Provides HAL-agnostic items related to Ethernet.
+
+/// `if_index` to use to obtain a MAC address for the first Ethernet interface.
+pub const MAC_ADDRESS_DEVICE_ID_IF_INDEX: u32 = 0;

--- a/src/ariel-os-embassy-common/src/lib.rs
+++ b/src/ariel-os-embassy-common/src/lib.rs
@@ -5,6 +5,7 @@
 #![deny(missing_docs)]
 
 pub mod cell;
+pub mod ethernet;
 pub mod gpio;
 
 #[cfg(context = "cortex-m")]

--- a/src/ariel-os-embassy/src/ethernet.rs
+++ b/src/ariel-os-embassy/src/ethernet.rs
@@ -5,3 +5,24 @@ pub(crate) use crate::hal::ethernet::NetworkDevice;
 pub(crate) mod wiznet;
 #[cfg(feature = "ethernet-wiznet")]
 pub(crate) use wiznet::NetworkDevice;
+
+/// Returns a stable MAC address based on the device identity.
+///
+/// # Panics
+///
+/// Panics in case of transient issue when obtaining the device identity.
+/// This function only used when enforcing that an implementation of `ariel-os-identity` exists, so
+/// this will not unconditionally panic.
+// NOTE: Keep in sync with the implementation for the STM32 Ethernet MAC.
+// NOTE: This cannot be moved to `ariel-os-embassy-common` because a concrete implementation of
+// `DeviceId` is needed.
+#[allow(dead_code, reason = "conditional compilation")]
+fn get_mac_address() -> [u8; 6] {
+    use ariel_os_embassy_common::{
+        ethernet::MAC_ADDRESS_DEVICE_ID_IF_INDEX, identity::DeviceId as _,
+    };
+
+    let device_id =
+        crate::hal::identity::DeviceId::get().expect("the device identity can be obtained");
+    device_id.interface_eui48(MAC_ADDRESS_DEVICE_ID_IF_INDEX).0
+}

--- a/src/ariel-os-stm32/src/ethernet.rs
+++ b/src/ariel-os-stm32/src/ethernet.rs
@@ -3,8 +3,7 @@ use embassy_stm32::peripherals::ETH;
 use embassy_stm32::{bind_interrupts, eth};
 use static_cell::StaticCell;
 
-// Index of the builtin Ethernet MAC, used for generating the MAC address.
-const IF_INDEX: u32 = 0;
+use ariel_os_embassy_common::ethernet::MAC_ADDRESS_DEVICE_ID_IF_INDEX;
 
 bind_interrupts!(struct Irqs {
     ETH => eth::InterruptHandler;
@@ -36,12 +35,13 @@ pub fn device(peripherals: &mut crate::OptionalPeripherals) -> NetworkDevice {
 }
 
 /// Returns a stable MAC address based on the device identity.
+// NOTE: Keep in sync with the general implementation in `ariel-os-embassy`.
 fn get_mac_address() -> [u8; 6] {
-    use ariel_os_embassy_common::identity::DeviceId;
+    use ariel_os_embassy_common::identity::DeviceId as _;
 
     // NOTE(no-panic): infallible on STM32.
     match crate::identity::DeviceId::get() {
-        Ok(device_id) => device_id.interface_eui48(IF_INDEX).0,
+        Ok(device_id) => device_id.interface_eui48(MAC_ADDRESS_DEVICE_ID_IF_INDEX).0,
         Err(_) => unreachable!(),
     }
 }


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
Following https://github.com/ariel-os/ariel-os/pull/2237#discussion_r3969537565, this attempts to factor out as much as possible how the MAC address is obtained for the (first) Ethernet interface. When doing that, this introduces a (private) `ethernet` laze module that factors out the dependency on `hw/device-identity`, which is required to generate the MAC address.

The scope of this PR might change a bit if we find a way to factor this out a bit more.

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
-->
- Documenting the dependency of Ethernet on the device identity is done in #2242.

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
