### PR TITLE
feat(board): add board support for Winky esp32c6 variant 

### DIFF
--- a/boards/ariel-chips.yaml
+++ b/boards/ariel-chips.yaml
@@ -10,6 +10,7 @@ ariel:
     - esp32-wroom-32d
     - esp32-wroom-32u
     - esp32-c3-mini-1
+    - esp32-c6-mini-1-x4
     - esp32-c6-wroom-1
     - esp32-s3-wroom-1
     - esp32-s2-solo-2

--- a/boards/winky-esp32-c6.yaml
+++ b/boards/winky-esp32-c6.yaml
@@ -1,0 +1,24 @@
+version: 0.4.0
+targets:
+  winky-esp32-c6:
+    chip: esp32-c6-mini-1-x4
+    flags:
+      - has_usb_cdc_acm_port
+    buttons:
+      # B1
+      - pin: GPIO9
+        active: low
+    uarts:
+      - aliases:
+          - QWIIC_DEBUG
+        tx_pin: GPIO16
+        rx_pin: GPIO17
+        possible_peripherals: [UART0, UART1]
+        host_facing: true # Used to send debug info.
+
+      - aliases:
+          - TIC
+        tx_pin: GPIO15 # Not connected, this UART is only used for receiving.
+        rx_pin: GPIO4
+        possible_peripherals: [UART1, UART0] # UART1 preferred as UART0 is the default for logging.
+        host_facing: false

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -53,6 +53,7 @@
   - [Unihiker K10](./boards/unihiker-k10.md)
   - [Waveshare ESP32-S3-ETH](./boards/waveshare-esp32-s3-eth.md)
   - [Waveshare ESP32-S3-Matrix](./boards/waveshare-esp32-s3-matrix.md)
+  - [Winky ESP32-C6](./boards/winky-esp32-c6.md)
 - [Chips](./chips/index.md)
   - [ESP32-D0WD](./chips/esp32-d0wd.md)
   - [ESP32-C3](./chips/esp32c3.md)

--- a/book/src/boards/index.md
+++ b/book/src/boards/index.md
@@ -48,3 +48,4 @@
 - [Unihiker K10](./unihiker-k10.md)
 - [Waveshare ESP32-S3-ETH](./waveshare-esp32-s3-eth.md)
 - [Waveshare ESP32-S3-Matrix](./waveshare-esp32-s3-matrix.md)
+- [Winky ESP32-C6](./winky-esp32-c6.md)

