### PR TITLE
docs(i2c-scanner): fix scanning on RP MCUs

### DIFF
--- a/examples/i2c-scanner/src/main.rs
+++ b/examples/i2c-scanner/src/main.rs
@@ -21,7 +21,8 @@ async fn i2c_scanner(peripherals: pins::Peripherals) {
     info!("Checking for I2C devices on the bus...");
 
     for addr in 1..=127 {
-        if i2c_bus.write(addr, &[]).await.is_ok() {
+        // The byte is unnecessary, but this otherwise always fails on RP.
+        if i2c_bus.read(addr, &mut [0]).await.is_ok() {
             info!("Found device at address 0x{:x}", addr);
         }
     }

--- a/examples/i2c-scanner/src/main.rs
+++ b/examples/i2c-scanner/src/main.rs
@@ -4,6 +4,7 @@
 mod pins;
 
 use ariel_os::{
+    debug::{ExitCode, exit},
     hal,
     i2c::controller::{Kilohertz, highest_freq_in},
     log::info,
@@ -28,4 +29,5 @@ async fn i2c_scanner(peripherals: pins::Peripherals) {
     }
 
     info!("Done checking. Have a great day!");
+    exit(ExitCode::SUCCESS);
 }


### PR DESCRIPTION
# Description

<!-- A summary of your changes and why you made them. -->
This fixes an issue with the `i2c-scanner`, which is unable to scan properly for I2C targets on RP MCUs (it always fails to find any targets).

## Testing

<!-- If relevant, explain what testing you have done and how a reviewer can validate your changes. -->
Tested the `i2c-scanner` example on the following:

- bbc-microbit-v2
- an RP2040 board with sensors
- an espressif-esp32-c6-devkitc-1 with an attached sensor
- st-steval-mkboxpro

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
The `i2c-scanner` now succeeds in scanning when used on an RP MCU.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