--- a/book/src/boards/winky-esp32-c6.md
+++ b/book/src/boards/winky-esp32-c6.md
@@ -1,0 +1,69 @@
+# Winky ESP32-C6
+
+## References
+
+- [Manufacturer link](https://gricad-gitlab.univ-grenoble-alpes.fr/ferrarij/winky)
+
+## laze Builders
+
+For more information on laze builders, check out [this page](../build-system.md#laze-builders).
+
+### `winky-esp32-c6`
+
+- **Tier:** 2
+- **Chip:** [ESP32-C6Fx4](../chips/esp32c6fx4.md)
+- **Chip Ariel OS Name:** `esp32c6fx4`
+
+To target this laze builder, run the following command in the root of your Ariel OS app:
+
+```bash
+laze build -b winky-esp32-c6
+```
+
+#### Support Matrix
+
+|Functionality|Support Status|
+|---|:---:|
+|Debug Channel|<span title="supported">✅</span>|
+|Logging|<span title="supported">✅</span>|
+|GPIO|<span title="supported">✅</span>|
+|I2C Controller Mode|<span title="supported">✅</span>|
+|SPI Main Mode|<span title="supported">✅</span>|
+|UART|<span title="supported">✅</span>|
+|Ethernet|<span title="not available on this piece of hardware">–</span>|
+|User USB|<span title="not available on this piece of hardware">–</span>[^no-generic-usb-peripheral]|
+|Ethernet over USB|<span title="not available on this piece of hardware">–</span>|
+|Wi-Fi|<span title="supported">✅</span>|
+|Bluetooth Low Energy|<span title="supported">✅</span>|
+|Hardware Random Number Generator|<span title="supported">✅</span>|
+|Persistent Storage|<span title="available in hardware, but not currently supported by Ariel OS">❌</span>[^requires-partitioning-support]|
+
+<p>Legend:</p>
+
+<dl>
+  <div>
+    <dt>✅</dt><dd>supported</dd>
+  </div>
+  <div>
+    <dt>☑️</dt><dd>supported with some caveats</dd>
+  </div>
+  <div>
+    <dt>🚦</dt><dd>needs testing</dd>
+  </div>
+  <div>
+    <dt>❌</dt><dd>available in hardware, but not currently supported by Ariel OS</dd>
+  </div>
+  <div>
+    <dt>–</dt><dd>not available on this piece of hardware</dd>
+  </div>
+</dl>
+<style>
+dt, dd {
+  display: inline;
+}
+</style>
+
+
+  
+[^no-generic-usb-peripheral]: No generic USB peripheral.
+[^requires-partitioning-support]: Requires partitioning support.

--- a/book/src/chips/esp32c6fx4.md
+++ b/book/src/chips/esp32c6fx4.md
@@ -125,6 +125,28 @@ Boards using this chip.
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       </tr>
 	  </tbody>
+	<tbody class="odd">
+      <tr>
+	    <td rowspan="2"><a href="../boards/winky-esp32-c6.html">Winky ESP32-C6</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>winky-esp32-c6</code></td>
+		<td style="text-align: center;">2</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+      </tr>
+	  </tbody>
   </tbody>
 </table>
 </div>

--- a/book/src/support_matrix.html
+++ b/book/src/support_matrix.html
@@ -739,6 +739,28 @@
 	  </tbody>
 	<tbody class="odd">
       <tr>
+	    <td rowspan="2"><a href="boards/winky-esp32-c6.html">Winky ESP32-C6</a></td>
+	  </tr>
+	  <tr>
+	    <td><code>winky-esp32-c6</code></td>
+		<td style="text-align: center;">2</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="not available on this piece of hardware">–</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="supported">✅</td>
+		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
+      </tr>
+	  </tbody>
+	<tbody class="even">
+      <tr>
 	    <td rowspan="2"><a href="boards/adafruit-feather-nrf52840-sense.html">Adafruit Feather nRF52840 Sense</a></td>
 	  </tr>
 	  <tr>
@@ -759,7 +781,7 @@
 		  <td class="support-cell" title="supported">✅</td>
       </tr>
 	  </tbody>
-	<tbody class="even">
+	<tbody class="odd">
       <tr>
 	    <td rowspan="2"><a href="boards/bbc-micro-bit-v1.html">BBC micro:bit V1</a></td>
 	  </tr>
@@ -781,7 +803,7 @@
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       </tr>
 	  </tbody>
-	<tbody class="odd">
+	<tbody class="even">
       <tr>
 	    <td rowspan="2"><a href="boards/espressif-esp32-c3-devkit-rust-1.html">Espressif ESP32-C3-DevKit-RUST-1</a></td>
 	  </tr>
@@ -803,7 +825,7 @@
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       </tr>
 	  </tbody>
-	<tbody class="even">
+	<tbody class="odd">
       <tr>
 	    <td rowspan="2"><a href="boards/espressif-esp32-s2-devkitc-1.html">Espressif ESP32-S2-DevKitC-1</a></td>
 	  </tr>
@@ -825,7 +847,7 @@
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       </tr>
 	  </tbody>
-	<tbody class="odd">
+	<tbody class="even">
       <tr>
 	    <td rowspan="2"><a href="boards/heltec-wifi-lora-32-v3.html">Heltec WiFi LoRa 32 V3</a></td>
 	  </tr>
@@ -847,7 +869,7 @@
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       </tr>
 	  </tbody>
-	<tbody class="even">
+	<tbody class="odd">
       <tr>
 	    <td rowspan="2"><a href="boards/makerdiary-nrf52840-mdk-usb-dongle.html">makerdiary nRF52840 MDK USB Dongle</a></td>
 	  </tr>
@@ -869,7 +891,7 @@
 		  <td class="support-cell" title="supported">✅</td>
       </tr>
 	  </tbody>
-	<tbody class="odd">
+	<tbody class="even">
       <tr>
 	    <td rowspan="2"><a href="boards/seeed-studio-lora-e5-mini.html">Seeed Studio LoRa-E5 mini</a></td>
 	  </tr>
@@ -891,7 +913,7 @@
 		  <td class="support-cell" title="supported with some caveats">☑️</td>
       </tr>
 	  </tbody>
-	<tbody class="even">
+	<tbody class="odd">
       <tr>
 	    <td rowspan="2"><a href="boards/seeed-studio-xiao-esp32-s3.html">Seeed Studio XIAO ESP32-S3</a></td>
 	  </tr>
@@ -913,7 +935,7 @@
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       </tr>
 	  </tbody>
-	<tbody class="odd">
+	<tbody class="even">
       <tr>
 	    <td rowspan="2"><a href="boards/seeed-studio-xiao-nrf52840-plus.html">Seeed Studio XIAO NRF52840 Plus</a></td>
 	  </tr>
@@ -935,7 +957,7 @@
 		  <td class="support-cell" title="supported">✅</td>
       </tr>
 	  </tbody>
-	<tbody class="even">
+	<tbody class="odd">
       <tr>
 	    <td rowspan="2"><a href="boards/st-nucleo-f042k6.html">ST NUCLEO-F042K6</a></td>
 	  </tr>
@@ -957,7 +979,7 @@
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       </tr>
 	  </tbody>
-	<tbody class="odd">
+	<tbody class="even">
       <tr>
 	    <td rowspan="2"><a href="boards/st-nucleo-f411re.html">ST NUCLEO-F411RE</a></td>
 	  </tr>
@@ -979,7 +1001,7 @@
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       </tr>
 	  </tbody>
-	<tbody class="even">
+	<tbody class="odd">
       <tr>
 	    <td rowspan="2"><a href="boards/st-nucleo-g431rb.html">ST NUCLEO-G431RB</a></td>
 	  </tr>
@@ -1001,7 +1023,7 @@
 		  <td class="support-cell" title="supported">✅</td>
       </tr>
 	  </tbody>
-	<tbody class="odd">
+	<tbody class="even">
       <tr>
 	    <td rowspan="2"><a href="boards/st-nucleo-h753zi.html">ST NUCLEO-H753ZI</a></td>
 	  </tr>
@@ -1023,7 +1045,7 @@
 		  <td class="support-cell" title="supported with some caveats">☑️</td>
       </tr>
 	  </tbody>
-	<tbody class="even">
+	<tbody class="odd">
       <tr>
 	    <td rowspan="2"><a href="boards/st-nucleo-wba55cg.html">ST NUCLEO-WBA55CG</a></td>
 	  </tr>
@@ -1045,7 +1067,7 @@
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       </tr>
 	  </tbody>
-	<tbody class="odd">
+	<tbody class="even">
       <tr>
 	    <td rowspan="2"><a href="boards/st-nucleo-wba65ri.html">ST NUCLEO-WBA65RI</a></td>
 	  </tr>
@@ -1067,7 +1089,7 @@
 		  <td class="support-cell" title="supported with some caveats">☑️</td>
       </tr>
 	  </tbody>
-	<tbody class="even">
+	<tbody class="odd">
       <tr>
 	    <td rowspan="2"><a href="boards/waveshare-esp32-s3-eth.html">Waveshare ESP32-S3-ETH</a></td>
 	  </tr>
@@ -1089,7 +1111,7 @@
 		  <td class="support-cell" title="available in hardware, but not currently supported by Ariel OS">❌</td>
       </tr>
 	  </tbody>
-	<tbody class="odd">
+	<tbody class="even">
       <tr>
 	    <td rowspan="2"><a href="boards/waveshare-esp32-s3-matrix.html">Waveshare ESP32-S3-Matrix</a></td>
 	  </tr>

--- a/doc/support_matrix.yml
+++ b/doc/support_matrix.yml
@@ -1405,6 +1405,11 @@ builders:
     tier: "3"
     support:
 
+  winky-esp32-c6:
+    chip: esp32c6fx4
+    tier: "2"
+    support:
+
 # Boards are the logical entity that represents the hardware, which can have
 # one or multiple laze builders.
 boards:
@@ -1645,3 +1650,8 @@ boards:
     url: https://web.archive.org/web/20251121141909/https://www.waveshare.com/wiki/ESP32-S3-Matrix
     builders:
       - waveshare-esp32-s3-matrix
+
+  - name: Winky ESP32-C6
+    url: https://gricad-gitlab.univ-grenoble-alpes.fr/ferrarij/winky
+    builders:
+      - winky-esp32-c6

--- a/laze-project.yml
+++ b/laze-project.yml
@@ -435,6 +435,10 @@ contexts:
   - name: esp32c6fx4
     parent: esp32c6
 
+  - name: esp32-c6-mini-1-x4
+    help: 4MB flash version of the esp32-c6-mini-1, includes esp32-c6-mini-1-n4 and esp32-c6-mini-1-h4
+    parent: esp32c6fx4
+
   - name: esp32-c6-wroom-1
     parent: esp32c6
 

--- a/src/ariel-os-boards/build.rs
+++ b/src/ariel-os-boards/build.rs
@@ -92,4 +92,5 @@ pub fn main() {
     println!(
         "cargo::rustc-check-cfg=cfg(context, values(\"waveshare-esp32-s3-matrix\"))"
     );
+    println!("cargo::rustc-check-cfg=cfg(context, values(\"winky-esp32-c6\"))");
 }

--- a/src/ariel-os-boards/laze.yml
+++ b/src/ariel-os-boards/laze.yml
@@ -360,3 +360,9 @@ builders:
   provides:
   - has_usb_cdc_acm_port
   - has_usb_device_port
+- name: winky-esp32-c6
+  parent: esp32-c6-mini-1-x4
+  provides:
+  - has_buttons
+  - has_host_facing_uart
+  - has_usb_cdc_acm_port

--- a/src/ariel-os-boards/src/lib.rs
+++ b/src/ariel-os-boards/src/lib.rs
@@ -66,5 +66,6 @@ cfg_if::cfg_if! {
     #[cfg(context = "unihiker-k10")] { include!("unihiker-k10.rs"); } else if
     #[cfg(context = "waveshare-esp32-s3-eth")] { include!("waveshare-esp32-s3-eth.rs"); }
     else if #[cfg(context = "waveshare-esp32-s3-matrix")] {
-    include!("waveshare-esp32-s3-matrix.rs"); } else {}
+    include!("waveshare-esp32-s3-matrix.rs"); } else if #[cfg(context =
+    "winky-esp32-c6")] { include!("winky-esp32-c6.rs"); } else {}
 }

--- a/src/ariel-os-boards/src/winky-esp32-c6.rs
+++ b/src/ariel-os-boards/src/winky-esp32-c6.rs
@@ -1,0 +1,11 @@
+// @generated
+
+pub mod pins {
+    ariel_os_hal::define_peripherals!(ButtonPeripherals { button0 : GPIO9, });
+    ariel_os_hal::define_uarts![
+        { name : uart0, device : UART0, tx : GPIO16, rx : GPIO17, host_facing : true }, {
+        name : uart1, device : UART1, tx : GPIO15, rx : GPIO4, host_facing : false },
+    ];
+}
+#[allow(unused_variables)]
+pub fn init(peripherals: &mut ariel_os_hal::hal::OptionalPeripherals) {}


### PR DESCRIPTION
# Description

This adds support for the esp32c6 variant of the Winky project, the schematic can be found [on the gitlab of the project](https://gricad-gitlab.univ-grenoble-alpes.fr/ferrarij/winky/-/blob/main/WinKy_PCB_Design/Version_ESP32/ESP32C6-V1.6a/Winky.pdf). 

An UART peripheral is used to read the data from the Linky meter. A LED is available but requires a special setup to work (communication from the meter, GPIO4 to be pulled down and GPIO22 outputting High). 

## Testing

Run hello-world on the board:

```sh 
laze -C examples/hello-world build -b winky-esp32-c6 run
```

## Issues/PRs References

<!--
- Issues and pull requests relevant for context.
- Issues resolved by this PR: use keywords (e.g., fixes, closes) so that the issues get automatically
  closed when your pull request is merged.
  See <https://help.github.com/articles/closing-issues-using-keywords/>.
  Example: Fixes #1234. Closes #1234.
- Dependencies on other PRs: when other issues/PRs must be closed before this PR can be merged,
  make this PR depend on them (one line per issue/PR). This is enforced by CI.
  Syntax: Depends on <ref-to-issue-or-pr>.
-->

## Open Questions

<!-- Unresolved questions, if any. -->

## Changelog Entry

<!--
The changelog entry, if any.
It should likely contain variations of "has been" or "is now": past entries can
be used as reference: <https://github.com/ariel-os/ariel-os/blob/main/CHANGELOG.md>.
If you are unsure about how to phrase the entry, you can leave it empty and a
maintainer will write it for you.
For maintainers: if no entry is added, the `changelog:skip` label must be attached.
-->
<!-- changelog:begin -->
Added support for the Winky esp32-c6 module.
<!-- changelog:end -->

## Change Checklist

<!--
Please make sure that:

- Commit messages adhere to the Conventional Commits specification.
- The commit history is clear and informative.
- The Developer Certificate of Origin (DCO) Sign-off is present in your commits.
  - See <https://github.com/ariel-os/ariel-os/blob/main/CONTRIBUTING.md#developer-certificate-of-origin>.
-->
- [x] The [commit history][conventional-commits] will be clean at the latest after applying [autosquash].
- [x] I have followed the [Coding Conventions][coding-conventions].
- [x] I have tested and performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.

[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[coding-conventions]: https://ariel-os.github.io/ariel-os/dev/docs/book/coding-conventions.html
[autosquash]: https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash
